### PR TITLE
DMPRoadmap/roadmap#483

### DIFF
--- a/app/views/contact_us/contacts/new.html.erb
+++ b/app/views/contact_us/contacts/new.html.erb
@@ -16,36 +16,31 @@
       <fieldset class="side-by-side">
         <% if ContactUs.require_name %>
           <div class="form-input">
-            <label for="contact_us_contact_name"><%= _('Name') %>*</label>
-            <input type="text" id="contact_us_contact_name" name="contact_us[contact_name]" 
-                   class="left-indent required input-large" value="<%= current_user.nil? ? '' : current_user.name(false) %>"<%= current_user.nil? ? '' : 'disabled="true"' %> />
+            <%= f.label(:name, _('Name')+'*') %>
+            <%= f.text_field(:name, class: "left-indent required input-large", value: current_user.nil? ? '' : current_user.name(false), readonly: !current_user.nil?) %>
           </div>
         <% end %>
         
         <div class="form-input">
-          <label for="contact_us_contact_email"><%= _('Email') %>*</label>
-          <input type="email" id="contact_us_contact_email" name="contact_us[contact_email]" 
-                 class="left-indent required input-large" value="<%= current_user.nil? ? '' : current_user.email %>"<%= current_user.nil? ? '' : 'disabled="true"' %> />
+          <%= f.label(:email, _('Email')+'*') %>
+          <%= f.text_field(:email, class: "left-indent required input-large", value: current_user.nil? ? '' : current_user.email, readonly: !current_user.nil?) %>
           <span role="" id="contact_us_contact_email_error" class="error-tooltip-right left-indent"></span>
         </div>
         
         <% if ContactUs.require_subject %>
           <div class="form-input">
-            <label for="contact_us_contact_subject align-top"><%= _('Subject') %>*</label>
-            <input type="text" id="contact_us_contact_subject" name="contact_us[contact_subject]" 
-                   class="left-indent required input-large" />
+            <%= f.label(:subject, _('Subject')+'*') %>
+            <%= f.text_field(:subject, class: "left-indent required input-large") %>
           </div>
         <% end %>
         
         <div class="form-input">
-          <label for="contact_us_contact_message" class="align-top"><%= _('Message') %>*</label>
-          <textarea id="contact_us_contact_message" name="contact_us[contact_message]" rows="10" 
-                    class="left-indent required input-large"></textarea>
+          <%= f.label(:message, _('Message')+'*', class: "align-top") %>
+          <%= f.text_area(:message, class: "left-indent required input-large", rows: 10) %>
         </div>
-        
         <% if !user_signed_in? then %>
           <div class="form-input">
-            <label class="align-top"><%= _('Security check') %>*</label>
+            <%= label_tag(nil, _('Security check')+'*', class: "align-top") %>
             <div class="inline left-indent">
               <%= recaptcha_tags %>
             </div>

--- a/lib/assets/javascripts/dmproadmap/forms.js
+++ b/lib/assets/javascripts/dmproadmap/forms.js
@@ -49,7 +49,7 @@ function validatePassword(sPassword) {
 
 // ---------------------------------------------------------------------------
 function validateEmail(sEmail) {
-  var filter = /^[a-zA-Z0-9]+[a-zA-Z0-9_.-]+[a-zA-Z0-9_-]+@[a-zA-Z0-9]+[a-zA-Z0-9.-]+.[a-z]{2,4}$/;
+  var filter = /[^@\s]+@(?:[-a-z0-9]+\.)+[a-z]{2,}$/;
   if(filter.test(sEmail)){
     return '';
   }else{

--- a/lib/assets/javascripts/views/contacts/new_contact.js
+++ b/lib/assets/javascripts/views/contacts/new_contact.js
@@ -10,16 +10,16 @@ $(document).ready(function(){
 	
   $("input[type='text'], input[type='email'], textarea").change(function(e){
     var enable = ($("#contact_us_contact_name").val().trim().length > 0 &&
-                  validateEmail($("#contact_us_contact_email").val().trim()) != '' &&
+                  validateEmail($("#contact_us_contact_email").val().trim()) === '' &&
                   $("#contact_us_contact_subject").val().trim().length > 0 &&
                   $("#contact_us_contact_message").val().trim().length > 0);
     
-		// Check the recaptcha status
-		if($("#recaptcha-anchor")){
-			if($("#recaptcha-anchor").prop('aria-checked') != 'true'){
-				enable = false;
-			}
-		}
+    // Disabled recaptcha since always sets enable, TODO change when we tackle https://github.com/DMPRoadmap/roadmap/issues/501
+		// if($("#recaptcha-anchor")){
+		// 	if($("#recaptcha-anchor").prop('aria-checked') != 'true'){
+		// 		enable = false;
+		// 	}
+		// }
     $("#create_contact_submit").attr('aria-disabled', !enable);
   });
 });


### PR DESCRIPTION
-Replaced wrong parameter names since it is expected contact_us_contact[...]
-Fixed logic for when an email is valid and re-introduced the previous regex, which is compatible with contact_us gem
-Replaced disabled fields (e.g. email, name) with readonly attribute, otherwise these parameters are not send to the server

