### PR TITLE
Uncomment guidance selection on Project Details page

### DIFF
--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -142,26 +142,26 @@
         </div>
       </div>
       <%= f.button(_('Submit'), class: "btn btn-default", type: "submit") %>
-    <% end %>
-  </div>
-  <div class="col-md-4">
-    <h2><%= _('Plan Guidance Configuration') %></h2>
-    <p><%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations.') %
-    {application_name: Rails.configuration.branding[:application][:name]} %>
-    </p>
-    <p><%= _('Select up to 6 organisations to see their guidance.') %></p>
-    <!--ul id="priority-guidance-orgs">
-          <%#= render partial: "guidance_choices", 
-                     locals: {choices: @important_ggs, form: f,
-                              current_selections: @selected_guidance_groups} %>
-        </ul>
+    </div>
+    <div class="col-md-4">
+      <h2><%= _('Plan Guidance Configuration') %></h2>
+      <p><%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations.') %
+        {application_name: Rails.configuration.branding[:application][:name]} %>
+      </p>
+      <p><%= _('Select up to 6 organisations to see their guidance.') %></p>
+      <ul id="priority-guidance-orgs">
+        <%= render partial: "guidance_choices", 
+                      locals: {choices: @important_ggs, form: f,
+                               current_selections: @selected_guidance_groups} %>
+      </ul>
 
-        <a href="#" id="show-other-guidance-orgs"><%#= _('See guidance from additional organisations') %></a>
+      <a href="#" id="show-other-guidance-orgs"><%#= _('See guidance from additional organisations') %></a>
 
-        <ul id="other-guidance-orgs" style="display: none;">
-          <%#= render partial: "guidance_choices", 
-                     locals: {choices: @all_ggs_grouped_by_org, form: f, 
-                              current_selections: @selected_guidance_groups} %>
-        </ul-->
-  </div>
+      <ul id="other-guidance-orgs" style="display: none;">
+        <%= render partial: "guidance_choices", 
+                   locals: {choices: @all_ggs_grouped_by_org, form: f, 
+                            current_selections: @selected_guidance_groups} %>
+      </ul>
+    </div>
+  <% end %>
 </div>

--- a/app/views/plans/_guidance_choices.html.erb
+++ b/app/views/plans/_guidance_choices.html.erb
@@ -1,26 +1,29 @@
 <% choices.each do |org, groups| %>
   <% if groups && groups.size == 1 %>
-    <li>
+    <li class="checkbox">
       <%= check_box_tag "guidance_group_ids[]", groups[0].id,
                         current_selections.include?(groups[0].id), class: 'guidance-choice' %>
       <%= form.label org.name, for: groups[0].id, 
               class: 'inline checkbox-label regular-text guidance-group-label' %>
     </li>
   <% elsif groups %>
-    <li>
+    <li class="checkbox">
       <input type="checkbox" disabled>
       <label class="inline checkbox-label regular-text guidance-group-label">
         <%= org.name %>
       </label>
+
+      <ul>
+        <% groups.each do |group| %>
+          <li class="checkbox">
+            <span class="sublist">└─ </span> 
+            <%= check_box_tag "guidance_group_ids[]", group.id,
+                              current_selections.include?(group.id), class: 'guidance-choice' %>
+            <%= form.label group.name, for: group.id, 
+                     class: "left-indent checkbox-label regular-text guidance-group-label" %>
+          </li>
+        <% end %>
+      </ul>
     </li>
-    <% groups.each do |group| %>
-      <li class="under-input">
-        <span>└─ </span> 
-        <%= check_box_tag "guidance_group_ids[]", group.id,
-                          current_selections.include?(group.id), class: 'guidance-choice' %>
-        <%= form.label group.name, for: group.id, 
-                class: "left-indent checkbox-label regular-text guidance-group-label" %>
-      </li>
-    <% end %>
   <% end%>
 <% end %>

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -78,6 +78,12 @@ thead th {
   color: $white;
 }
 
+/* LIST STYLING */
+span.sublist {
+  margin-left: -15px;
+  margin-right: 25px;
+}
+
 /* BUTTONS STYLING */
 
 /*


### PR DESCRIPTION
There was no open ticket for this. It was uncommented a while ago, but is preventing the testing of guidance logic on the plans pages
- Bootstrapped the plan guidance selection partial
- Un-commented it on the project details page

We may want to consider enabling auto-save for this section in the future. right now changes are saved when submitting the form