### PR TITLE
Fix JS bug on create plan page

### DIFF
--- a/lib/assets/javascripts/views/plans/new.js
+++ b/lib/assets/javascripts/views/plans/new.js
@@ -51,7 +51,7 @@ $(() => {
         $('#plan_template_id option').remove();
 
         // Fetch the available templates fbased on the funder and research org selected
-        const jQueryForm = $('form');
+        const jQueryForm = $('form#new_plan');
         const formElements = jQueryForm.serializeArray();
         $.ajax({
           method: getMethod(jQueryForm),


### PR DESCRIPTION
fixes #682
JS on `plans/new.js` did not have a specific enough selector and was picking up a different form.
