### PR TITLE
Issue 295

### DIFF
--- a/app/models/exported_plan.rb
+++ b/app/models/exported_plan.rb
@@ -128,6 +128,8 @@ class ExportedPlan < ActiveRecord::Base
         value = self.send(at)
         if value.present?
           output += admin_field_t(at.to_s) + ": " + value + "\n"
+        else
+          output += admin_field_t(at.to_s) + ": " + _('-') + "\n"
         end
     end
 

--- a/app/models/exported_plan.rb
+++ b/app/models/exported_plan.rb
@@ -86,7 +86,7 @@ class ExportedPlan < ActiveRecord::Base
   end
 
   def questions_for_section(section_id)
-    questions.where(section_id: section_id).sort_by(&:number)
+    Question.where(id: questions).where(section_id: section_id).order(:number)
   end
 
   def admin_details
@@ -164,18 +164,17 @@ class ExportedPlan < ActiveRecord::Base
 private
 
   def questions
-    @questions ||= begin
-      question_settings = self.settings(:export).fields[:questions]
-
-      return [] if question_settings.is_a?(Array) && question_settings.empty?
-
-      questions = if question_settings.present? && question_settings != :all
-        Question.where(id: question_settings)
+    question_settings = self.settings(:export).fields[:questions]
+    @questions ||= if question_settings.present?
+      if question_settings == :all
+        Question.where(section_id: self.plan.sections.collect { |s| s.id }).pluck(:id)
+      elsif question_settings.is_a?(Array)
+        question_settings
       else
-        Question.where(section_id: self.plan.sections.collect {|s| s.id })
+        []
       end
-
-      questions.order(:number)
+    else
+      []
     end
   end
 

--- a/app/views/plans/export.html.erb
+++ b/app/views/plans/export.html.erb
@@ -22,7 +22,7 @@
 					%>
 						<tr>
 							<th class="dmp_th_border"><p>- <%= admin_field_t(field.to_s) -%></p></th>
-							<td class="dmp_td_border"><%= value.present? ? value : _('-') -%></td>
+							<td class="dmp_td_border"><%= value.present? ? value : _('-') %></td>
 						</tr>
 						<% end %>
 					</tbody>

--- a/app/views/plans/export.pdf.erb
+++ b/app/views/plans/export.pdf.erb
@@ -21,9 +21,10 @@
         <h1><%= @plan.title %></h1>
         <% @exported_plan.admin_details.each do |field|
              value = @exported_plan.send(field)
-             if value.present?
-        %>
-          <p><strong><%= admin_field_t(field.to_s) -%></strong> <%= value -%></p>
+             if value.present? %>
+                <p><strong><%= admin_field_t(field.to_s) -%></strong> <%= value -%></p>
+          <% else %>
+                <p><strong><%= admin_field_t(field.to_s) -%></strong> <%= _('-') %></p>
           <% end %>
         <% end %>
 


### PR DESCRIPTION
- Plan details fields selected are now shown always for every format. If a selected field does not have value associated, a hyphen (e.g. -) is shown instead.
- Fixed a bug when plan export settings have no sections selected.