### PR TITLE
Xsrust/bugfixes

### DIFF
--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -120,9 +120,9 @@ class PhasesController < ApplicationController
     end
     if @phase.template.customization_of.present?
       @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
-    else 
-      @original_org = @phase.template.org 
-    end 
+    else
+      @original_org = @phase.template.org
+    end
   end
 
 
@@ -184,6 +184,11 @@ class PhasesController < ApplicationController
       @section_id = (params[:section_id].nil? ? nil : params[:section_id].to_i)
       @question_id = (params[:question_id].nil? ? nil : params[:question_id].to_i)
       flash[:notice] = failed_update_error(@phase, _('phase'))
+      if @phase.template.customization_of.present?
+        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+      else
+        @original_org = @phase.template.org
+      end
       render 'admin_show'
     end
   end
@@ -208,6 +213,11 @@ class PhasesController < ApplicationController
       @section_id = (params[:section_id].nil? ? nil : params[:section_id].to_i)
       @question_id = (params[:question_id].nil? ? nil : params[:question_id].to_i)
       flash[:notice] = failed_destroy_error(@phase, _('phase'))
+      if @phase.template.customization_of.present?
+        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+      else
+        @original_org = @phase.template.org
+      end
       render 'admin_show'
     end
   end

--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -118,6 +118,11 @@ class PhasesController < ApplicationController
     if params.has_key?(:question_id)
       @question_id = params[:question_id].to_i
     end
+    if @phase.template.customization_of.present?
+      @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+    else 
+      @original_org = @phase.template.org 
+    end 
   end
 
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -35,10 +35,15 @@ class QuestionsController < ApplicationController
         @question_id = @question.id
 
         flash[:notice] = failed_create_error(@question, _('question'))
+        if @phase.template.customization_of.present?
+          @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+        else
+          @original_org = @phase.template.org
+        end
         render template: 'phases/admin_show'
       end
     rescue ActionController::ParameterMissing => e
-      flash[:notice] = e.message    
+      flash[:notice] = e.message
     end
   end
 
@@ -46,7 +51,7 @@ class QuestionsController < ApplicationController
   def admin_update
     @question = Question.find(params[:id])
     authorize @question
-    guidance = @question.get_guidance_annotation(current_user.org_id) 
+    guidance = @question.get_guidance_annotation(current_user.org_id)
     if params["question-guidance-#{params[:id]}"].present?
       if guidance.blank?
         guidance = @question.annotations.build
@@ -76,6 +81,11 @@ class QuestionsController < ApplicationController
       @question_id = @question.id
 
       flash[:notice] = failed_update_error(@question, _('question'))
+      if @phase.template.customization_of.present?
+        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+      else
+        @original_org = @phase.template.org
+      end
       render template: 'phases/admin_show'
     end
   end
@@ -89,7 +99,7 @@ class QuestionsController < ApplicationController
     if @question.destroy
       @phase.template.dirty = true
       @phase.template.save!
-      
+
       redirect_to admin_show_phase_path(id: @phase.id, section_id: @section.id, edit: 'true'), notice: _('Information was successfully deleted.')
     else
       redirect_to admin_show_phase_path(id: @phase.id, section_id: @section.id, edit: 'true'), notice: failed_destroy_error(@question, 'question')

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -12,7 +12,7 @@ class SectionsController < ApplicationController
     if @section.save
       @section.phase.template.dirty = true
       @section.phase.template.save!
-      
+
       redirect_to admin_show_phase_path(id: @section.phase_id,
         :section_id => @section.id, edit: 'true'), notice: _('Information was successfully created.')
     else
@@ -22,6 +22,11 @@ class SectionsController < ApplicationController
       @section_id = @section.id
       @question_id = nil
       flash[:notice] = failed_create_error(@section, _('section'))
+      if @phase.template.customization_of.present?
+        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+      else
+        @original_org = @phase.template.org
+      end
       render template: 'phases/admin_show'
     end
   end
@@ -36,7 +41,7 @@ class SectionsController < ApplicationController
     if @section.update_attributes(params[:section])
       @section.phase.template.dirty = true
       @section.phase.template.save!
-      
+
       redirect_to admin_show_phase_path(id: @phase.id, section_id: @section.id , edit: 'true'), notice: _('Information was successfully updated.')
     else
       @edit = (@phase.template.org == current_user.org)
@@ -45,6 +50,11 @@ class SectionsController < ApplicationController
       @section_id = @section.id
       @question_id = nil
       flash[:notice] = failed_update_error(@section, _('section'))
+      if @phase.template.customization_of.present?
+        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+      else
+        @original_org = @phase.template.org
+      end
       render template: 'phases/admin_show'
     end
   end
@@ -55,11 +65,11 @@ class SectionsController < ApplicationController
     @section = Section.includes(phase: :template).find(params[:section_id])
     authorize @section
     @phase = @section.phase
-    
+
     if @section.destroy
       @phase.template.dirty = true
       @phase.template.save!
-      
+
       redirect_to admin_show_phase_path(id: @phase.id, edit: 'true' ), notice: _('Information was successfully deleted.')
     else
       @edit = (@phase.template.org == current_user.org)
@@ -67,10 +77,15 @@ class SectionsController < ApplicationController
       @sections = @phase.sections
       @section_id = @section.id
       @question_id = nil
-      
+
       flash[:notice] = failed_destroy_error(@section, _('section'))
+      if @phase.template.customization_of.present?
+        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+      else
+        @original_org = @phase.template.org
+      end
       render template: 'phases/admin_show'
     end
   end
-  
+
 end

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -117,7 +117,7 @@ class TemplatesController < ApplicationController
           if section.modifiable
             # this is a custom section
             section_copy = Section.deep_copy(section)
-            customization_phase = new_customization.phases.includes(:sections.where(number: phase.number).first)
+            customization_phase = new_customization.phases.includes(:sections).where(number: phase.number).first
             section_copy.phase_id = customization_phase.id
             # custom sections get added to the end
             section_copy.number = customization_phase.sections.length + 1

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -55,7 +55,6 @@ class Template < ActiveRecord::Base
     Template.where(customization_of: dmptemplate_id, org_id: org_id).order(version: :desc).valid.first
   end
 
-
   ##
   # deep copy the given template and all of it's associations
   #

--- a/app/views/layouts/_signin_signout.html.erb
+++ b/app/views/layouts/_signin_signout.html.erb
@@ -12,7 +12,9 @@
             <li><%= link_to _('Super admin area'), "/admin", class: "signIn_dropdown_link" %></li>
           <% end %>
           <% if current_user.can_org_admin? && !current_user.org_id.nil? %>
-            <% if current_user.can_modify_templates? %>
+            <% if current_user.can_modify_org_details? && current_user.org.abbreviation.blank? %>
+              <li><%= link_to _("Admin area"), admin_show_org_path(current_user.org_id), class: "signIn_dropdown_link" %></li>
+            <% elsif  current_user.can_modify_templates?%>
               <li><%= link_to _("Admin area"), admin_index_template_path(current_user.org_id), class: "signIn_dropdown_link" %></li>
             <% elsif current_user.can_modify_guidance? %>
               <li><%= link_to _("Admin area"), admin_index_guidance_path(current_user.org_id), class: "signIn_dropdown_link" %></li>

--- a/app/views/orgs/admin_show.html.erb
+++ b/app/views/orgs/admin_show.html.erb
@@ -28,6 +28,10 @@
 				<td class="first"><%= _('Abbreviation') %></td>
 				<td><%= @org.abbreviation %></td>
 			</tr>
+      <% else %>
+      <tr>
+        <td class="first"><%= _('Abbreviation') %></td>
+        <td><emph><%= _('Please add an abbreviation to your org for display with annotations!')%></emph></td>
 			<% end %>
 
       <% if @org.banner_text.present? then %>

--- a/app/views/questions/_show_question.html.erb
+++ b/app/views/questions/_show_question.html.erb
@@ -63,7 +63,7 @@
 
     <!-- Suggested answer or Example-->
     <% if !question.section.phase.template.org.funder? %>
-      <% example_answer = question.get_example_answer(current_user.org_id) %>
+      <% example_answer = question.get_example_answer(@original_org.id) %>
       <% if example_answer.present?  && example_answer.text.present?  %>
         <tr>
           <td class="first_template">
@@ -74,7 +74,7 @@
       <% end %>
     <% end %>
     <!-- Guidance linked to this question -->
-    <% guidance = question.get_guidance_annotation(current_user.org_id) %>
+    <% guidance = question.get_guidance_annotation(@original_org.id) %>
     <% if guidance.present?  %>
       <tr>
         <td class="first_template"><%= _('Guidance')%></td>

--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -12,7 +12,7 @@ def get_default_locale
     return language.nil? ? 'en_GB' : language.abbreviation
 end
 
-FastGettext.add_text_domain 'app', :path => 'config/locale', :type => :po, :ignore_fuzzy => true
+FastGettext.add_text_domain 'app', :path => 'config/locale', :type => :po, :ignore_fuzzy => true, :report_warning => false
 FastGettext.default_text_domain = 'app'
 FastGettext.default_available_locales = get_available_locales()
 FastGettext.default_locale = get_default_locale()

--- a/config/locale/app.pot
+++ b/config/locale/app.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-08 14:43+0000\n"
-"PO-Revision-Date: 2017-06-08 14:43+0000\n"
+"POT-Creation-Date: 2017-06-15 12:42+0000\n"
+"PO-Revision-Date: 2017-06-15 12:42+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -351,6 +351,9 @@ msgstr ""
 msgid "Bad Credentials"
 msgstr ""
 
+msgid "Bad Parameters"
+msgstr ""
+
 msgid "Before submitting, please consider:"
 msgstr ""
 
@@ -433,6 +436,9 @@ msgid "Create a new plan"
 msgstr ""
 
 msgid "Create a template"
+msgstr ""
+
+msgid "Create account"
 msgstr ""
 
 msgid "Create plan"
@@ -966,6 +972,9 @@ msgstr ""
 msgid "Plan was successfully updated."
 msgstr ""
 
+msgid "Please add an abbreviation to your org for display with annotations!"
+msgstr ""
+
 msgid "Please enter a First name."
 msgstr ""
 
@@ -1186,9 +1195,6 @@ msgid "Sign in"
 msgstr ""
 
 msgid "Sign out"
-msgstr ""
-
-msgid "Create account"
 msgstr ""
 
 msgid "Signed in as "
@@ -1650,6 +1656,9 @@ msgstr ""
 msgid "must have access to guidances api"
 msgstr ""
 
+msgid "must have access to plans api"
+msgstr ""
+
 msgid "no research organisation is associated with this plan"
 msgstr ""
 
@@ -1698,14 +1707,5 @@ msgstr ""
 msgid "user"
 msgstr ""
 
-msgid "{\"Error\":\"Organisation does not exist\"}"
-msgstr ""
-
-msgid "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-msgstr ""
-
-msgid "{\"Error\":\"Organisation specified is not a funder\"}"
-msgstr ""
-
-msgid "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
+msgid "user must be in your organisation"
 msgstr ""

--- a/config/locale/de/app.po
+++ b/config/locale/de/app.po
@@ -378,6 +378,9 @@ msgstr "Hintergrund"
 msgid "Bad Credentials"
 msgstr ""
 
+msgid "Bad Parameters"
+msgstr ""
+
 msgid "Before submitting, please consider:"
 msgstr ""
 
@@ -469,6 +472,9 @@ msgstr "Einen neuen Plan erstellen"
 
 msgid "Create a template"
 msgstr "Vorlage erstellen"
+
+msgid "Create account"
+msgstr "Registrieren"
 
 msgid "Create plan"
 msgstr "Erstelle Plan"
@@ -1022,6 +1028,9 @@ msgstr "Plan wurde erfolgreich angelegt."
 msgid "Plan was successfully updated."
 msgstr ""
 
+msgid "Please add an abbreviation to your org for display with annotations!"
+msgstr ""
+
 #, fuzzy
 msgid "Please enter a First name."
 msgstr "Bitte geben Sie ihren Vornamen ein."
@@ -1254,9 +1263,6 @@ msgstr "Anmelden"
 
 msgid "Sign out"
 msgstr "Abmelden"
-
-msgid "Create account"
-msgstr "Registrieren"
 
 msgid "Signed in as "
 msgstr "Angemeldet als "
@@ -1763,6 +1769,10 @@ msgid "must have access to guidances api"
 msgstr "guidances"
 
 #, fuzzy
+msgid "must have access to plans api"
+msgstr "guidances"
+
+#, fuzzy
 msgid "no research organisation is associated with this plan"
 msgstr "Organisation"
 
@@ -1820,14 +1830,6 @@ msgstr "templates"
 msgid "user"
 msgstr "user"
 
-msgid "{\"Error\":\"Organisation does not exist\"}"
-msgstr "{\"Error\":\"Organisation does not exist\"}"
-
-msgid "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-msgstr "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-
-msgid "{\"Error\":\"Organisation specified is not a funder\"}"
-msgstr "{\"Error\":\"Organisation specified is not a funder\"}"
-
-msgid "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
-msgstr "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
+#, fuzzy
+msgid "user must be in your organisation"
+msgstr "Organisation"

--- a/config/locale/en_GB/app.po
+++ b/config/locale/en_GB/app.po
@@ -366,6 +366,9 @@ msgstr "Background"
 msgid "Bad Credentials"
 msgstr ""
 
+msgid "Bad Parameters"
+msgstr ""
+
 msgid "Before submitting, please consider:"
 msgstr "Before submitting, please consider:"
 
@@ -453,6 +456,9 @@ msgstr "Create a new plan"
 
 msgid "Create a template"
 msgstr "Create a template"
+
+msgid "Create account"
+msgstr "Create account"
 
 msgid "Create plan"
 msgstr "Create plan"
@@ -1001,6 +1007,9 @@ msgstr "Plan was successfully deleted."
 msgid "Plan was successfully updated."
 msgstr "Plan was successfully updated."
 
+msgid "Please add an abbreviation to your org for display with annotations!"
+msgstr ""
+
 #, fuzzy
 msgid "Please enter a First name."
 msgstr "Please enter your first name."
@@ -1233,9 +1242,6 @@ msgstr "Sign in"
 
 msgid "Sign out"
 msgstr "Sign out"
-
-msgid "Create account"
-msgstr "Create account"
 
 msgid "Signed in as "
 msgstr "Signed in as "
@@ -1715,6 +1721,10 @@ msgid "must have access to guidances api"
 msgstr "must have access to guidances api"
 
 #, fuzzy
+msgid "must have access to plans api"
+msgstr "must have access to guidances api"
+
+#, fuzzy
 msgid "no research organisation is associated with this plan"
 msgstr "organisation"
 
@@ -1764,14 +1774,6 @@ msgstr "template"
 msgid "user"
 msgstr "user"
 
-msgid "{\"Error\":\"Organisation does not exist\"}"
-msgstr "{\"Error\":\"Organisation does not exist\"}"
-
-msgid "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-msgstr "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-
-msgid "{\"Error\":\"Organisation specified is not a funder\"}"
-msgstr "{\"Error\":\"Organisation specified is not a funder\"}"
-
-msgid "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
-msgstr "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
+#, fuzzy
+msgid "user must be in your organisation"
+msgstr "organisation"

--- a/config/locale/en_US/app.po
+++ b/config/locale/en_US/app.po
@@ -366,6 +366,9 @@ msgstr "Background"
 msgid "Bad Credentials"
 msgstr ""
 
+msgid "Bad Parameters"
+msgstr ""
+
 msgid "Before submitting, please consider:"
 msgstr "Before submitting, please consider:"
 
@@ -453,6 +456,9 @@ msgstr "Create a new plan"
 
 msgid "Create a template"
 msgstr "Create a template"
+
+msgid "Create account"
+msgstr "Create account"
 
 msgid "Create plan"
 msgstr "Create plan"
@@ -1001,6 +1007,9 @@ msgstr "Plan was successfully deleted."
 msgid "Plan was successfully updated."
 msgstr "Plan was successfully updated."
 
+msgid "Please add an abbreviation to your org for display with annotations!"
+msgstr ""
+
 #, fuzzy
 msgid "Please enter a First name."
 msgstr "Please enter your first name."
@@ -1233,9 +1242,6 @@ msgstr "Sign in"
 
 msgid "Sign out"
 msgstr "Sign out"
-
-msgid "Create account"
-msgstr "Create account"
 
 msgid "Signed in as "
 msgstr "Signed in as "
@@ -1715,6 +1721,10 @@ msgid "must have access to guidances api"
 msgstr "must have access to guidances api"
 
 #, fuzzy
+msgid "must have access to plans api"
+msgstr "must have access to guidances api"
+
+#, fuzzy
 msgid "no research organisation is associated with this plan"
 msgstr "organization"
 
@@ -1764,14 +1774,6 @@ msgstr "template"
 msgid "user"
 msgstr "user"
 
-msgid "{\"Error\":\"Organisation does not exist\"}"
-msgstr "{\"Error\":\"Organization does not exist\"}"
-
-msgid "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-msgstr "{\"Error\":\"Organization has more than one template and template name unspecified or invalid\"}"
-
-msgid "{\"Error\":\"Organisation specified is not a funder\"}"
-msgstr "{\"Error\":\"Organization specified is not a funder\"}"
-
-msgid "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
-msgstr "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
+#, fuzzy
+msgid "user must be in your organisation"
+msgstr "organization"

--- a/config/locale/es/app.po
+++ b/config/locale/es/app.po
@@ -375,6 +375,9 @@ msgstr "Volver"
 msgid "Bad Credentials"
 msgstr ""
 
+msgid "Bad Parameters"
+msgstr ""
+
 msgid "Before submitting, please consider:"
 msgstr ""
 
@@ -465,6 +468,9 @@ msgstr "Crear un nuevo plan"
 
 msgid "Create a template"
 msgstr "Crear una plantilla"
+
+msgid "Create account"
+msgstr "Registrarse"
 
 msgid "Create plan"
 msgstr "Crear un plan"
@@ -1017,6 +1023,9 @@ msgstr "Plan creado con éxito"
 msgid "Plan was successfully updated."
 msgstr ""
 
+msgid "Please add an abbreviation to your org for display with annotations!"
+msgstr ""
+
 #, fuzzy
 msgid "Please enter a First name."
 msgstr "Por favor, introduzca su nombre."
@@ -1249,9 +1258,6 @@ msgstr "Conectar"
 
 msgid "Sign out"
 msgstr "Desconectar"
-
-msgid "Create account"
-msgstr "Registrarse"
 
 msgid "Signed in as "
 msgstr "Registrado como "
@@ -1747,6 +1753,10 @@ msgid "must have access to guidances api"
 msgstr "guidances"
 
 #, fuzzy
+msgid "must have access to plans api"
+msgstr "guidances"
+
+#, fuzzy
 msgid "no research organisation is associated with this plan"
 msgstr "Organización"
 
@@ -1803,14 +1813,6 @@ msgstr "templates"
 msgid "user"
 msgstr "user"
 
-msgid "{\"Error\":\"Organisation does not exist\"}"
-msgstr "{\"Error\":\"Organization does not exist\"}"
-
-msgid "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-msgstr "{\"Error\":\"Organization has more than one template and template name unspecified or invalid\"}"
-
-msgid "{\"Error\":\"Organisation specified is not a funder\"}"
-msgstr "{\"Error\":\"Organization specified is not a funder\"}"
-
-msgid "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
-msgstr "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
+#, fuzzy
+msgid "user must be in your organisation"
+msgstr "Organización"

--- a/config/locale/fr/app.po
+++ b/config/locale/fr/app.po
@@ -374,6 +374,9 @@ msgstr "Assistant PGD"
 msgid "Bad Credentials"
 msgstr ""
 
+msgid "Bad Parameters"
+msgstr ""
+
 msgid "Before submitting, please consider:"
 msgstr ""
 
@@ -463,6 +466,9 @@ msgstr "Créer un nouveau plan"
 
 msgid "Create a template"
 msgstr "Créer un modèle"
+
+msgid "Create account"
+msgstr "Sinscrire"
 
 msgid "Create plan"
 msgstr "Create plan"
@@ -1014,6 +1020,9 @@ msgstr "Création du plan effectuée."
 msgid "Plan was successfully updated."
 msgstr ""
 
+msgid "Please add an abbreviation to your org for display with annotations!"
+msgstr ""
+
 #, fuzzy
 msgid "Please enter a First name."
 msgstr "Entrez votre prénom, svp."
@@ -1246,9 +1255,6 @@ msgstr "Connexion"
 
 msgid "Sign out"
 msgstr "Déconnexion"
-
-msgid "Create account"
-msgstr "Sinscrire"
 
 msgid "Signed in as "
 msgstr "Connecté en tant que "
@@ -1744,6 +1750,10 @@ msgid "must have access to guidances api"
 msgstr "guidances"
 
 #, fuzzy
+msgid "must have access to plans api"
+msgstr "guidances"
+
+#, fuzzy
 msgid "no research organisation is associated with this plan"
 msgstr "Organisation"
 
@@ -1800,14 +1810,6 @@ msgstr "templates"
 msgid "user"
 msgstr "user"
 
-msgid "{\"Error\":\"Organisation does not exist\"}"
-msgstr ""
-
-msgid "{\"Error\":\"Organisation has more than one template and template name unspecified or invalid\"}"
-msgstr ""
-
-msgid "{\"Error\":\"Organisation specified is not a funder\"}"
-msgstr ""
-
-msgid "{\"Error\":\"You do not have authorisation to view this endpoint\"}"
-msgstr ""
+#, fuzzy
+msgid "user must be in your organisation"
+msgstr "Organisation"


### PR DESCRIPTION
 - Funder guidance displays on customised templates
    - before was just displaying the customiser's guidance twice
 - Since annotations display with the org's abbreviation, added logic to drive org admins of orgs without an abbrivation to the show org details page
 - removed fuzzy translations warnings which appear when you run a rails c/raketask