### PR TITLE
Bug fix for expand/collapse all links on Plan page

### DIFF
--- a/lib/assets/javascripts/utils/expandCollapseAll.js
+++ b/lib/assets/javascripts/utils/expandCollapseAll.js
@@ -40,7 +40,7 @@ export default () => {
     $.each($(el).children('a[data-toggle-direction]'), (i, a) => {
       $(a).click((event) => {
         event.preventDefault();
-        $(`#${accordion} div.panel-collapse`).collapse(`${$(a).attr('data-toggle-direction')}`);
+        $(`#${accordion}`).children('div.panel-collapse').collapse(`${$(a).attr('data-toggle-direction')}`);
       });
     });
   });


### PR DESCRIPTION
fixes #730 
- updated JS to only go one level deep when expanding/collapsing accordion sections