### PR TITLE
Fixed sign up form. DMPRoadmap/roadmap#317

### DIFF
--- a/app/views/shared/_register_form.html.erb
+++ b/app/views/shared/_register_form.html.erb
@@ -1,10 +1,12 @@
-<%= form_for(resource, :as => "user", :url => registration_path("user"),  :htmlb => {:autocomplete =>"off"}) do |f| %>
+<% javascript "shared/register_form.js" %>
+
+<%= form_for(resource, :as => "user", :url => registration_path("user"),  :htmlb => {:autocomplete =>"off"}, :html => {class: "roadmap-form"}) do |f| %>
   <ul>
 	<li>
 		<%= devise_error_messages! %>
 	</li>
 	<li>
-		<%= f.email_field :email, placeholder: (_('Email') + ' *'), :required => true, :as => :email, :class => 'text_field has-tooltip reg-input', 'data-toggle' => "tooltip", 'data-container' => "body", 'title' => _('This must be a valid email address - a message will be sent to it for confirmation.') %>
+		<%= f.email_field :email, placeholder: (_('Email') + ' *'), :as => :email, :class => 'text_field has-tooltip reg-input', 'data-toggle' => "tooltip", 'data-container' => "body", 'title' => _('Please enter your email') %>
 		<div class="alert alert-error" style="display:none">
 			<strong><%= _('Error!')%></strong> <%= _('You must enter a valid email address.')%>
 		</div>
@@ -36,24 +38,28 @@
 		<%= f.text_field :other_organisation, placeholder: ( _('Organisation name') + ' *'), :as => :string , :autocomplete => "off", :class => 'text_field has-tooltip reg-input', 'data-toggle' => "tooltip", 'data-container' => "body", 'title' => _('Please enter the name of your organisation.') %>
 	</li>
 	<li>
-		<%= f.password_field :password, placeholder: (_('Password') + ' *'), :autocomplete => "off", :required => true, :as => :password, :class => 'text_field has-tooltip reg-input', 'data-toggle' => "tooltip", 'data-container' => "body", 'title' => _('Your password must contain at least 8 characters.') %>
+		<%= f.password_field :password, placeholder: (_('Password') + ' *'), :autocomplete => "off", :as => :password, :class => 'text_field has-tooltip reg-input', 'data-toggle' => "tooltip", 'data-container' => "body", 'title' => _('Your password must contain at least 8 characters.') %>
 		<div class="alert alert-error" style="display:none">
 			<strong><%= _('Error!')%></strong> <%= _('Your password must contain at least 8 characters.')%>
 		</div>
 	</li>
 	<li>
-		<%= f.password_field :password_confirmation, placeholder: (_('Password confirmation') + ' *'), :required => true, :as => :password, :class => 'text_field has-tooltip reg-input', 'data-toggle' => "tooltip", 'data-container' => "body", 'title' => _('Your password must contain at least 8 characters.') %>
+		<%= f.password_field :password_confirmation, placeholder: (_('Password confirmation') + ' *'), :as => :password, :class => 'text_field has-tooltip reg-input', 'data-toggle' => "tooltip", 'data-container' => "body", 'title' => _('Your password must contain at least 8 characters.') %>
 		<div class="alert alert-error" style="display:none">
 			<strong><%= _('Error!')%></strong>&nbsp;<%= _('This must match what you entered in the previous field.')%>
 		</div>
 	</li>
 	<li class="remember_me_li">
-		<%= f.check_box :accept_terms, :required => true %> <%= f.label :accept_terms, :class => "remember_div"  do %>
-		  <%= raw _(' I accept the <a href="/%{current_locale}/terms" target="_blank">terms and conditions</a> *') % { :current_locale => FastGettext.locale } %>
+		<%= f.check_box :accept_terms %> <%= f.label :accept_terms, :class => "remember_div"  do %>
+		  <%= raw _(' I accept the <a href="/terms" target="_blank">terms and conditions</a> *') %>
 		<%end%>
 	</li>
 	<li>
-		<%= f.submit _('Sign up'), :class => "btn btn-primary" %>
+		<%= render partial: 'shared/accessible_submit_button',
+               locals: {id: 'sign_up_submit', 
+                         val: _('Sign up'), 
+                        disabled_initially: true,
+                        tooltip: _('You can not continue until you have filled in all of the required information.')} %>
 	</li>
 </ul>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -81,6 +81,7 @@ module DMPRoadmap
     config.assets.precompile += %w(roadmap-form.scss)
     config.assets.precompile += %w(plans/new_plan.js)
     config.assets.precompile += %w(contacts/new_contact.js)
+    config.assets.precompile += %w(shared/register_form.js)
     
     config.autoload_paths += %W(#{config.root}/lib)
     config.action_controller.include_all_helpers = true

--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -84,33 +84,6 @@ $( document ).ready(function() {
     $(this).closest("form").submit();
   });
 
-  $("#user_email.text_field.reg-input").blur(function () {
-    if (validateEmail($(this).val())) {
-      $(this).parent().children("div").hide();
-    }
-    else {
-      $(this).parent().children("div").show();
-    }
-  });
-
-  $("#user_password.text_field.reg-input").blur(function () {
-    if ($(this).val().length >= 8) {
-      $(this).parent().children("div").hide();
-    }
-    else {
-      $(this).parent().children("div").show();
-    }
-  });
-
-  $("#user_password_confirmation.text_field.reg-input").blur(function () {
-    if ($(this).val() == $("#user_password.text_field.reg-input").val()) {
-      $(this).parent().children("div").hide();
-    }
-    else {
-      $(this).parent().children("div").show();
-    }
-  });
-
   $('#user_organisation_id').on("change", function(e) {
     e.preventDefault();
     var selected_org = $(this).select2("val");
@@ -197,17 +170,6 @@ $( document ).ready(function() {
   });*/
 
 });
-
-// ---------------------------------------------------------------------------
-function validateEmail(sEmail) {
-  var filter = /^[a-zA-Z0-9]+[a-zA-Z0-9_.-]+[a-zA-Z0-9_-]+@[a-zA-Z0-9]+[a-zA-Z0-9.-]+[a-zA-Z0-9]+.[a-z]{2,4}$/;
-  if (filter.test(sEmail)) {
-    return true;
-  }
-  else {
-    return false;
-  }
-}
 
 // ---------------------------------------------------------------------------
 function selectItemsFromJsonArray(array, selector, array_of_values, callback){

--- a/lib/assets/javascripts/shared/register_form.js
+++ b/lib/assets/javascripts/shared/register_form.js
@@ -1,0 +1,61 @@
+$(document).ready(function() {
+    var email_regex = /[^@\s]+@(?:[-a-z0-9]+\.)+[a-z]{2,}$/;
+    var valid_email = false;
+    var valid_password = false;
+    var valid_password_confirmation = false;
+    var valid_accept_terms = false;
+
+    $("#user_email.text_field.reg-input").change(function(){
+        if (email_regex.test($(this).val())) {
+            $(this).next().hide();
+            valid_email = true;
+        }
+        else {
+            $(this).next().show();
+            valid_email = false;
+        }
+        set_aria_submit();
+    });
+    $("#user_password.text_field.reg-input").change(function() {
+        if($(this).val().length >= 8) {
+            $(this).next().hide();
+            valid_password = true;
+        }
+        else {
+            $(this).next().show();
+            valid_password = false;
+        }
+        // If password_confirmation is non empty already, force to check its validity
+        if($("#user_password_confirmation.text_field.reg-input").val().length > 0){
+            console.log('force to check validity of confirmation');
+            $("#user_password_confirmation.text_field.reg-input").change();
+        }
+        set_aria_submit();
+    });
+    $("#user_password_confirmation.text_field.reg-input").change(function() {
+        if ($(this).val() === $("#user_password.text_field.reg-input").val()) {
+            $(this).next().hide();
+            valid_password_confirmation = true;
+        }
+        else {
+            $(this).next().show();
+            valid_password_confirmation = false;
+        }
+        set_aria_submit();
+    });
+    $("#user_accept_terms").change(function(){
+        valid_accept_terms = $(this).prop('checked');
+        set_aria_submit();
+    });
+    function set_aria_submit(){
+        if(valid_email
+            && valid_password
+            && valid_password_confirmation
+            && valid_accept_terms){
+            $("#sign_up_submit").attr('aria-disabled', false);
+        }
+        else {
+            $("#sign_up_submit").attr('aria-disabled', true);
+        }
+    }
+});


### PR DESCRIPTION
- Removed required attribute from email, password, password_confirmation and accept terms
- Modified tooltip when email field receives focus
- Update link for terms and conditions since locale is no longer part of the URL
- Fixed regex for validating email according to the regex defined in rails validations (e.g. app/validators/email_validator.rb
- Replaced current sign up button with accessible submit button
- Added new .js to encapsulate the logic for register_form