### PR TITLE
Xsrust/bugfixes

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -56,9 +56,20 @@ class QuestionsController < ApplicationController
       if guidance.blank?
         guidance = @question.annotations.build
         guidance.type = :guidance
+        guidance.org_id = current_user.org_id
       end
       guidance.text = params["question-guidance-#{params[:id]}"]
       guidance.save
+    end
+    example_answer = @question.get_example_answer(current_user.org_id)
+    if params["question"]["annotations_attributes"]["0"]["id"].present?
+      if example_answer.blank?
+        example_answer = @question.annotations.build
+        example_answer.type = :example_answer
+        example_answer.org_id = current_user.org_id
+      end
+      example_answer.text = params["question"]["annotations_attributes"]["0"]["text"]
+      example_answer.save
     end
     if @question.question_format.textfield?
       @question.default_value = params["question-default-value-textfield"]

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -62,7 +62,7 @@ class QuestionsController < ApplicationController
       guidance.save
     end
     example_answer = @question.get_example_answer(current_user.org_id)
-    if params["question"]["annotations_attributes"]["0"]["id"].present?
+    if params["question"]["annotations_attributes"].present? && params["question"]["annotations_attributes"]["0"]["id"].present?
       if example_answer.blank?
         example_answer = @question.annotations.build
         example_answer.type = :example_answer

--- a/app/views/plans/export.docx.erb
+++ b/app/views/plans/export.docx.erb
@@ -21,9 +21,7 @@
   %>
       <h3><%= section.title %></h3>
       <% questions.each do |question| %>
-        <p>
           <%= raw question.text %>
-        </p>
         <% answer = @plan.answer(question.id, false) %>
         <% if answer.nil? %>
           <p><%= _('Question not answered') %></p>
@@ -42,6 +40,7 @@
             <%= raw answer.text %>
           <% end %> <!-- end if q_format.option_based? -->
         <% end%> <!-- end if answer.nil? --> 
+        <p></p>
     <% end %>	<!-- end questions.each -->
   <% end %> <!-- end if questions.present? -->
 <% end %> <!-- end @exported_plan.sections.each -->

--- a/app/views/sections/_add_section.html.erb
+++ b/app/views/sections/_add_section.html.erb
@@ -25,7 +25,8 @@
           <tr>
             <td class="first_template"><%= _('Order of display') %></td>
             <td>
-              <%= f.number_field :number, in: 1..15, class: "number_field has-tooltip", "data-toggle" => "tooltip", title: _('This allows you to order sections.') %>
+              <% range = @phase.template.customization_of.present? ? 0..15 : 1..15 %>
+              <%= f.number_field :number, in: range, class: "number_field has-tooltip", "data-toggle" => "tooltip", title: _('This allows you to order sections.') %>
             </td>
           </tr>
           <tr>

--- a/app/views/sections/_edit_section.html.erb
+++ b/app/views/sections/_edit_section.html.erb
@@ -39,7 +39,8 @@
         <table class="dmp_details_table">
           <tr>
             <td class="first_template"><%= _('Order of display') %></td>
-            <td><%= s.number_field :number, in: 1..15, class: "number_field has-tooltip", 'data-toggle' => "tooltip", 'title' => _('This allows you to order sections.') %></td>
+            <% range = @phase.template.customization_of.present? ? 0..15 : 1..15 %>
+            <td><%= s.number_field :number, in: range, class: "number_field has-tooltip", 'data-toggle' => "tooltip", 'title' => _('This allows you to order sections.') %></td>
           </tr>
           <tr>
             <td class="first_template"><%= _('Description') %></td>

--- a/config/tinymce.yml
+++ b/config/tinymce.yml
@@ -7,6 +7,8 @@ plugins:
   - autoresize
   - link
   - paste
+  - advlist
+advlist_bullet_styles: "circle,square" #only disc bullets display on htmltoword
 target_list: false
 autoresize_min_height: 130
 autoresize_bottom_margin: 10

--- a/config/tinymce.yml
+++ b/config/tinymce.yml
@@ -8,7 +8,7 @@ plugins:
   - link
   - paste
   - advlist
-advlist_bullet_styles: "circle,square" #only disc bullets display on htmltoword
+advlist_bullet_styles: "circle,disc,square" #only disc bullets display on htmltoword
 target_list: false
 autoresize_min_height: 130
 autoresize_bottom_margin: 10


### PR DESCRIPTION
Adds options for bullets to be square, disk, or circle in TinyMCE editor.  Only Square and circle export to docx due to limitations in the htmltoword gem we are using for this functionality.

Updated Questions controller to properly deal with annotations being updated and assign org to guidance.