### PR TITLE
Converted collate/filterise table to ES6 

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -317,7 +317,7 @@ class PlansController < ApplicationController
   def set_test
     plan = Plan.find(params[:id])
     authorize plan
-    plan.visibility = "#{plan_params[:visibility]}"
+    plan.visibility = (params[:is_test] === "1" ? :is_test : :privately_visible)
     if plan.save
       render json: {msg: (plan.is_test? ? _('Your project is now a test.') : _('Your project is no longer a test.') )}
     else

--- a/app/views/layouts/_es5_scripts.html.erb
+++ b/app/views/layouts/_es5_scripts.html.erb
@@ -5,8 +5,8 @@
     <%= javascript_include_tag 'rails.js' %>
     <%= javascript_include_tag 'jquery-ui.min.js' %>
     <%= javascript_include_tag 'placeholder.min.js' %>
-    <%= javascript_include_tag 'jquery.tablesorter.min.js' %>
-    <%= javascript_include_tag 'jquery.tablesorter.widgets.min.js' %>
+    <%#= javascript_include_tag 'jquery.tablesorter.min.js' %>
+    <%#= javascript_include_tag 'jquery.tablesorter.widgets.min.js' %>
     <%= javascript_include_tag 'jquery.timeago.js' %>
     <%#= javascript_include_tag 'bootstrap.min.js' %>
 <!-- END third party libraries -->
@@ -17,8 +17,8 @@
     <%= javascript_include_tag 'utils_es5/tinymce.js' %>
     <%= javascript_include_tag 'utils_es5/validate.js' %>
     <%= javascript_include_tag 'utils_es5/ariatiseForm.js' %>
-    <%= javascript_include_tag 'utils_es5/filteriseTable.js' %>
-    <%= javascript_include_tag 'utils_es5/collateTable.js' %>
+    <%#= javascript_include_tag 'utils_es5/filteriseTable.js' %>
+    <%#= javascript_include_tag 'utils_es5/collateTable.js' %>
 <!-- END utils scripts -->
 
 <!-- START dmproadmap scripts -->
@@ -34,7 +34,6 @@
     <%= javascript_include_tag 'views/orgs/admin_edit.js' %>    <!-- (app/views/orgs/admin_edit.html.erb) -->
     <%= javascript_include_tag 'views/orgs/shibboleth_ds.js' %> <!-- (app/views/orgs/shibboleth_ds.html.erb) -->
     <%= javascript_include_tag 'views/plans/available_templates.js' %>  <!-- (app/views/plans/_available_templates.html.erb) -->
-    <%= javascript_include_tag 'views/plans/index.js' %>    <!-- -->
     <%= javascript_include_tag 'views/registrations/sign_in_sign_up.js' %>  <!-- -->
     <%= javascript_include_tag 'views/shared/login_form.js' %>  <!-- -->
     <%= javascript_include_tag 'views/shared/register_form.js' %>   <!-- -->

--- a/app/views/phases/_admin_add.html.erb
+++ b/app/views/phases/_admin_add.html.erb
@@ -1,4 +1,3 @@
-<%- model_class = Phase -%>
 <h2><%= _('Phase details') %></h2>
 <p><%= _('When you create a new phase for your template, a version will automatically be created. Once you complete the form below you will be provided with options to create sections and questions.') %></p>
 <%= form_for :phase, { url: admin_create_phase_path, html: { class: 'form-horizontal' }} do |f| %>

--- a/app/views/phases/admin_preview.html.erb
+++ b/app/views/phases/admin_preview.html.erb
@@ -1,5 +1,3 @@
-<%- model_class = Phase -%>
-
 <div class="row">
   <div class="col-md-12">
     <h1>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -54,12 +54,16 @@
                 <td><%= display_role(plan.roles.find_by(user: current_user)) %></td>
                 <td class="text-center">
                   <% if plan.administerable_by?(current_user.id) then %>
-                    <input type="checkbox" id="is_test-<%= plan.id %>"<%= plan.visibility === 'is_test' ? 'checked="true"' : '' %><%= plan.administerable_by?(current_user.id) ? '' : 'disabled="true"' %> />
+                    <%= form_for plan, url: set_test_plan_url(plan), html: {method: :post, id: 'update-test-plan'} do |f| %>
+                      <%= check_box_tag(:is_test, "1", (plan.visibility === 'is_test')) %>
+                    <% end %>
                   <% else %>
                     <%= plan.visibility === 'is_test' ? _('Yes') : _('No') %>
                   <% end %>
                 </td>
-                <td id="visibility-<%= plan.id %>"><%= raw display_visibility(plan.visibility) %></td>
+                <td class="plan-visibility">
+                  <%= plan.visibility === 'is_test' ? _('N/A') : raw(display_visibility(plan.visibility)) %>
+                </td>
                 <td>
                   <div class="dropdown">
                     <button class="btn btn-link dropdown-toggle" type="button"

--- a/app/views/public_pages/plan_index.html.erb
+++ b/app/views/public_pages/plan_index.html.erb
@@ -1,5 +1,3 @@
-<%- model_class = Plan -%>
-
 <div class="row">
   <div class="col-md-12">
     <h1><%= raw _('Public DMPs') %></h1>

--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -3,17 +3,27 @@ import './views/contacts/new';
 import './views/devise/invitations/edit';
 import './views/devise/passwords/edit';
 import './views/devise/passwords/new';
+import './views/devise/registrations/edit';
+import './views/notes/index';
 import './views/phases/edit';
 import './views/phases/show';
 import './views/plans/download';
 import './views/plans/edit_details';
+import './views/plans/index';
 import './views/plans/new';
 import './views/plans/share';
-import './views/devise/registrations/edit';
-import './views/notes/index';
-import './views/templates/show';
-import './views/templates/edit';
+import './views/questions/new';
 import './views/sections/index';
 import './views/sections/new';
 import './views/questions/index';
-import './views/questions/new';
+import './views/templates/show';
+import './views/templates/edit';
+
+// Not sure if this belongs here. All tables share the same class/id selectors 
+// so having it on one page makes it work everywhere
+import { collateTable, filteriseTable } from './utils/tableHelper';
+
+$().ready(() => {
+  collateTable({ selector: 'table.tablesorter' });
+  filteriseTable({ selector: '#filter' });
+});

--- a/lib/assets/javascripts/constants.js
+++ b/lib/assets/javascripts/constants.js
@@ -13,3 +13,7 @@ export const VALIDATION_MESSAGE_TEXT = 'This field is required.';
 export const SHOW_PASSWORD_MESSAGE = 'Show password';
 export const SHOW_SELECT_ORG_MESSAGE = 'Select an organisation from the list.';
 export const SHOW_OTHER_ORG_MESSAGE = 'My organisation isn\'t listed';
+
+export const PLAN_VISIBILITY_WHEN_TEST = 'N/A';
+export const PLAN_VISIBILITY_WHEN_NOT_TEST = 'Private';
+export const PLAN_VISIBILITY_WHEN_NOT_TEST_TOOLTIP = 'Private: restricted to me and people I invite.';

--- a/lib/assets/javascripts/utils/tableHelper.js
+++ b/lib/assets/javascripts/utils/tableHelper.js
@@ -1,0 +1,51 @@
+import 'tablesorter/dist/js/jquery.tablesorter.min';
+import debounce from '../utils/debounce';
+import { isObject, isString } from './isType';
+
+export const collateTable = (options) => {
+  if (isObject(options) && isString(options.selector)) {
+    $(options.selector).tablesorter({
+      theme: 'bootstrap_3',
+      headerTemplate: '{content} {icon}',
+      cssIconAsc: 'fa fa-sort-asc',
+      cssIconDesc: 'fa fa-sort-desc',
+      cssIconNone: 'fa fa-sort',
+    });
+  }
+};
+
+export const filteriseTable = (options) => {
+  if (isObject(options) && isString(options.selector)) {
+    const filter = ((el) => {
+      const query = $(el).val();
+      const regex = new RegExp(query, 'i');
+
+      $.each($(el).closest('table').find('tbody tr'), (idx, tr) => {
+        if (regex.test($(tr).text())) {
+          $(tr).show();
+        } else {
+          $(tr).hide();
+        }
+      });
+    });
+
+    const clear = ((el) => {
+      $(el).val('');
+      $(el).closest('table').find('tbody tr').show();
+    });
+
+    /* initialize a debounced listener for the filter box */
+    const debounced = debounce(filter);
+
+    /* Bind the clear function to the clear icon's click event */
+    $(options.selector).keyup((e) => {
+      debounced(e.currentTarget);
+    });
+
+    $(options.selector).siblings('#clear_filter').click((e) => {
+      e.preventDefault();
+      clear(e.currentTarget);
+      debounced.cancel();
+    });
+  }
+};

--- a/lib/assets/javascripts/views/plans/index.js
+++ b/lib/assets/javascripts/views/plans/index.js
@@ -1,23 +1,30 @@
-$(document).ready(function(){
-  dmproadmap.utils.collateTable.init({ selector: 'table.tablesorter' });
-  dmproadmap.utils.filteriseTable.init({ selector: '#filter' });
+import { PLAN_VISIBILITY_WHEN_TEST, PLAN_VISIBILITY_WHEN_NOT_TEST, PLAN_VISIBILITY_WHEN_NOT_TEST_TOOLTIP } from '../../constants';
 
-  // Update the plan's test status via ajax when the checkbox is clicked
-  $("input[type='checkbox']").on('click, change', function(e){
-    var self = this;
-    var id = $(this).attr("id").replace("is_test-", "");
-    var params = {plan: {visibility: $(this).is(':checked') ? 'is_test' : 'privately_visible'}};
+$().ready(() => {
+  const checkboxHandler = (el) => {
+    const form = $(el).closest('form');
 
-    asyncRequest(
-      {url: "/plans/" + id + "/set_test", 
-       type: 'POST', 
-       data: JSON.stringify(params)}, 
-      {success: function(data){ 
-        if($(self).is(':checked')){
-          $("#visibility-" + id + " span").html(__('N/A')).attr('title', '');
-        }else{
-          $("#visibility-" + id + " span").html(__('Private'))
-        }
-      }});
+    $.ajax({
+      method: $(form).attr('method'),
+      url: $(form).attr('action'),
+      data: $(form).serializeArray(),
+    }).done((data) => {
+      $('#notification-area').removeClass('hide').find('span').last()
+        .html(data.msg);
+
+      if ($(el).is(':checked')) {
+        $(form).parent().siblings('.plan-visibility').html(PLAN_VISIBILITY_WHEN_TEST)
+          .attr('title', '');
+      } else {
+        $(form).parent().siblings('.plan-visibility').html(PLAN_VISIBILITY_WHEN_NOT_TEST)
+          .attr('title', PLAN_VISIBILITY_WHEN_NOT_TEST_TOOLTIP);
+      }
+    }, () => {
+      // TODO adequate error handling for network error 
+    });
+  };
+
+  $("input[type='checkbox']").on('click, change', (e) => {
+    checkboxHandler(e.currentTarget);
   });
 });


### PR DESCRIPTION
Addresses #658

Removed old <%- ... -%> style markup. This was from Rails pre 3.x

added tableHelper.js with collate and ariatise methods. updated my dashboard page to use tableHelper

moved collate/filterise calls to application.js since the selectors are the same across tables