### PR TITLE
Removed need to enter password on profile page except for email

### DIFF
--- a/app/views/devise/registrations/_password_confirmation.html.erb
+++ b/app/views/devise/registrations/_password_confirmation.html.erb
@@ -1,0 +1,23 @@
+<div class="modal fade" id="password-confirmation" tabindex="-1" role="dialog" aria-labelledby="modal-title">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Please confirm your password</h4>
+      </div>
+      <div id="confirmation" class="modal-body">
+        <p><%= _('Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change.') %></p>
+        <div class="form-group">
+          <%= f.label :current_password, _('Password'), class: 'control-label' %>
+          <%= f.password_field :current_password, class: 'form-control' %>
+          <%= f.password_field :password, class: 'hide' %>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" id="cancel-confirmation" 
+                data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" 
+                data-dismiss="modal">Continue</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -10,7 +10,8 @@
 
   <div class="form-group col-xs-8">
     <%= f.label(:email, _('Email'), class: 'control-label') %>
-    <%= f.email_field(:email, class: "form-control", "aria-required": true, 'data-toggle': "tooltip", title: _('Please enter your current password below when changing your email address.'), value: @user.email) %>
+    <%= f.email_field(:email, class: "form-control", "aria-required": true, value: @user.email) %>
+    <%= hidden_field_tag :original_email, @user.email %>
   </div>
 
   <div class="form-group col-xs-8">
@@ -21,11 +22,6 @@
   <div class="form-group col-xs-8">
     <%= f.label(:surname, _('Last name'), class: 'control-label') %>
     <%= f.text_field(:surname, class: "form-control", "aria-required": true, value: @user.surname) %>
-  </div>
-
-  <div class="form-group col-xs-8">
-    <%= f.label(:password, _('Password'), class: 'control-label') %>
-    <%= f.password_field(:password, class: "form-control", "aria-required": true) %>
   </div>
 
   <% org_admin = (current_user.can_org_admin? && !current_user.can_super_admin?) %>
@@ -78,6 +74,7 @@
   <div class="form-group col-xs-8">
     <%= f.button(_('Save'), class: 'btn btn-default', type: "submit") %>
   </div>
+
+  <%= render partial: 'password_confirmation', locals: {f: f} %>
+
 <% end %>
-
-

--- a/lib/assets/javascripts/views/devise/registrations/edit.js
+++ b/lib/assets/javascripts/views/devise/registrations/edit.js
@@ -1,5 +1,7 @@
 import ariatiseForm from '../../../utils/ariatiseForm';
 import { DISABLE_ORG_COMBO_MESSAGE } from '../../../constants';
+import { isObject, isString } from '../../../utils/isType';
+import { isValidPassword } from '../../../utils/isValidInputType';
 import { addMatchingPasswordValidator, togglisePasswords } from '../../../utils/passwordHelper';
 
 $(() => {
@@ -17,4 +19,29 @@ $(() => {
     $('#org-controls .combobox-clear-button').hide();
     $('#other_org_toggle a').hide();
   }
+
+  // If the user has changed their email address display the password
+  // confirmation modal on form submission
+  $('#personal_details_registration_form [type="submit"]').click((e) => {
+    const newEmail = $('#personal_details_registration_form #user_email');
+    if (isObject($('#original_email')) && isObject($(newEmail))) {
+      const original = $('#original_email').val();
+      const email = $(newEmail).val();
+      const pwd = $('#password-confirmation #user_current_password').val();
+
+      // If the user changed the email and has not confirmed their password
+      if (isString(original) && isString(email)) {
+        if ((original.toLowerCase() !== email.toLowerCase()) && !isValidPassword(pwd)) {
+          e.preventDefault();
+          $('#password-confirmation').modal('show');
+        }
+      }
+    }
+  });
+
+  // Devise seems to require both the password and current_password so sync them
+  // when the user enters their password in the modal
+  $('#password-confirmation #user_current_password').change((e) => {
+    $('#password-confirmation #user_password').val($(e.target).val());
+  });
 });


### PR DESCRIPTION
Issue #533 
- User now only has to enter password when changing their email address
- When user changes their email a modal window opens asking them to enter their password to confirm the change (similar to @jollopre suggestion on the ticket)
