### PR TITLE
Ensure Templates assigned to plans are valid

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -404,7 +404,7 @@ class PlansController < ApplicationController
     # If no templates were available use the generic templates
     if @templates.empty?
       @msg = _("Using the generic Data Management Plan")
-      @templates << Template.where(is_default: true, published: true).first
+      @templates << Template.valid.where(is_default: true, published: true).first
     end
 
     @templates = @templates.sort{|x,y| x.title <=> y.title } if @templates.count > 1


### PR DESCRIPTION
Valid flag used to distinguish templates which were created by the migration from those in the correct format for the new site.

Tuuli was having an issue where legacy data was also marked with is_default, and an outdated template being given to the end-users.

Please delete this patch branch after accepting PR