### PR TITLE
Xsrust/bugfixes

### DIFF
--- a/app/controllers/guidances_controller.rb
+++ b/app/controllers/guidances_controller.rb
@@ -39,18 +39,10 @@ class GuidancesController < ApplicationController
     @guidance = Guidance.new(guidance_params)
     authorize @guidance
     @guidance.text = params["guidance-text"]
-    
+
     @guidance.themes = []
     if !guidance_params[:theme_ids].nil?
       guidance_params[:theme_ids].map{|t| @guidance.themes << Theme.find(t.to_i) unless t.empty? }
-    end
-    
-    if @guidance.published == true then
-      @gg = GuidanceGroup.find(@guidance.guidance_group_id)
-      if @gg.published == false || @gg.published.nil? then
-        @gg.published = true
-        @gg.save
-      end
     end
 
     if @guidance.save

--- a/app/controllers/guidances_controller.rb
+++ b/app/controllers/guidances_controller.rb
@@ -69,8 +69,7 @@ class GuidancesController < ApplicationController
  		@guidance = Guidance.find(params[:id])
     authorize @guidance
 		@guidance.text = params["guidance-text"]
-
-    if @guidance.save(guidance_params)
+    if @guidance.update_attributes(guidance_params)
       redirect_to admin_show_guidance_path(params[:guidance]), notice: _('Guidance was successfully updated.')
     else
       flash[:notice] = failed_update_error(@guidance, _('guidance'))

--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -23,14 +23,14 @@ class PhasesController < ApplicationController
     # get the ids of the dynamically selected guidance groups
     # and keep a map of them so we can extract the names later
     guidance_groups_ids = @plan.guidance_groups.map{|pgg| pgg.id}
-    guidance_groups =  GuidanceGroup.includes({guidances: :themes}).find(guidance_groups_ids)
+    guidance_groups =  GuidanceGroup.includes({guidances: :themes}).where(published: true, id: guidance_groups_ids)
 
     # create a map from theme to array of guidances
     # where guidance is a hash with the text and the org name
     theme_guidance = {}
 
     guidance_groups.each do |guidance_group|
-      guidance_group.guidances.each do |guidance|
+      guidance_group.guidances.where(published: true).each do |guidance|
         guidance.themes.each do |theme|
           title = theme.title
           if !theme_guidance.has_key?(title)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -139,7 +139,8 @@ class Plan < ActiveRecord::Base
         section.questions.each do |question|
           question.themes.each do |theme|
             theme.guidances.each do |guidance|
-              ggroups << guidance.guidance_group
+              ggroups << guidance.guidance_group if guidance.guidance_group.published
+              # only show published guidance groups
             end
           end
         end
@@ -163,7 +164,8 @@ class Plan < ActiveRecord::Base
         section.questions.each do |question|
           question.themes.each do |theme|
             theme.guidances.each do |guidance|
-              ggroups << guidance.guidance_group
+              ggroups << guidance.guidance_group if guidance.guidance_group.published
+              # only show published guidance groups
             end
           end
         end

--- a/app/views/plans/_plan_details.html.erb
+++ b/app/views/plans/_plan_details.html.erb
@@ -153,10 +153,10 @@
   <!-- Selection of guidance groups -->
   <%= form_tag( update_guidance_choices_plan_path(@plan), method: :put) do %>
   <div id="plan-guidance-important">
-      <h3>Guidance Choices</h3>
+      <h3><%=_('Guidance Choices')%></h3>
       <table id="dmp_table" class="dmp_table tablesorter">
       <tbody>
-          <% @important_ggs.each do |org, groups| %>                                                                                                                                                                  
+          <% @important_ggs.each do |org, groups| %>
               <tr>
               <td class="dmp_td_medium">
                   <% if groups && groups.size == 1 %>

--- a/config/locale/app.pot
+++ b/config/locale/app.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-15 12:42+0000\n"
-"PO-Revision-Date: 2017-06-15 12:42+0000\n"
+"POT-Creation-Date: 2017-06-27 12:05+0000\n"
+"PO-Revision-Date: 2017-06-27 12:05+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -40,9 +40,6 @@ msgid " and "
 msgstr ""
 
 msgid " by"
-msgstr ""
-
-msgid " by "
 msgstr ""
 
 msgid " has been removed by "
@@ -184,9 +181,6 @@ msgid "<p>To create a new template, first enter a title and description. Once yo
 msgstr ""
 
 msgid "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
-msgstr ""
-
-msgid "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
 msgstr ""
 
 msgid "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
@@ -519,9 +513,6 @@ msgstr ""
 msgid "Edit phase"
 msgstr ""
 
-msgid "Edit phase details"
-msgstr ""
-
 msgid "Edit plan details"
 msgstr ""
 
@@ -634,6 +625,9 @@ msgid "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 msgstr ""
 
 msgid "Guidance"
+msgstr ""
+
+msgid "Guidance Choices"
 msgstr ""
 
 msgid "Guidance choices saved."
@@ -1314,9 +1308,6 @@ msgstr ""
 msgid "This plan is based on:"
 msgstr ""
 
-msgid "This section is locked for editing by "
-msgstr ""
-
 msgid "Title"
 msgstr ""
 
@@ -1345,12 +1336,6 @@ msgid "Unknown formatting setting"
 msgstr ""
 
 msgid "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
-msgstr ""
-
-msgid "Unlink account"
-msgstr ""
-
-msgid "Unlink institutional credentials alert"
 msgstr ""
 
 msgid "Unlock my account"
@@ -1501,9 +1486,6 @@ msgid "You have been granted permission by your organisation to use our API. You
 msgstr ""
 
 msgid "You have un-published changes"
-msgstr ""
-
-msgid "You have unsaved answers in the following sections:"
 msgstr ""
 
 msgid "You must accept the terms and conditions to register."

--- a/config/locale/de/app.po
+++ b/config/locale/de/app.po
@@ -43,9 +43,6 @@ msgstr ""
 msgid " by"
 msgstr " von "
 
-msgid " by "
-msgstr " von "
-
 #, fuzzy
 msgid " has been removed by "
 msgstr " von "
@@ -198,9 +195,6 @@ msgstr "<p>Um eine Vorlage anzulegen beginnen sie mit einem Titel und einer Besc
 
 msgid "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
 msgstr "<p>Nach der Anmeldung in DMPonline werden sie zur 'Meine Pläne'-Seite weitergeleitet. Dies ist der Startpunkt, um ihre Pläne zu Edieren, zu Teilen oder zu löschen. Sie sehen außerdem, welche Pläne sie mit anderen geteilt haben.</p> <h3>Pläne erstellen</h3> <p>Um einen Plan zu erstellen, klicken sie auf den 'Plan erstellen'-Knopf auf der 'Meine Pläne'-Seite, oder im Hauptmenü. Wählen sie die passenden Optionen in den Ausklappmenüs und Auswahlboxen aus, um zu bestimmen, welche Fragen und Hilfestellungen ihnen angezeigt werden sollen. Bestätigen sie ihre Auswahl durch das Klicken von 'Ja, Plan erstellen'.</p> <h3>Pläne schreiben</h3> <p>Die Reiter der Benutzerschnittstelle erlauben ihnen durch die verschiedenen Bereiche zu navigieren wenn sie ihren Plan bearbeiten.</p> <ul> <li>- 'Plandetails' enthält die grundliegenden administrativen Details, listet die Fragen und Hilfestellungen, auf denen ihr Plan basiert und gibt eine Übersicht über die zu beantwortenden Fragen</li> <li>- die folgenden Reiter repräsentieren die zu beantwortenden Fragen. Sollten ihr Förderer oder ihre Institution verschiedene Fragen zu verschiedenen Stufen des Plans beantwortet wissen möchten, können hier mehrere Reiter auftauchen</li> <li>- 'Teilen' enthält Details zum Einladen von anderen Personen zum Lesen oder zur aktiven Mitabeit am Plan</li> <li>- 'Export' enthält Möglichkeiten zum Export des Plans in verschiedene Dateiformate. Dies kann nützlich sein, wenn sie ihren Plan im Rahmen eines Antrags einreichen müssen</li> </ul> <p>In den Fragereitern sind die verschiedenen Abschnitte ihres Plans dargestellt, die sich durch anklicken zur Bearbeitung auswählen lassen. Die Antworttexte können mit den Textbearbeitungsknöpfen formatiert werden.</p> <p>Hilfestellungen werden rechts von den Fragen durch klicken des '+'-Symbols angezeigt.</p> <p>Bitte vergessen sie nicht ihre Antworten zu speichern, bevor sie die Seite verlassen.</p> <h3>Pläne teilen</h3> <p>Geben sie die E-Mail-Adresse der Person an, die ihren Plan lesen oder bearbeiten können sollen. Mithilfe des Ausklappmenüs können sie die Befugnisse, die die Person im Bezug auf den Plan haben soll, auswählen. Klicken sie abschließend auf 'Mitarbeitende(n) hinzufügen'.</p> <h3>Pläne exportieren</h3> <p>Wählen sie das Dateiformat aus, in das sie ihren Plan exportieren möchten und klicken sie 'Export'. Unterhalb des Dialogs können sie durch klicken auf das '+'-Symbol detaillierte Einstellungen zum Export vornehmen.</p>"
-
-msgid "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
-msgstr "<p>You are about to unlink DMP Builder of your institutional credentials, would you like to continue?</p>"
 
 #, fuzzy
 msgid "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
@@ -556,9 +550,6 @@ msgstr "Anpassungen bearbeiten"
 msgid "Edit phase"
 msgstr "Phase bearbeiten"
 
-msgid "Edit phase details"
-msgstr "Details der Phase bearbeiten"
-
 msgid "Edit plan details"
 msgstr "Plandetails bearbeiten"
 
@@ -677,6 +668,10 @@ msgid "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 msgstr "Das Förderkennzeichen als Referenz, sofern sinnvoll (Nur für Datenmanagement-Pläne nach der Bewilligung)."
 
 msgid "Guidance"
+msgstr "Hilfestellung"
+
+#, fuzzy
+msgid "Guidance Choices"
 msgstr "Hilfestellung"
 
 #, fuzzy
@@ -1385,9 +1380,6 @@ msgstr "templates"
 msgid "This plan is based on:"
 msgstr "Dieser Plan basiert auf:"
 
-msgid "This section is locked for editing by "
-msgstr "Dieser Abschnitt ist gespert wegen Bearbeitung durch "
-
 msgid "Title"
 msgstr "Titel"
 
@@ -1418,12 +1410,6 @@ msgstr "Unbekannte Formatierungseinstellung"
 
 msgid "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
 msgstr "Unbekannter Rand. Kann nur 'oben', 'unten', 'links' oder 'rechts' sein"
-
-msgid "Unlink account"
-msgstr "Trenne Zugang"
-
-msgid "Unlink institutional credentials alert"
-msgstr "Unlink institutional credentials alert"
 
 msgid "Unlock my account"
 msgstr "Unlock my account"
@@ -1589,11 +1575,6 @@ msgstr "Organisation"
 
 msgid "You have un-published changes"
 msgstr ""
-
-#, fuzzy
-msgid "You have unsaved answers in the following sections:"
-msgstr ""
-"You have unsaved answers in the following sections:\n"
 
 msgid "You must accept the terms and conditions to register."
 msgstr ""

--- a/config/locale/domain.pot
+++ b/config/locale/domain.pot
@@ -1,0 +1,3 @@
+# Some descriptive title
+msgid ""
+msgstr ""

--- a/config/locale/en_GB/app.po
+++ b/config/locale/en_GB/app.po
@@ -44,9 +44,6 @@ msgstr " on "
 msgid " by"
 msgstr " by"
 
-msgid " by "
-msgstr " by "
-
 msgid " has been removed by "
 msgstr " has been removed by "
 
@@ -193,9 +190,6 @@ msgstr "<p>To create a new template, first enter a title and description. Once y
 
 msgid "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
 msgstr "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
-
-msgid "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
-msgstr "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
 
 msgid "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
 msgstr "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
@@ -540,9 +534,6 @@ msgstr "Edit customisation"
 msgid "Edit phase"
 msgstr "Edit phase"
 
-msgid "Edit phase details"
-msgstr "Edit phase details"
-
 msgid "Edit plan details"
 msgstr "Edit plan details"
 
@@ -659,6 +650,10 @@ msgid "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 msgstr "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 
 msgid "Guidance"
+msgstr "Guidance"
+
+#, fuzzy
+msgid "Guidance Choices"
 msgstr "Guidance"
 
 #, fuzzy
@@ -1363,9 +1358,6 @@ msgstr "template"
 msgid "This plan is based on:"
 msgstr "This plan is based on:"
 
-msgid "This section is locked for editing by "
-msgstr "This section is locked for editing by "
-
 msgid "Title"
 msgstr "Title"
 
@@ -1395,12 +1387,6 @@ msgstr "Unknown formatting setting"
 
 msgid "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
 msgstr "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
-
-msgid "Unlink account"
-msgstr "Unlink account"
-
-msgid "Unlink institutional credentials alert"
-msgstr "Unlink institutional credentials alert"
 
 msgid "Unlock my account"
 msgstr "Unlock my account"
@@ -1559,9 +1545,6 @@ msgid "You have been granted permission by your organisation to use our API. You
 msgstr ""
 
 msgid "You have un-published changes"
-msgstr ""
-
-msgid "You have unsaved answers in the following sections:"
 msgstr ""
 
 msgid "You must accept the terms and conditions to register."

--- a/config/locale/en_US/app.po
+++ b/config/locale/en_US/app.po
@@ -44,9 +44,6 @@ msgstr " on "
 msgid " by"
 msgstr " by"
 
-msgid " by "
-msgstr " by "
-
 msgid " has been removed by "
 msgstr " has been removed by "
 
@@ -193,9 +190,6 @@ msgstr "<p>To create a new template, first enter a title and description. Once y
 
 msgid "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
 msgstr "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
-
-msgid "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
-msgstr "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
 
 msgid "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
 msgstr "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
@@ -540,9 +534,6 @@ msgstr "Edit customisation"
 msgid "Edit phase"
 msgstr "Edit phase"
 
-msgid "Edit phase details"
-msgstr "Edit phase details"
-
 msgid "Edit plan details"
 msgstr "Edit plan details"
 
@@ -659,6 +650,10 @@ msgid "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 msgstr "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 
 msgid "Guidance"
+msgstr "Guidance"
+
+#, fuzzy
+msgid "Guidance Choices"
 msgstr "Guidance"
 
 #, fuzzy
@@ -1363,9 +1358,6 @@ msgstr "template"
 msgid "This plan is based on:"
 msgstr "This plan is based on:"
 
-msgid "This section is locked for editing by "
-msgstr "This section is locked for editing by "
-
 msgid "Title"
 msgstr "Title"
 
@@ -1395,12 +1387,6 @@ msgstr "Unknown formatting setting"
 
 msgid "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
 msgstr "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
-
-msgid "Unlink account"
-msgstr "Unlink account"
-
-msgid "Unlink institutional credentials alert"
-msgstr "Unlink institutional credentials alert"
 
 msgid "Unlock my account"
 msgstr "Unlock my account"
@@ -1559,9 +1545,6 @@ msgid "You have been granted permission by your organisation to use our API. You
 msgstr "You have been granted permission by your organization to use our API. Your API token and instructions for using the API endpoints can be found "
 
 msgid "You have un-published changes"
-msgstr ""
-
-msgid "You have unsaved answers in the following sections:"
 msgstr ""
 
 msgid "You must accept the terms and conditions to register."

--- a/config/locale/es/app.po
+++ b/config/locale/es/app.po
@@ -43,9 +43,6 @@ msgstr ""
 msgid " by"
 msgstr " por "
 
-msgid " by "
-msgstr " por "
-
 #, fuzzy
 msgid " has been removed by "
 msgstr " por "
@@ -195,9 +192,6 @@ msgstr "<p>Para crear una plantilla nueva, en primer lugar introduzca un título
 
 msgid "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
 msgstr ""
-
-msgid "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
-msgstr "<p>Va a desvincular DMPonline de las credenciales de su institución, ¿Quiere continuar?</p>"
 
 #, fuzzy
 msgid "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
@@ -552,9 +546,6 @@ msgstr "Editar la personalización"
 msgid "Edit phase"
 msgstr "Editar fase"
 
-msgid "Edit phase details"
-msgstr "Editar los detalles de las fase"
-
 msgid "Edit plan details"
 msgstr "Editar los detalles del plan"
 
@@ -673,6 +664,10 @@ msgid "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 msgstr "Número de referencia de la subvención si es aplicable [SÓLO PGDs YA ADJUDICADOS]"
 
 msgid "Guidance"
+msgstr "Guía"
+
+#, fuzzy
+msgid "Guidance Choices"
 msgstr "Guía"
 
 #, fuzzy
@@ -1378,9 +1373,6 @@ msgstr "templates"
 msgid "This plan is based on:"
 msgstr "Este plan está basado en:"
 
-msgid "This section is locked for editing by "
-msgstr "Esta sección está bloqueda para su edición por "
-
 msgid "Title"
 msgstr "Título"
 
@@ -1411,12 +1403,6 @@ msgstr "Valores de formato desconocidos"
 
 msgid "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
 msgstr "Margen desconocido. Sólo puede ser 'superior', 'inferior', 'izquierdo' or 'derecho'"
-
-msgid "Unlink account"
-msgstr "Desvincular cuenta"
-
-msgid "Unlink institutional credentials alert"
-msgstr "Desvincule las alertas relacionadas con las credenciales de su institución"
 
 msgid "Unlock my account"
 msgstr ""
@@ -1581,9 +1567,6 @@ msgid "You have been granted permission by your organisation to use our API. You
 msgstr "Organización"
 
 msgid "You have un-published changes"
-msgstr ""
-
-msgid "You have unsaved answers in the following sections:"
 msgstr ""
 
 msgid "You must accept the terms and conditions to register."

--- a/config/locale/fr/app.po
+++ b/config/locale/fr/app.po
@@ -43,9 +43,6 @@ msgstr ""
 msgid " by"
 msgstr " par "
 
-msgid " by "
-msgstr " par "
-
 #, fuzzy
 msgid " has been removed by "
 msgstr " par "
@@ -194,9 +191,6 @@ msgstr "<p>Pour créer un nouveau modèle, commencez par saisir un titre et une 
 
 msgid "<p>When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p> <h3>Create a plan</h3> <p>To create a plan, click the 'Create plan' button from the 'My plans' page or  the top menu. Select options from the drop-down menus and tickboxes to determine what questions and guidance you should be presented with. Confirm your selection by clicking 'Yes, create plan'</p> <h3>Write your plan</h3> <p>The tabbed interface allows you to navigate through different functions when editing your plan.</p> <ul> <li>- 'Plan details' includes basic administrative details, tells you what sets of questions and guidance your plan is based on and gives you an overview to the questions that you will be asked.</li> <li>- The following tab(s) present the questions to answer. There may be more than one tab if your funder or university asks different sets of questions at different stages e.g. at grant application and post-award.</li> <li>- The 'Share' tab allows you to invite others to read or contribute to your plan.</li> <li>- The 'Export' tab allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application.</li> </ul> <p>When viewing any of the question tabs, you will see the different sections of your plan displayed. Click into these in turn to answer the questions. You can format your responses using the text editing buttons.</p> <p>Guidance is displayed in the right-hand panel. Click the '+' symbol to view this.</p> <p>Remember to 'save' your responses before moving on.</p> <h3>Share plans</h3> <p>Insert the email address of any collaborators you would like to invite to read or edit your plan. Set the level of permissions you would like to grant them via the drop-down options and click to 'Add collaborator'</p> <h3>Export plans</h3> <p>From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to export. When you login to %{application_name} you will be directed to the 'My plans' page. From here you can edit, share, export or delete any of your plans. You will also see plans that have been shared with you by others.</p>"
 msgstr "<p>Lorsque vous vous connectez à l'Assistant PGD, vous serez dirigé vers la page « Mes plans ». À partir de cette page, vous pouvez modifier, partager, exporter ou supprimer l'un ou l'autre de vos plans. Vous verrez également les plans qui ont été partagés avec vous par d'autres personnes.</p> <h3>Créer un plan</h3> <p>Pour créer un plan, cliquez sur le bouton « Créer un plan » à la page « Mes plans » ou dans le menu du haut. Faites des choix dans les listes déroulantes et les cases à cocher afin de déterminer les questions et les directives qui seront affichées. Confirmez votre choix en cliquant sur « Oui, créer un plan ».</p> <h3>Rédiger votre plan</h3> <p>L'interface à onglets vous permet de naviguer dans diverses fonctions lorsque vous mettez au point votre plan.</p> <ul> <li>- L'option « renseignements sur le plan » comprend des renseignements administratifs de base, indique la série de questions et de directives sur laquelle votre plan s'appuie et vous donne un aperçu des questions auxquelles vous devez répondre.</li> <li>- Les onglets suivants contiennent les questions auxquelles il faut répondre. Il peut y avoir plus d'un onglet si votre bailleur de fonds ou votre université pose différentes séries de questions à diverses étapes, par exemple lors d'une demande de subvention et après l'octroi d'une subvention.</li> <li>- L'onglet « Partager » vous permet d'inviter d'autres personnes à lire votre plan ou à y collaborer.</li> <li>- L'onglet « Exporter » vous permet de télécharger votre plan en divers formats, ce qui peut être utile si vous devez joindre votre plan à une demande de subvention.</li> </ul> <p>Lorsque vous consultez l'un ou l'autre des onglets de questions, vous verrez les différentes sections de votre plan affichées. Cliquez sur ces onglets à tour de rôle pour répondre aux questions. Vous pouvez choisir le format de vos réponses à l'aide des boutons de mise en forme.</p> <p>Les directives sont affichées dans la partie de droite. Cliquez sur le symbole « + » pour les consulter.</p> <p>N'oubliez pas d'enregistrer vos réponses avant de poursuivre.</p> <h3>Partager les plans</h3> <p>Inscrivez l'adresse électronique de tout collaborateur que vous aimeriez inviter à lire ou à modifier votre plan. Choisissez le niveau d'autorisation que vous souhaitez lui accorder dans les options de la liste déroulante et cliquez sur « Ajouter un collaborateur ».</p> <h3>Exporter les plans</h3> <p>En choisissant cette option, vous pouvez télécharger votre plan en divers formats, ce qui peut être utile si vous devez joindre votre plan à une demande de subvention. Choisissez le format dans lequel vous aimeriez voir ou télécharger votre plan et cliquez pour l'exporter. Lorsque vous vous connectez à l'Assistant PGD, vous êtes dirigé vers la page « Mes plans ». À partir de cette page, vous pouvez modifier, partager, exporter ou supprimer l'un ou l'autre de vos plans. Vous voyez également les plans qui ont été partagés avec vous par d'autres personnes.</p>"
-
-msgid "<p>You are about to unlink %{application_name} of your institutional credentials, would you like to continue?</p>"
-msgstr "<p>Vous allez détacher DMPonline de votre authentfiant détablissement, voulez-vous continuer ?</p>"
 
 #, fuzzy
 msgid "<p>You can give other people access to your plan here. There are three permission levels.<ul><li>Users with \"read only\" access can only read the plan.</li><li>Editors can contribute to the plan.</li><li>Co-owners can also contribute to the plan, but additionally can edit the plan details and control access to the plan.</li></ul></p><p>Add each collaborator in turn by entering their email address below, choosing a permission level and clicking \"Add collaborator\".</p><p>Those you invite will receive an email notification that they have access to this plan, inviting them to register with %{application_name} if they don't already have an account. A notification is also issued when a user's permission level is changed.</p>"
@@ -550,9 +544,6 @@ msgstr "Modifier la personnalisation"
 msgid "Edit phase"
 msgstr "Modifier la phase"
 
-msgid "Edit phase details"
-msgstr "Modifiez les détails de la phase"
-
 msgid "Edit plan details"
 msgstr "Modifier des détails du plan"
 
@@ -671,6 +662,10 @@ msgid "Grant reference number if applicable [POST-AWARD DMPs ONLY]"
 msgstr "N° de réféence de la subvention, le cas échéant (UNIQUEMENT POUR LES DMP CRÉÉS APRÈS OCTROI DUNE SUBVENTION)"
 
 msgid "Guidance"
+msgstr "Conseils"
+
+#, fuzzy
+msgid "Guidance Choices"
 msgstr "Conseils"
 
 #, fuzzy
@@ -1375,9 +1370,6 @@ msgstr "templates"
 msgid "This plan is based on:"
 msgstr "Ce plan sinspire de :"
 
-msgid "This section is locked for editing by "
-msgstr "La modification de cette section a été verrouillée par "
-
 msgid "Title"
 msgstr "Titre"
 
@@ -1408,12 +1400,6 @@ msgstr "Réglage de mise en forme"
 
 msgid "Unknown margin. Can only be 'top', 'bottom', 'left' or 'right'"
 msgstr "Marge inconnue. Seules marges possibles : Haut, Bas, Gauche et Droite"
-
-msgid "Unlink account"
-msgstr "Délier le compte"
-
-msgid "Unlink institutional credentials alert"
-msgstr "Alerte de détachement dauthentifiant détablissement"
 
 msgid "Unlock my account"
 msgstr ""
@@ -1578,9 +1564,6 @@ msgid "You have been granted permission by your organisation to use our API. You
 msgstr "Organisation"
 
 msgid "You have un-published changes"
-msgstr ""
-
-msgid "You have unsaved answers in the following sections:"
 msgstr ""
 
 msgid "You must accept the terms and conditions to register."


### PR DESCRIPTION
Fixes #461, changed save to update_attributes in guidance controller

Fixes #462, implemented concept of published/unpublished guidance.  filtering at model/controller level keeps most logic out of views

removes auto-publishing of guidance_groups based off published guidance.

ripped whitespace and block comments out of code

added translation to a file where un-translated text existed.