### PR TITLE
Updated dragonfly resize to 75px height (retain aspect ratio)

### DIFF
--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -146,8 +146,8 @@ class Org < ActiveRecord::Base
     #
     def resize_image
       unless logo.nil?
-        if logo.height != 165
-          self.logo = logo.thumb('x165')  # resize height and maintain aspect ratio
+        if logo.height != 75
+          self.logo = logo.thumb('x75')  # resize height and maintain aspect ratio
         end
       end
     end

--- a/lib/assets/webpack.config.js
+++ b/lib/assets/webpack.config.js
@@ -75,22 +75,6 @@ module.exports = {
     new CopyWebPackPlugin([ // Copies every file under images or videos
       { from: './images/**/*', to: `${destPath}/` },
       { from: './videos/**/*', to: `${destPath}/` },
-      /* START DEPENDENCIES NEEDED FOR ES5 scripts */
-      { from: './node_modules/jquery/dist/jquery.min.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/jquery-ujs/src/rails.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/jquery-ui-dist/jquery-ui.min.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/jquery-accessible-autocomplete-list-aria/jquery-accessible-autocomplete-list-aria.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/placeholder/dist/placeholder.min.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/tablesorter/dist/js/jquery.tablesorter.min.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/tablesorter/dist/js/jquery.tablesorter.widgets.min.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/timeago/jquery.timeago.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/tinymce/tinymce.min.js', to: `${destPath}/javascripts/` },
-      { from: './node_modules/bootstrap-sass/assets/javascripts/bootstrap.min.js', to: `${destPath}/javascripts/` },
-      { from: './javascripts/utils_es5/**/*', to: `${destPath}/` },
-      { from: './javascripts/dmproadmap/**/*', to: `${destPath}/` },
-      { from: './javascripts/views/**/*', to: `${destPath}/` },
-      { from: './javascripts/admin.js', to: `${destPath}/javascripts/` },
-      /* END DEPENDENCIES NEEDED FOR ES5 scripts */
     ]),
     function deleteAssets() { // Deletes ONLY files within the following paths.
       const relativePaths = ['/javascripts', '/stylesheets', '/fonts'];

--- a/lib/tasks/logos.rake
+++ b/lib/tasks/logos.rake
@@ -1,0 +1,12 @@
+namespace :logos do
+  desc "Resize all of the logos based on the settings in `models/org.rb`"
+  task resize_all: :environment do
+    Org.all.each do |org|
+      if org.logo.present?
+        img = org.logo
+        org.logo = img
+        org.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
- decreased dragonfly resize of logos to 75px height
- added rake task `bundle exec rake logos:resize_all` to auto resize all logos to the new 75px
- also removed old ES5 copy statements from webpack config