### PR TITLE
changed text for plan titles on view plans and public dmps page. adde…

### DIFF
--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -17,7 +17,7 @@
   <table id="dmp_table" class="dmp_table tablesorter">
     <thead>
       <tr>
-        <th class="col-large"><%= _('Plan') %></th>
+        <th class="col-large"><%= _('Project Title') %></th>
         <th class="col-large"><%= _('Template') %></th>
         <th class="col-small"><%= _('Edited') %></th>
         <th class="col-small"><%= _('Role') %></th>

--- a/app/views/plans/public_export.pdf.erb
+++ b/app/views/plans/public_export.pdf.erb
@@ -27,6 +27,8 @@
                 <p><strong><%= admin_field_t(field.to_s) -%></strong> <%= _('-') %></p>
           <% end %>
         <% end %>
+				
+				<p><%= _("Copyright information: The above plan creator(s) have agreed that others may use as much of the text of this plan as they would like in their own plans, and customise it as necessary. You do not need to credit the creator(s) as the source of the language used, but using any of the plan's text does not imply that the creator(s) endorse, or have any relationship to, your project or proposal") %></p>
 
         <% @exported_plan.sections.each do |section| %>
             <% questions = @exported_plan.questions_for_section(section.id)

--- a/app/views/plans/public_index.html.erb
+++ b/app/views/plans/public_index.html.erb
@@ -15,7 +15,7 @@
   <table id="dmp_table" class="dmp_table tablesorter">
     <thead>
       <tr>
-        <th class="col-large"><%= _('Plan') %></th>
+        <th class="col-large"><%= _('Plan Title') %></th>
         <th class="col-large"><%= _('Template') %></th>
         <th class="col-medium"><%= _('Organisation') %></th>
         <th class="col-medium"><%= _('Owner') %></th>
@@ -28,7 +28,7 @@
           <td><%= plan.title %></td>
           <td><%= plan.template.title %></td>
           <td><%= (plan.owner.nil? || plan.owner.org.nil? ? _('Not Applicable') : plan.owner.org.name) %></td>
-          <td><%= (plan.owner.nil? ? _('Unknown') : plan.owner.name) %></td>
+          <td><%= (plan.owner.nil? ? _('Unknown') : plan.owner.name(false)) %></td>
           <td class="dmp_td_medium centered">
             <%= link_to _('PDF'), 
                         public_export_path(plan, format: :pdf), 


### PR DESCRIPTION
- Change column heading on view plans and public DMP page from 'Title' to 'Project Title' and 'Plan Title' respectively. 
- The 'Owner' column on the public DMP page will now show the user's first and last name instead of email address. 
- Added copyright information to the public DMP export PDF document