### PR TITLE
Fix url issues

### DIFF
--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -54,7 +54,7 @@
                 <td><%= display_role(plan.roles.find_by(user: current_user)) %></td>
                 <td class="text-center">
                   <% if plan.administerable_by?(current_user.id) then %>
-                    <%= form_for plan, url: set_test_plan_url(plan), html: {method: :post, id: 'update-test-plan'} do |f| %>
+                    <%= form_for plan, url: set_test_plan_path(plan), html: {method: :post, id: 'update-test-plan'} do |f| %>
                       <%= check_box_tag(:is_test, "1", (plan.visibility === 'is_test')) %>
                     <% end %>
                   <% else %>

--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -1,6 +1,9 @@
-// Not sure if this file is the best place for this.
-import 'bootstrap-sass/assets/javascripts/bootstrap/tooltip';
+// Generic JS that is applicable across multiple pages
+import './utils/linkHelper';
+import './utils/tableHelper';
+import './utils/tooltipHelper';
 
+// Page specific JS
 import './views/answers/status';
 import './views/contacts/new';
 import './views/devise/invitations/edit';
@@ -26,23 +29,3 @@ import './views/shared/sign_in_form';
 import './views/templates/edit';
 import './views/templates/show';
 import './views/users/notification_preferences';
-
-// Not sure if this file is the best place for this. 
-// All tables share the same class/id selectors so having it on one page makes it work everywhere
-// All tooltips have the data-toggle="tooltip" attribute
-import { collateTable, filteriseTable } from './utils/tableHelper';
-
-$(() => {
-  collateTable({ selector: 'table.tablesorter' });
-  filteriseTable({ selector: '#filter' });
-
-  // When using a tooltip on a tinymce textarea, add the HTML attributes for the tooltips to 
-  // the parent `<div class="form-group">`. TODO: this does not work on focus though since tinymce
-  // uses an iframe and we can't detect when the editor window gains focus. It only works on hover.
-  //
-  // If the content of the tooltip contains HTML, then add `data-html="true"` to the element
-  $('[data-toggle="tooltip"]').tooltip({
-    animated: 'fade',
-    placement: 'right',
-  });
-});

--- a/lib/assets/javascripts/utils/linkHelper.js
+++ b/lib/assets/javascripts/utils/linkHelper.js
@@ -1,0 +1,25 @@
+import { isString } from './isType';
+
+$(() => {
+  const restfulLinks = $('a[data-method]');
+
+  restfulLinks.map((idx, el) => {
+    const method = $(el).attr('data-method');
+    const target = $(el).attr('href');
+    const token = $('meta[name="csrf-token"]').attr('content');
+
+    if (isString(method) && isString(target)) {
+      const html = `<form action="${target}" method="POST" style="display:none">
+        <input type="hidden" name="_method" value="${method.toUpperCase()}" />
+        <input type="hidden" name="authenticity_token" value="${token}" />
+        </form>`;
+      $(el).append(html);
+
+      $(el).click((e) => {
+        e.preventDefault();
+        $(e.currentTarget).find('form').submit();
+      });
+    }
+    return true;
+  });
+});

--- a/lib/assets/javascripts/utils/tableHelper.js
+++ b/lib/assets/javascripts/utils/tableHelper.js
@@ -49,3 +49,9 @@ export const filteriseTable = (options) => {
     });
   }
 };
+
+// Attach the tablesorter and filter to all tables with those selectors
+$(() => {
+  collateTable({ selector: 'table.tablesorter' });
+  filteriseTable({ selector: '#filter' });
+});

--- a/lib/assets/javascripts/utils/tooltipHelper.js
+++ b/lib/assets/javascripts/utils/tooltipHelper.js
@@ -1,0 +1,13 @@
+import 'bootstrap-sass/assets/javascripts/bootstrap/tooltip';
+
+$(() => {
+  // When using a tooltip on a tinymce textarea, add the HTML attributes for the tooltips to 
+  // the parent `<div class="form-group">`. TODO: this does not work on focus though since tinymce
+  // uses an iframe and we can't detect when the editor window gains focus. It only works on hover.
+  //
+  // If the content of the tooltip contains HTML, then add `data-html="true"` to the element
+  $('[data-toggle="tooltip"]').tooltip({
+    animated: 'fade',
+    placement: 'right',
+  });
+});

--- a/lib/assets/javascripts/views/shared/create_account_form.js
+++ b/lib/assets/javascripts/views/shared/create_account_form.js
@@ -1,6 +1,6 @@
 import initAutoComplete from '../../utils/autoComplete';
 import ariatiseForm from '../../utils/ariatiseForm';
-import togglisePasswords from '../../utils/passwordHelper';
+import { togglisePasswords } from '../../utils/passwordHelper';
 import { SHOW_SELECT_ORG_MESSAGE, SHOW_OTHER_ORG_MESSAGE } from '../../constants';
 
 $(() => {

--- a/lib/assets/javascripts/views/shared/sign_in_form.js
+++ b/lib/assets/javascripts/views/shared/sign_in_form.js
@@ -1,5 +1,5 @@
 import ariatiseForm from '../../utils/ariatiseForm';
-import togglisePasswords from '../../utils/passwordHelper';
+import { togglisePasswords } from '../../utils/passwordHelper';
 
 $(() => {
   ariatiseForm({ selector: '#sign_in_form' });


### PR DESCRIPTION
- Adds curly braces to import statement on ES6 JS file #688
- Switch to use path instead of url helper for form being submitted by AJAX #689 
- Introduces a linkHelper.js to get Rails' RESTful links to work now that we have disabled the asset pipeline and removed all old ES5 JS references. #685 
- Moved generic table and tooltip JS from application.js to their own helpers and then import those helpers within application.js