### PR TITLE
Fixes issue with node install for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 2.2.2
 before_install: 
-  - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y nodejs
+  - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - && sudo apt-get install -y nodejs
 before_script:
   - cd lib/assets && npm install && npm run bundle -- -p && cd -
   - cp config/database_example.yml config/database.yml


### PR DESCRIPTION
Replace node 6.x with 8.x. All commits started resulting in a 401 error when installing node dependencies.
