### PR TITLE
Added Feedback Request to Org Details

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,6 +85,18 @@ class ApplicationController < ActionController::Base
     "#{_('Successfully %{action} your %{object}.') % {object: obj_name, action: action}}"
   end
 
+  # Check whether the string is a valid array of JSON objects
+  def is_json_array_of_objects?(string)
+    if string.present?
+      begin
+        json = JSON.parse(string)
+        return (json.is_a?(Array) && json.all?{ |o| o.is_a?(Hash) })
+      rescue JSON::ParserError
+        return false
+      end
+    end
+  end
+
   private
     # Override rails default render action to look for a branded version of a
     # template instead of using the default one. If no override exists, the 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,6 @@
 class UserMailer < ActionMailer::Base
-	default from: Rails.configuration.branding[:organisation][:email]
-	
+  default from: Rails.configuration.branding[:organisation][:email]
+  
   def welcome_notification(user)
     @user = user
     FastGettext.with_locale FastGettext.default_locale do
@@ -9,33 +9,33 @@ class UserMailer < ActionMailer::Base
     end
   end
   
-	def sharing_notification(role, user)
+  def sharing_notification(role, user)
     @role = role
     @user = user
     FastGettext.with_locale FastGettext.default_locale do
-  		mail(to: @role.user.email, 
+      mail(to: @role.user.email, 
            subject: "#{_('A Data Management Plan in ')} #{Rails.configuration.branding[:application][:name]} #{_(' has been shared with you')}")
     end
-	end
-	
-	def permissions_change_notification(role, current_user)
-		@role = role
+  end
+  
+  def permissions_change_notification(role, current_user)
+    @role = role
                 @current_user = current_user
-		FastGettext.with_locale FastGettext.default_locale do
+    FastGettext.with_locale FastGettext.default_locale do
       mail(to: @role.user.email, 
            subject: "#{_('Changed permissions on a DMP in')} #{Rails.configuration.branding[:application][:name]}")
     end
-	end
-	
-	def project_access_removed_notification(user, plan, current_user)
-		@user = user
-		@plan = plan
+  end
+  
+  def project_access_removed_notification(user, plan, current_user)
+    @user = user
+    @plan = plan
                 @current_user = current_user
     FastGettext.with_locale FastGettext.default_locale do
-  		mail(to: @user.email, 
+      mail(to: @user.email, 
            subject: "#{_('Permissions removed on a DMP in')} #{Rails.configuration.branding[:application][:name]}")
     end
-	end
+  end
 
   def api_token_granted_notification(user)
       @user = user
@@ -43,5 +43,28 @@ class UserMailer < ActionMailer::Base
         mail(to: @user.email, 
              subject: "#{_('API rights in')} #{Rails.configuration.branding[:application][:name]}")
       end
+  end
+  
+  def feedback_notification(user, plan)
+    @user = user
+
+    if user.org.present?
+      @org = org
+      @plan = plan
+      
+      # Use the generic feedback message unless the Org has specified one
+      subject = org.feedback_email_subject ||= EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_SUBJECT
+      
+      # Send an email to all of the org admins as well as the Org's administrator email
+      emails = user.org.users.select{ |usr| usr.can_org_admin? && usr != user }
+      emails << user.org.contact_email if user.org.contact_email.present?
+      
+      emails.each do |email|
+        @email = email
+        FastGettext.with_locale FastGettext.default_locale do
+          mail(to: email, subject: subject)
+        end
+      end
+    end
   end
 end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -7,6 +7,8 @@ class Org < ActiveRecord::Base
   # Sort order: Name ASC
   default_scope { order(name: :asc) }
 
+  # Stores links as an JSON array: [{"link":"http://www.myorg.edu","text":"My Org"},...]
+  serialize :links, JSON
 
   ##
   # Associations
@@ -25,12 +27,13 @@ class Org < ActiveRecord::Base
   ##
   # Possibly needed for active_admin
   #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-	attr_accessible :abbreviation, :banner_text, :logo, :remove_logo,
-                  :logo_file_name, :name, :target_url,
+	attr_accessible :abbreviation, :logo, :remove_logo,
+                  :logo_file_name, :name, :links,
                   :organisation_type_id, :wayfless_entity, :parent_id, :sort_name,
-                  :token_permission_type_ids, :language_id, :contact_email, 
+                  :token_permission_type_ids, :language_id, :contact_email, :contact_name,
                   :language, :org_type, :region, :token_permission_types, 
-                  :guidance_group_ids, :is_other, :region_id, :logo_uid, :logo_name
+                  :guidance_group_ids, :is_other, :region_id, :logo_uid, :logo_name,
+                  :feedback_enabled, :feedback_email_subject, :feedback_email_msg
 
   ##
   # Validators
@@ -40,7 +43,6 @@ class Org < ActiveRecord::Base
   dragonfly_accessor :logo do
     after_assign :resize_image
   end
-  validates_property :height, of: :logo, in: (0..165), message: _("height must be less than 165px")
   validates_property :format, of: :logo, in: ['jpeg', 'png', 'gif','jpg','bmp'], message: _("must be one of the following formats: jpeg, jpg, png, gif, bmp")
   validates_size_of :logo, maximum: 500.kilobytes, message: _("can't be larger than 500KB")
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,11 @@ class User < ActiveRecord::Base
   # Scopes
   default_scope { includes(:org, :perms) }
 
-
+  # Retrieves all of the org_admins for the specified org
+  scope :org_admins, -> (org_id) { 
+    joins(:perms).where("users.org_id = ? AND perms.name IN (?)", org_id,
+      ['grant_permissions', 'modify_templates', 'modify_guidance', 'change_org_details'])
+  }
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW
   #

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -21,15 +21,11 @@
     <div class="collapse navbar-collapse" id="org-navbar-menu">
       <% if user_signed_in? && !current_user.org.nil? %>
           <ul class="nav navbar-nav">
-            <li>
-              <a><%= current_user.org.name %></a>
-            </li>
-            <li>
-              <%= link_to _('RDM Info'), root_path %>
-            </li>
-            <li>
-              <%= link_to _('RDM Policy'), root_path %>
-            </li>
+            <% current_user.org.links.each do |url| %>
+              <% unless url['link'].blank? %>
+                <li><%= link_to (url['text'].blank? ? url['link'] : url['text']), url['link'] %>
+              <% end %>
+            <% end %>
           </ul>
       <% end %>
 

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_for(@org, url: admin_update_org_path(@org), html: { multipart: true, method: :put, id: "edit_org_feedback_form" } ) do |f| %>
+  <h2><%= _('Request Feedback') %></h2>
+  <div class="row">
+    <div class="radio col-xs-8">
+      <%= f.label :feedback_enabled, raw("#{f.radio_button(:feedback_enabled, true)} #{_('On')}") %>
+      <%= f.label :feedback_enabled, raw("#{f.radio_button(:feedback_enabled, false)} #{_('Off')}") %>
+    </div>
+  </div>
+  <div id="feeback-email">
+    <h3><%= _('Request Expert Feedback - Automated Email:') %></h3>
+    <div class="row">
+      <div class="form-group col-xs-8">
+        <%= f.label :feedback_email_subject, _('Subject'), class: "control-label" %>
+        <%= f.text_field :feedback_email_subject, class: "form-control",
+              placeholder: "#{_('A user has requested feedback for their DMP in')} #{Rails.configuration.branding[:application][:name]}" %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="form-group col-xs-8">
+        <%= f.label :feedback_email_msg, _('Message'), class: "control-label" %>
+        <%= f.text_area :feedback_email_msg, class: "form-control" %>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <%= f.button(_('Save'), id:"save_org_submit", class: "btn btn-primary", type: "submit") %>
+      <%= f.button(_('Reset to defaults'), id:"reset-to-default-feedback-email", class: "btn btn-default", type: "button") %>
+      <div id="feedback-email-default-subject" class="hide"><%= EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_SUBJECT %></div>
+      <div id="feedback-email-default-message" class="hide"><%= EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_MESSAGE %></div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/orgs/_org_link.html.erb
+++ b/app/views/orgs/_org_link.html.erb
@@ -1,0 +1,15 @@
+<div class="row org-link">
+  <div class="form-group col-xs-4">
+    <%= label_tag 'org_links_url', _('URL'), class: "control-label" %>
+    <%= text_field_tag 'org_links_url', link, class: "form-control" %>
+  </div>
+  <div class="form-group col-xs-4">
+    <%= label_tag 'org_links_text', _('Link text'), class: "control-label" %>
+    <%= text_field_tag 'org_links_text', text, class: "form-control" %>
+  </div>
+  <div class="form-group col-xs-2">
+    <a href="#" class="remove-org-link" aria-label="<%= _('Remove this link') %>">
+      <i class="fa fa-times-circle fa-reverse" aria-hidden="true"></i>
+    </a> 
+  </div>
+</div>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -1,0 +1,92 @@
+<%= form_for(@org, url: admin_update_org_path(@org), html: { multipart: true, method: :put, id: "edit_org_profile_form" } ) do |f| %>
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <%= f.label :name, _('Organisation full name'), class: "control-label" %>
+      <%= f.text_field :name, id: "org_name", class: "form-control", "aria-required": true %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <%= f.label :abbreviation, _('Organisation abbreviated name'), class: "control-label" %>
+      <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="row">  
+    <div class="form-group col-xs-8">
+      <%= f.label :logo, _('Organization logo'), class: "control-label"  %>
+
+      <% if @org.logo.present? %>
+        <div class="clearfix"></div>
+        <%= image_tag @org.logo.url, alt: "#{@org.name} #{_('logo')}" %>
+        <div class="org-logo-controls checkbox">
+          <%= f.label :remove_logo, raw("#{f.check_box :remove_logo, title: _("This will remove your organisation's logo")} #{_('Remove logo')}") %>
+          <strong> - <%= _('or') %> - </strong>
+          <span class="btn btn-default btn-file"><%= f.file_field :logo %></span>
+        </div>
+      <% else %>
+        <%= f.file_field :logo %>
+      <% end %>
+    </div>
+  </div>
+
+  <div id="org-link-section">
+    <%= f.hidden_field :links %>
+    <div class="row">
+      <div class="form-group col-xs-8">
+        <h3><%= _("Organisation URL") %> <small>(<%= _('Up to ') %><span id="max-nbr-urls"></span>)</small></h3>
+      </div>
+    </div>
+    <% if @org.links.length > 0 %>
+      <% @org.links.each do |url| %>
+        <%= render partial: 'org_link', locals: {link: url['link'], text: url['text']} %>
+      <% end %>
+    <% else %>
+      <%= render partial: 'org_link', locals: {link: '', text: ''} %>
+    <% end %>
+    <div class="row">
+      <div class="form-group col-xs-8">
+        <a href="#" id="add-org-link"><%= _('+ Add an additional URL') %></a>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <h3><%= _("Administrator contact") %></h3>
+    </div>
+  </div>
+  <div class="row">
+    <div class="form-group col-xs-4">
+      <%= f.label :contact_email, _('Contact email'), class: "control-label" %>
+      <%= f.text_field :contact_email, class: "form-control", 'aria-required': true %>
+    </div>
+    <div class="form-group col-xs-4">
+      <%= f.label :contact_name, _('Link text'), class: "control-label" %>
+      <%= f.text_field :contact_name, class: "form-control" %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <%= f.button(_('Save'), id:"save_org_submit", class: "btn btn-primary", type: "submit") %>
+    </div>
+  </div>
+
+  <% if current_user.can_super_admin? %>
+    <div class="bordered col-xs-8" data-toggle="tooltip" title="<%= _('This information can be changed in the Super Admin section.') %>">
+      <h3><%= _('Organisational Configuration Information') %></h3>
+      <dl>
+        <% shibboleth = @org.org_identifiers.select{ |ids| ids.identifier_scheme == IdentifierScheme.find_by(name: 'shibboleth')} %>
+        <% if Rails.application.config.shibboleth_use_filtered_discovery_service && shibboleth.size > 0 %>
+          <dt><%= _('Entity ID') %></dt>
+          <dd><%= shibboleth.first.identifier %></dd>
+          <dt><%= _('Sibboleth domain') %></dt>
+          <dd><%= JSON.parse(shibboleth.first.attrs)['domain'] if shibboleth.first.attrs.present? %></dd>
+        <% end %>
+        <dt><%= _('Organisation type') %></dt>
+        <dd><%= @org.type %></dd>
+      </dl>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/orgs/admin_edit.html.erb
+++ b/app/views/orgs/admin_edit.html.erb
@@ -6,62 +6,28 @@
 
 <div class="row">
   <div class="col-md-12">
-  <%= form_for(@org, url: admin_update_org_path(@org), html: { multipart: true, method: :put, id: "edit_org_details_form" } ) do |f| %>
-    
-    <div class="form-group col-xs-8">
-      <%= f.label :name, 'Organization Name', class: "control-label" %>
-      <%= f.text_field :name, id: "org_name", class: "form-control", "aria-required": true %>
-    </div>
-
-    <div class="form-group col-xs-8">
-      <%= f.label :abbreviation, 'Abbreviated Name', class: "control-label" %>
-      <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control", "aria-required": true %>
-    </div>
-
-    <div class="form-group col-xs-8" id="banner-text">
-      <%= f.label _('Top banner text'), for: @org.banner_text, class: "control-label" %>
-      <%= text_area_tag('org_banner_text', @org.banner_text, id: "org_banner_text", class: "form-control", rows: "3") %>
-    </div>
-
-    <% if @org.logo.present? %>
-      <div class="form-group col-xs-8">
-        <%= f.label :logo, 'Organization Logo', class: "control-label" %>
+    <ul class="nav nav-tabs" role="tablist">
+      <li role="profile" class="active">
+        <a href="#profile" role="tab" aria-controls="profile" data-toggle="tab"><%= _('Profile information') %></a>
+      </li>
+      <li role="feedback">
+        <a href="#feedback" role="tab" aria-controls="feedback" data-toggle="tab"><%= _('Request feedback') %></a>
+      </li>
+    </ul>
+  
+    <div class="tab-content">
+      <div id="profile" role="tabpanel" class="tab-pane active px-2">
+        <%= render partial: 'profile_form' %>
       </div>
-      <div class="form-group col-xs-8">
-          <%= image_tag @org.logo.url, alt: "#{@org.name} #{_('logo')}" %>
-      </div>
-      <div class="form-group col-xs-8">
-        <%= f.check_box :remove_logo, title: _("This will remove your organisation's logo") %>
-        <%= f.label _('Remove logo') % {application_name: Rails.configuration.branding[:application][:name]}, for: :remove_logo, class: "control-label" %>
-      </div>
-      <div class="form-group col-xs-8">
-        <strong> - <%= _('or') %> - </strong>
-      </div>
-      <div class="form-group col-xs-8">
-        <%= f.file_field :logo %>
-      </div>
-    <% else %>
-      <div class="form-group col-xs-8">
-        <%= f.label :logo, 'Organization Logo', class: "control-label"  %>
-        <%= f.file_field :logo %>
-      </div>
-    <% end %>
 
-    <div class="form-group col-xs-8">
-      <%= f.label :target_url, 'Organization URL', class: "control-label" %>
-      <%= f.text_field :target_url, class: "form-control" %>
-    </div>
+      <div id="feedback" role="tabpanel" class="tab-pane">
+        <%= render partial: 'feedback_form' %>
+      </div>
 
-    <div class="form-group col-xs-8">
-      <%= f.label :contact_email, 'Contact Email', class: "control-label" %>
-      <%= f.text_field :contact_email, class: "form-control" %>
+      <div id="notification-preferences" role="tabpanel" class="tab-pane">
+        <%= render partial: 'users/notification_preferences' %>
+      </div>
     </div>
-    
-    <div class="form-group col-xs-8">
-      <%= f.button(_('Save'), id:"save_org_submit", class: "btn btn-primary", type: "submit") %>
-    </div>
-
-  <% end %>
   </div>
 </div>
 

--- a/app/views/user_mailer/feedback_notification.html.erb
+++ b/app/views/user_mailer/feedback_notification.html.erb
@@ -1,0 +1,6 @@
+<% FastGettext.with_locale FastGettext.default_locale do %>
+<% if @org.feedback_email_msg.present? %>
+  <%= raw @org.feedback_email_msg %>
+<% else %>
+  <%= raw EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_MESSAGE %>
+<% end %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -2,3 +2,10 @@ LANGUAGES = (ActiveRecord::Base.connection.table_exists? 'languages') ? Language
 MANY_LANGUAGES = LANGUAGES.length > 1
 TABLE_FILTER_MIN_ROWS = 10
 
+# Default Feedback Request Email sent to the requesting user
+# This email can be overriden by local Org Admins on the Org Details page
+# TODO: Move this to a location that gets loaded AFTER FastGettext so that we can  use fastgettext to manage localisations
+EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_SUBJECT = 'Your DMP has been submitted for feedback in %{application_name}'
+EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_MESSAGE = '<p>Hello [user_name],</p>'\
+  '<p>Your DMP "[plan_name]" has been submitted for feedback from an administrator at your institution.  If you have questions pertaining to this action, please contact your local administrator at [organisation_email].</p>'\
+  '<p>All the best,<br />The %{application_name} team.</p>'

--- a/db/migrate/20171024214257_add_links_to_orgs.rb
+++ b/db/migrate/20171024214257_add_links_to_orgs.rb
@@ -1,0 +1,5 @@
+class AddLinksToOrgs < ActiveRecord::Migration
+  def change
+    add_column :orgs, :links, :string, default: '[]'
+  end
+end

--- a/db/migrate/20171024220146_add_contact_name_to_orgs.rb
+++ b/db/migrate/20171024220146_add_contact_name_to_orgs.rb
@@ -1,0 +1,5 @@
+class AddContactNameToOrgs < ActiveRecord::Migration
+  def change
+    add_column :orgs, :contact_name, :string
+  end
+end

--- a/db/migrate/20171025200301_add_feedback_fields_to_orgs.rb
+++ b/db/migrate/20171025200301_add_feedback_fields_to_orgs.rb
@@ -1,0 +1,7 @@
+class AddFeedbackFieldsToOrgs < ActiveRecord::Migration
+  def change
+    add_column :orgs, :feedback_enabled, :boolean, default: false
+    add_column :orgs, :feedback_email_subject, :string
+    add_column :orgs, :feedback_email_msg, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171013152425) do
+ActiveRecord::Schema.define(version: 20171025200301) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "question_id", limit: 4
@@ -167,23 +167,28 @@ ActiveRecord::Schema.define(version: 20171013152425) do
   add_index "org_token_permissions", ["token_permission_type_id"], name: "fk_rails_2aa265f538", using: :btree
 
   create_table "orgs", force: :cascade do |t|
-    t.string   "name",            limit: 255
-    t.string   "abbreviation",    limit: 255
-    t.string   "target_url",      limit: 255
-    t.string   "wayfless_entity", limit: 255
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
-    t.integer  "parent_id",       limit: 4
+    t.string   "name",                   limit: 255
+    t.string   "abbreviation",           limit: 255
+    t.string   "target_url",             limit: 255
+    t.string   "wayfless_entity",        limit: 255
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
+    t.integer  "parent_id",              limit: 4
     t.boolean  "is_other"
-    t.string   "sort_name",       limit: 255
-    t.text     "banner_text",     limit: 65535
-    t.string   "logo_file_name",  limit: 255
-    t.integer  "region_id",       limit: 4
-    t.integer  "language_id",     limit: 4
-    t.string   "logo_uid",        limit: 255
-    t.string   "logo_name",       limit: 255
-    t.string   "contact_email",   limit: 255
-    t.integer  "org_type",        limit: 4,     default: 0, null: false
+    t.string   "sort_name",              limit: 255
+    t.text     "banner_text",            limit: 65535
+    t.string   "logo_file_name",         limit: 255
+    t.integer  "region_id",              limit: 4
+    t.integer  "language_id",            limit: 4
+    t.string   "logo_uid",               limit: 255
+    t.string   "logo_name",              limit: 255
+    t.string   "contact_email",          limit: 255
+    t.integer  "org_type",               limit: 4,     default: 0,     null: false
+    t.string   "links",                                default: "[]"
+    t.string   "contact_name"
+    t.boolean  "feedback_enabled",                     default: false
+    t.string   "feedback_email_subject"
+    t.text     "feedback_email_msg"
   end
 
   add_index "orgs", ["language_id"], name: "fk_rails_5640112cab", using: :btree

--- a/lib/assets/javascripts/constants.js
+++ b/lib/assets/javascripts/constants.js
@@ -1,6 +1,10 @@
 export const PASSWORD_MIN_LENGTH = 8;
 export const PASSWORD_MAX_LENGTH = 128;
 
+// Maximum number of URLs allowed on the Org details page. These links appear at the
+// top of the screen in the lower navigation row next to the Org Logo
+export const MAX_NUMBER_ORG_URLS = 3;
+
 export const VALIDATION_MESSAGE_DEFAULT = 'Please enter a valid value.';
 export const VALIDATION_MESSAGE_EMAIL = 'You must enter a valid email address.';
 export const VALIDATION_MESSAGE_NUMBER = 'Please enter a valid number.';
@@ -14,7 +18,6 @@ export const VALIDATION_MESSAGE_TEXT = 'This field is required.';
 export const SHOW_PASSWORD_MESSAGE = 'Show password';
 export const SHOW_SELECT_ORG_MESSAGE = 'Select an organisation from the list.';
 export const SHOW_OTHER_ORG_MESSAGE = 'My organisation isn\'t listed';
-export const SHOW_ORG_BANNER_MESSAGE = 'Please only enter up to 165 characters. If you are entering an URL try to use something like http://tinyurl.com/ to make it smaller.';
 
 export const PLAN_VISIBILITY_WHEN_TEST = 'N/A';
 export const PLAN_VISIBILITY_WHEN_NOT_TEST = 'Private';

--- a/lib/assets/javascripts/utils/tabHelper.js
+++ b/lib/assets/javascripts/utils/tabHelper.js
@@ -10,5 +10,6 @@ $(() => {
   $('.nav-tabs').click((e) => {
     $(e.target).tab('show');
     window.location.hash = $(e.target).attr('href');
+    window.scrollTo(0, 0);
   });
 });

--- a/lib/assets/javascripts/views/orgs/admin_edit.js
+++ b/lib/assets/javascripts/views/orgs/admin_edit.js
@@ -1,29 +1,82 @@
-// Import TinyMCE
-import tinymce from 'tinymce/tinymce';
-import { Tinymce } from '../../utils/tinymce';
+// TODO: we need to be able to swap in the appropriate locale here
+import 'number-to-text/converters/en-us';
+import { convertToText } from 'number-to-text/index';
 import ariatiseForm from '../../utils/ariatiseForm';
-import { SHOW_ORG_BANNER_MESSAGE } from '../../constants';
+import { Tinymce } from '../../utils/tinymce';
+import { MAX_NUMBER_ORG_URLS } from '../../constants';
 
 $(() => {
   ariatiseForm({ selector: '#edit_org_details_form' });
 
-  // Returns text statistics for the specified editor by id
-  const getStats = (id) => {
-    const body = tinymce.get(id).getBody();
-    const text = tinymce.trim(body.innerText || body.textContent);
-    return {
-      chars: text.length,
-    };
+  // We only allow up to 3 URLs
+  const toggleAddUrlLink = () => {
+    if ($('#org-link-section').find('div.org-link').length >= MAX_NUMBER_ORG_URLS) {
+      $('a#add-org-link').hide();
+    } else {
+      $('a#add-org-link').show();
+    }
   };
 
-  // Validate banner_text area for less than 165 character
-  $('#edit_org_details_form').on('submit', (e) => {
-    if (getStats('org_banner_text').chars > 165) {
-      $('#org_banner_text').text(SHOW_ORG_BANNER_MESSAGE);
-      e.preventDefault();
-    }
-  });
-  /* Initialises an editor for textarea defined above with id org_banner_text */
-  Tinymce.init({ selector: '#org_banner_text' });
-});
+  // Remove a URL
+  const removeUrl = (e) => {
+    $(e.target).closest('.row').remove();
+    toggleAddUrlLink();
+  };
 
+  const toggleFeedback = () => {
+    if ($('#org_feedback_enabled_true').is(':checked')) {
+      $('#feeback-email input, #feeback-email textarea').removeAttr('disabled');
+    } else {
+      $('#feeback-email input, #feeback-email textarea').attr('disabled', true);
+    }
+  };
+
+  // Add a URL
+  $('a#add-org-link').click(() => {
+    const link = $('#org-link-section').find('div.org-link').last();
+    const clone = $(link).clone();
+    clone.find('input').val('');
+    $(clone).find('.remove-org-link').click((e) => {
+      removeUrl(e);
+    });
+    link.after(clone);
+    toggleAddUrlLink();
+  });
+
+  $('.remove-org-link').click((e) => {
+    removeUrl(e);
+  });
+
+  $('#edit_org_feedback_form input[type="radio"]').click(() => {
+    toggleFeedback();
+  });
+
+  // Serialize URLs to JSON for form submission
+  $('#edit_org_profile_form').submit(() => {
+    const json = Array.from($('#org-link-section div.org-link')).map((el) => {
+      const link = $(el).find('#org_links_url');
+      const text = $(el).find('#org_links_text');
+      return {
+        link: (link.length > 0 ? $(link).val() : ''),
+        text: (text.length > 0 ? $(text).val() : ''),
+      };
+    });
+    $('#org_links').val(JSON.stringify(json));
+  });
+
+  // Initialises tinymce for any target element with class tinymce_answer
+  Tinymce.init({ selector: '#org_feedback_email_msg' });
+
+  $('#reset-to-default-feedback-email').click((e) => {
+    e.preventDefault();
+    $('#org_feedback_email_subject').val($('#feedback-email-default-subject').html());
+    const editor = Tinymce.findEditorById('org_feedback_email_msg');
+    editor.setContent($('#feedback-email-default-message').text());
+  });
+
+  // Convert the max number of URLs constant to text and display for user
+  $('#max-nbr-urls').text(convertToText(MAX_NUMBER_ORG_URLS).toLowerCase());
+
+  toggleAddUrlLink();
+  toggleFeedback();
+});

--- a/lib/assets/package-lock.json
+++ b/lib/assets/package-lock.json
@@ -5773,6 +5773,11 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "number-to-text": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/number-to-text/-/number-to-text-0.3.2.tgz",
+      "integrity": "sha1-WSericZm81uzpW7FaS3N6B6TOh8="
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -7841,13 +7846,13 @@
       "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
       "dev": true
     },
-    "timeago": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/timeago/-/timeago-1.6.1.tgz",
-      "integrity": "sha512-mvXlF+JKeclH6AxvBDcwLvDFJyfpjC9Qs3zs6O97u4WBoHYlnnx/QyE7h5INRkGnT53rS8BGUTRhIr661VqTZA==",
-       "requires": {
-        "jquery": "3.2.1"
-       }
+    "timeago.js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-3.0.2.tgz",
+      "integrity": "sha1-MqZ+fA2IfqQspYjTquJvd95edsw=",
+      "requires": {
+        "@types/jquery": "2.0.48"
+      }
     },
     "timers-browserify": {
       "version": "2.0.4",

--- a/lib/assets/package.json
+++ b/lib/assets/package.json
@@ -25,6 +25,7 @@
     "jquery-ui-dist": "1.12.1",
     "jquery-ujs": "1.2.2",
     "js-cookie": "2.1.4",
+    "number-to-text": "^0.3.2",
     "placeholder": "1.0.2",
     "tablesorter": "2.28.15",
     "timeago.js": "^3.0.2",

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -21,6 +21,11 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* ADD a BORDER */
+.bordered {
+  border: 1px solid $grey;
+  padding: 5px 20px 15px 20px;
+}
 
 /* TABLE STYLING */
 
@@ -43,6 +48,7 @@ thead th {
   color: $white;
   border: none;
   margin-right:2px;
+	margin-bottom: 10px;
 }
 .nav-tabs > li > a{
   border-radius: 2px;
@@ -64,13 +70,12 @@ thead th {
 }
 
 /* PANEL STYLING */
-
 .panel-default > .panel-heading {
   background-color: $grey;
   color: $white;
 }
 
- .panel-title a {
+.panel-title a {
   display: block;
   padding: 8px 15px;
   margin: -10px -15px;
@@ -84,6 +89,19 @@ span.sublist {
   margin-right: 25px;
 }
 
+/* FONTAWESOME STYLING */
+.fa {
+  font-size: 2rem;
+}
+.fa-reverse {
+  color: $grey;
+}
+
+/* RADIO BUTTONS */
+.radio label {
+  margin-right: 15px;
+}
+
 /* BUTTONS STYLING */
 
 /*
@@ -92,34 +110,36 @@ $cancel-button-color: #F17D04;
 */
 
 /* primary button */
-  .btn-primary,
-  .btn-primary:hover,
-  .btn-primary:focus,
-  .btn-primary:active,
-  .btn-primary:visited,
-  .btn-primary:active:hover, 
-  .btn-primary.active:hover { 
-    background-color: $grey;
-    color: $white;
-    border-color: $grey;
-    outline: none;
-    margin-top: 5px;
-  }
+.btn-primary,
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active,
+.btn-primary:visited,
+.btn-primary:active:hover, 
+.btn-primary.active:hover { 
+  background-color: $grey;
+  color: $white;
+  border-color: $grey;
+  outline: none;
+  margin-top: 5px;
+  margin-bottom: 10px;
+}
 
 /* primary button */
-  .btn-default,
-  .btn-default:hover,
-  .btn-default:focus,
-  .btn-default:active,
-  .btn-default:visited,
-  .btn-default:active:hover, 
-  .btn-default.active:hover { 
-    background-color: $grey;
-    color: $white;
-    border-color: $grey;
-    outline: none;
-    margin-top: 5px;
-  }
+.btn-default,
+.btn-default:hover,
+.btn-default:focus,
+.btn-default:active,
+.btn-default:visited,
+.btn-default:active:hover, 
+.btn-default.active:hover { 
+  background-color: $grey;
+  color: $white;
+  border-color: $grey;
+  outline: none;
+  margin-top: 5px;
+  margin-bottom: 10px;
+}
 
 /* MESSAGES */
 $error-color: $red;
@@ -285,3 +305,17 @@ $header-background: linear-gradient(#ED6406, #F59503);
 .js-combobox[type=text]::-ms-clear { display: none; width: 0; height: 0; }
 .js-combobox[type=text]::-ms-reveal { display: none; width: 0; height: 0; }
 
+
+/* PAGE SPECIFIC SETTINGS */
+/* ---------------------------------------------*/
+/* Org details page */
+.remove-org-link i {
+  margin-left: -15px;
+  margin-top: 30px;
+}
+.org-logo-controls {
+  display: inline-block;
+  margin-left: 15px;
+  input { display: inline-block; }
+  strong { margin: 0 10px; }
+}

--- a/test/functional/orgs_controller_test.rb
+++ b/test/functional/orgs_controller_test.rb
@@ -57,14 +57,13 @@ class OrgsControllerTest < ActionDispatch::IntegrationTest
     
     put admin_update_org_path(@org), {org: params}
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('saved')
-    assert_response :success
-    assert assigns(:org)
+    assert_response :redirect
     assert_equal 'Testing UPDATE', @org.reload.name, "expected the record to have been updated"
     
     # Invalid object
     put admin_update_org_path(@org), {org: {contact_email: 'abcdefg'}}
     assert flash[:alert].starts_with?(_('Could not update your'))
-    assert_response :success
+    assert_response :redirect
     assert assigns(:org)
   end
 end


### PR DESCRIPTION
issue #726
- Added contact_name, links, feedback_enabled, feedback_email_subject and feedback_email_msg columns to the orgs table
- Added rake task to convert old orgs.target_url to the links JSON column
- Updated look of org details to match wireframe
  - Separated page into tabs
  - Moved Logo up above URLs and Admin contact
  - Added ability for admin to specify up to 3 URLs
- Updated branding header to display the URLs provided by Admins

You will need to run the following when deploying this one:
- rake db:migrate
- rake migrate:org_target_url_to_links

Open question still on the ticket for the exact text of the email and whether or not the email has a default. Added note to #727 to revisit the user_mailer content later.