### PR TITLE
fixes bug with duplicate guidance and adds rake task to cleanup database

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -11,7 +11,7 @@ class TemplatesController < ApplicationController
   def admin_index
     authorize Template
 
-    funder_templates, org_templates, customizations = [], [], []
+    funder_templates, org_templates = [], []
 
     # Get all of the unique template family ids (dmptemplate_id) for each funder and the current org
     funder_ids = Org.funders.includes(:templates).collect{|f| f.templates.where(published: true).valid.collect{|ft| ft.dmptemplate_id } }.flatten.uniq
@@ -131,7 +131,7 @@ class TemplatesController < ApplicationController
               # find corresponding question in new template
               customization_question = customization_section.questions.where(number: question.number).first
               # apply annotations
-              question.annotations.each do |annotation|
+              question.annotations.where(org_id: current_user.org_id).each do |annotation|
                 annotation_copy = Annotation.deep_copy(annotation)
                 annotation_copy.question_id = customization_question.id
                 annotation_copy.save!
@@ -213,7 +213,7 @@ class TemplatesController < ApplicationController
         new_version.save
         @template = new_version
 #        @current = Template.current(@template.dmptemplate_id)
-       end
+      end
     else
       flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
     end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -219,15 +219,15 @@ namespace :migrate do
     if IdentifierScheme.find_by(name: 'orcid').nil?
       IdentifierScheme.create!(name: 'orcid', description: 'ORCID', active: true)
     end
-    
+
     scheme = IdentifierScheme.find_by(name: 'orcid')
-      
+
     unless scheme.nil?
       User.all.each do |u|
         if u.respond_to?(:orcid_id)
-          if u.orcid_id.present? 
+          if u.orcid_id.present?
             if u.orcid_id.gsub('orcid.org/', '').match(/^[\d-]+/)
-              u.user_identifiers << UserIdentifier.new(identifier_scheme: scheme, 
+              u.user_identifiers << UserIdentifier.new(identifier_scheme: scheme,
                                                        identifier: u.orcid_id.gsub('orcid.org/', ''))
               u.save!
             end
@@ -253,5 +253,14 @@ namespace :migrate do
       end
     end
   end
-  
+
+  desc "remove duplicate annotations caused by bug"
+  task remove_duplicate_annotations: :environment do
+    Question.joins(:annotations).group("questions.id").having("count(annotations.id) > count(DISTINCT annotations.text)")
+    Annotation.all.each do |a|
+      conflicts = Annotation.where(question_id: a.question_id, text: a.text).where.not(id: a.id)
+      conflicts.each {|c| matches += 1 }
+    end
+  end
+
 end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -256,10 +256,12 @@ namespace :migrate do
 
   desc "remove duplicate annotations caused by bug"
   task remove_duplicate_annotations: :environment do
-    Question.joins(:annotations).group("questions.id").having("count(annotations.id) > count(DISTINCT annotations.text)")
-    Annotation.all.each do |a|
-      conflicts = Annotation.where(question_id: a.question_id, text: a.text).where.not(id: a.id)
-      conflicts.each {|c| matches += 1 }
+    questions = Question.joins(:annotations).group("questions.id").having("count(annotations.id) > count(DISTINCT annotations.text)")
+    questions.each do |q|
+      q.annotations.each do |a|
+        conflicts = Annotation.where(question_id: a.question_id, text: a.text).where.not(id: a.id)
+        conflicts.each {|c| matches += 1 }
+      end
     end
   end
 


### PR DESCRIPTION
### original issue:
code which applies customizer's customizations to an updated base template copying over all guidance, not just that of the customizer, this caused duplicate funder guidance.

### bugfix: 
only copy over the current user's org's annotations

### data correction:
rake task added to remove all these duplicate annotations from the codebase
rake migrate:remove_duplicate_annotations

Also looks like the editor i've switched to, atom.io, has ripped trailing whitespace out of saved files