### PR TITLE
removed the default setting from plans.visibility

### DIFF
--- a/db/migrate/20171102164156_change_plan_visibility_default.rb
+++ b/db/migrate/20171102164156_change_plan_visibility_default.rb
@@ -1,0 +1,5 @@
+class ChangePlanVisibilityDefault < ActiveRecord::Migration
+  def change
+    change_column_default :plans, :visibility, nil  # default is application configurable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171025200301) do
+ActiveRecord::Schema.define(version: 20171102164156) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "question_id", limit: 4
@@ -22,9 +22,9 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.datetime "updated_at"
   end
 
-  add_index "annotations", ["org_id"], name: "fk_rails_aca7521f72", using: :btree
-  add_index "annotations", ["question_id"], name: "fk_rails_0e08e753b6", using: :btree
-  add_index "annotations", ["question_id"], name: "index_annotations_on_question_id", using: :btree
+  add_index "annotations", ["org_id"], name: "fk_rails_aca7521f72"
+  add_index "annotations", ["question_id"], name: "fk_rails_0e08e753b6"
+  add_index "annotations", ["question_id"], name: "index_annotations_on_question_id"
 
   create_table "answers", force: :cascade do |t|
     t.text     "text",         limit: 65535
@@ -36,16 +36,16 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.integer  "lock_version", limit: 4,     default: 0
   end
 
-  add_index "answers", ["plan_id"], name: "fk_rails_84a6005a3e", using: :btree
-  add_index "answers", ["question_id"], name: "fk_rails_3d5ed4418f", using: :btree
-  add_index "answers", ["user_id"], name: "fk_rails_584be190c2", using: :btree
+  add_index "answers", ["plan_id"], name: "fk_rails_84a6005a3e"
+  add_index "answers", ["question_id"], name: "fk_rails_3d5ed4418f"
+  add_index "answers", ["user_id"], name: "fk_rails_584be190c2"
 
   create_table "answers_question_options", id: false, force: :cascade do |t|
     t.integer "answer_id",          limit: 4, null: false
     t.integer "question_option_id", limit: 4, null: false
   end
 
-  add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id", using: :btree
+  add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id"
 
   create_table "exported_plans", force: :cascade do |t|
     t.integer  "plan_id",    limit: 4
@@ -84,9 +84,9 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.datetime "created_at"
   end
 
-  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", unique: true, using: :btree
-  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
-  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
+  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", unique: true
+  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
 
   create_table "guidance_groups", force: :cascade do |t|
     t.string   "name",            limit: 255
@@ -97,8 +97,8 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.boolean  "published"
   end
 
-  add_index "guidance_groups", ["org_id"], name: "fk_rails_819c1dbbc7", using: :btree
-  add_index "guidance_groups", ["org_id"], name: "index_guidance_groups_on_org_id", using: :btree
+  add_index "guidance_groups", ["org_id"], name: "fk_rails_819c1dbbc7"
+  add_index "guidance_groups", ["org_id"], name: "index_guidance_groups_on_org_id"
 
   create_table "guidances", force: :cascade do |t|
     t.text     "text",              limit: 65535
@@ -109,8 +109,8 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.boolean  "published"
   end
 
-  add_index "guidances", ["guidance_group_id"], name: "fk_rails_20d29da787", using: :btree
-  add_index "guidances", ["guidance_group_id"], name: "index_guidances_on_guidance_group_id", using: :btree
+  add_index "guidances", ["guidance_group_id"], name: "fk_rails_20d29da787"
+  add_index "guidances", ["guidance_group_id"], name: "index_guidances_on_guidance_group_id"
 
   create_table "identifier_schemes", force: :cascade do |t|
     t.string   "name",             limit: 255
@@ -139,9 +139,9 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.datetime "updated_at"
   end
 
-  add_index "notes", ["answer_id"], name: "fk_rails_907f8d48bf", using: :btree
-  add_index "notes", ["answer_id"], name: "index_notes_on_answer_id", using: :btree
-  add_index "notes", ["user_id"], name: "fk_rails_7f2323ad43", using: :btree
+  add_index "notes", ["answer_id"], name: "fk_rails_907f8d48bf"
+  add_index "notes", ["answer_id"], name: "index_notes_on_answer_id"
+  add_index "notes", ["user_id"], name: "fk_rails_7f2323ad43"
 
   create_table "org_identifiers", force: :cascade do |t|
     t.string   "identifier",           limit: 255
@@ -152,8 +152,8 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.integer  "identifier_scheme_id", limit: 4
   end
 
-  add_index "org_identifiers", ["identifier_scheme_id"], name: "fk_rails_189ad2e573", using: :btree
-  add_index "org_identifiers", ["org_id"], name: "fk_rails_36323c0674", using: :btree
+  add_index "org_identifiers", ["identifier_scheme_id"], name: "fk_rails_189ad2e573"
+  add_index "org_identifiers", ["org_id"], name: "fk_rails_36323c0674"
 
   create_table "org_token_permissions", force: :cascade do |t|
     t.integer  "org_id",                   limit: 4
@@ -162,9 +162,9 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.datetime "updated_at"
   end
 
-  add_index "org_token_permissions", ["org_id"], name: "fk_rails_e1db1b22c5", using: :btree
-  add_index "org_token_permissions", ["org_id"], name: "index_org_token_permissions_on_org_id", using: :btree
-  add_index "org_token_permissions", ["token_permission_type_id"], name: "fk_rails_2aa265f538", using: :btree
+  add_index "org_token_permissions", ["org_id"], name: "fk_rails_e1db1b22c5"
+  add_index "org_token_permissions", ["org_id"], name: "index_org_token_permissions_on_org_id"
+  add_index "org_token_permissions", ["token_permission_type_id"], name: "fk_rails_2aa265f538"
 
   create_table "orgs", force: :cascade do |t|
     t.string   "name",                   limit: 255
@@ -191,8 +191,8 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.text     "feedback_email_msg"
   end
 
-  add_index "orgs", ["language_id"], name: "fk_rails_5640112cab", using: :btree
-  add_index "orgs", ["region_id"], name: "fk_rails_5a6adf6bab", using: :btree
+  add_index "orgs", ["language_id"], name: "fk_rails_5640112cab"
+  add_index "orgs", ["region_id"], name: "fk_rails_5a6adf6bab"
 
   create_table "perms", force: :cascade do |t|
     t.string   "name",       limit: 255
@@ -200,8 +200,8 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.datetime "updated_at",             null: false
   end
 
-  add_index "perms", ["name"], name: "index_perms_on_name", using: :btree
-  add_index "perms", ["name"], name: "index_roles_on_name_and_resource_type_and_resource_id", using: :btree
+  add_index "perms", ["name"], name: "index_perms_on_name"
+  add_index "perms", ["name"], name: "index_roles_on_name_and_resource_type_and_resource_id"
 
   create_table "phases", force: :cascade do |t|
     t.string   "title",       limit: 255
@@ -214,7 +214,7 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.boolean  "modifiable"
   end
 
-  add_index "phases", ["template_id"], name: "index_phases_on_template_id", using: :btree
+  add_index "phases", ["template_id"], name: "index_phases_on_template_id"
 
   create_table "plans", force: :cascade do |t|
     t.string   "title",                             limit: 255
@@ -229,22 +229,22 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.string   "principal_investigator_identifier", limit: 255
     t.string   "data_contact",                      limit: 255
     t.string   "funder_name",                       limit: 255
-    t.integer  "visibility",                        limit: 4,     default: 0, null: false
+    t.integer  "visibility",                        limit: 4,     null: false
     t.string   "data_contact_email",                limit: 255
     t.string   "data_contact_phone",                limit: 255
     t.string   "principal_investigator_email",      limit: 255
     t.string   "principal_investigator_phone"
   end
 
-  add_index "plans", ["template_id"], name: "index_plans_on_template_id", using: :btree
+  add_index "plans", ["template_id"], name: "index_plans_on_template_id"
 
   create_table "plans_guidance_groups", force: :cascade do |t|
     t.integer "guidance_group_id", limit: 4
     t.integer "plan_id",           limit: 4
   end
 
-  add_index "plans_guidance_groups", ["guidance_group_id"], name: "fk_rails_ec1c5524d7", using: :btree
-  add_index "plans_guidance_groups", ["plan_id"], name: "fk_rails_13d0671430", using: :btree
+  add_index "plans_guidance_groups", ["guidance_group_id"], name: "fk_rails_ec1c5524d7"
+  add_index "plans_guidance_groups", ["plan_id"], name: "fk_rails_13d0671430"
 
   create_table "prefs", force: :cascade do |t|
     t.string  "settings", limit: 255
@@ -269,8 +269,8 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.datetime "updated_at"
   end
 
-  add_index "question_options", ["question_id"], name: "fk_rails_b9c5f61cf9", using: :btree
-  add_index "question_options", ["question_id"], name: "index_question_options_on_question_id", using: :btree
+  add_index "question_options", ["question_id"], name: "fk_rails_b9c5f61cf9"
+  add_index "question_options", ["question_id"], name: "index_question_options_on_question_id"
 
   create_table "questions", force: :cascade do |t|
     t.text     "text",                   limit: 65535
@@ -284,15 +284,15 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.boolean  "modifiable"
   end
 
-  add_index "questions", ["question_format_id"], name: "fk_rails_4fbc38c8c7", using: :btree
-  add_index "questions", ["section_id"], name: "index_questions_on_section_id", using: :btree
+  add_index "questions", ["question_format_id"], name: "fk_rails_4fbc38c8c7"
+  add_index "questions", ["section_id"], name: "index_questions_on_section_id"
 
   create_table "questions_themes", id: false, force: :cascade do |t|
     t.integer "question_id", limit: 4, null: false
     t.integer "theme_id",    limit: 4, null: false
   end
 
-  add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id", using: :btree
+  add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id"
 
   create_table "regions", force: :cascade do |t|
     t.string  "abbreviation",    limit: 255
@@ -310,10 +310,10 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.boolean  "active",               default: true
   end
 
-  add_index "roles", ["plan_id"], name: "fk_rails_a1ce6c2772", using: :btree
-  add_index "roles", ["plan_id"], name: "index_roles_on_plan_id", using: :btree
-  add_index "roles", ["user_id"], name: "fk_rails_ab35d699f0", using: :btree
-  add_index "roles", ["user_id"], name: "index_roles_on_user_id", using: :btree
+  add_index "roles", ["plan_id"], name: "fk_rails_a1ce6c2772"
+  add_index "roles", ["plan_id"], name: "index_roles_on_plan_id"
+  add_index "roles", ["user_id"], name: "fk_rails_ab35d699f0"
+  add_index "roles", ["user_id"], name: "index_roles_on_user_id"
 
   create_table "sections", force: :cascade do |t|
     t.string   "title",       limit: 255
@@ -326,7 +326,7 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.boolean  "modifiable"
   end
 
-  add_index "sections", ["phase_id"], name: "index_sections_on_phase_id", using: :btree
+  add_index "sections", ["phase_id"], name: "index_sections_on_phase_id"
 
   create_table "settings", force: :cascade do |t|
     t.string   "var",         limit: 255,   null: false
@@ -337,7 +337,7 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.datetime "updated_at",                null: false
   end
 
-  add_index "settings", ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true, using: :btree
+  add_index "settings", ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true
 
   create_table "splash_logs", force: :cascade do |t|
     t.string   "destination", limit: 255
@@ -362,8 +362,8 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.boolean  "dirty",                          default: false
   end
 
-  add_index "templates", ["org_id", "dmptemplate_id"], name: "template_organisation_dmptemplate_index", using: :btree
-  add_index "templates", ["org_id"], name: "index_templates_on_org_id", using: :btree
+  add_index "templates", ["org_id", "dmptemplate_id"], name: "template_organisation_dmptemplate_index"
+  add_index "templates", ["org_id"], name: "index_templates_on_org_id"
 
   create_table "themes", force: :cascade do |t|
     t.string   "title",       limit: 255
@@ -378,10 +378,10 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.integer "guidance_id", limit: 4
   end
 
-  add_index "themes_in_guidance", ["guidance_id"], name: "fk_rails_a5ab9402df", using: :btree
-  add_index "themes_in_guidance", ["guidance_id"], name: "index_themes_in_guidance_on_guidance_id", using: :btree
-  add_index "themes_in_guidance", ["theme_id"], name: "fk_rails_7d708f6f1e", using: :btree
-  add_index "themes_in_guidance", ["theme_id"], name: "index_themes_in_guidance_on_theme_id", using: :btree
+  add_index "themes_in_guidance", ["guidance_id"], name: "fk_rails_a5ab9402df"
+  add_index "themes_in_guidance", ["guidance_id"], name: "index_themes_in_guidance_on_guidance_id"
+  add_index "themes_in_guidance", ["theme_id"], name: "fk_rails_7d708f6f1e"
+  add_index "themes_in_guidance", ["theme_id"], name: "index_themes_in_guidance_on_theme_id"
 
   create_table "token_permission_types", force: :cascade do |t|
     t.string   "token_type",       limit: 255
@@ -398,9 +398,9 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.integer  "identifier_scheme_id", limit: 4
   end
 
-  add_index "user_identifiers", ["identifier_scheme_id"], name: "fk_rails_fe95df7db0", using: :btree
-  add_index "user_identifiers", ["user_id"], name: "fk_rails_65c9a98cdb", using: :btree
-  add_index "user_identifiers", ["user_id"], name: "index_user_identifiers_on_user_id", using: :btree
+  add_index "user_identifiers", ["identifier_scheme_id"], name: "fk_rails_fe95df7db0"
+  add_index "user_identifiers", ["user_id"], name: "fk_rails_65c9a98cdb"
+  add_index "user_identifiers", ["user_id"], name: "index_user_identifiers_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "firstname",              limit: 255
@@ -436,49 +436,17 @@ ActiveRecord::Schema.define(version: 20171025200301) do
     t.string   "recovery_email",         limit: 255
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["language_id"], name: "fk_rails_45f4f12508", using: :btree
-  add_index "users", ["org_id"], name: "fk_rails_e73753bccb", using: :btree
-  add_index "users", ["org_id"], name: "index_users_on_org_id", using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["language_id"], name: "fk_rails_45f4f12508"
+  add_index "users", ["org_id"], name: "fk_rails_e73753bccb"
+  add_index "users", ["org_id"], name: "index_users_on_org_id"
 
   create_table "users_perms", id: false, force: :cascade do |t|
     t.integer "user_id", limit: 4
     t.integer "perm_id", limit: 4
   end
 
-  add_index "users_perms", ["perm_id"], name: "fk_rails_457217c31c", using: :btree
-  add_index "users_perms", ["user_id"], name: "index_users_perms_on_user_id", using: :btree
+  add_index "users_perms", ["perm_id"], name: "fk_rails_457217c31c"
+  add_index "users_perms", ["user_id"], name: "index_users_perms_on_user_id"
 
-  add_foreign_key "annotations", "orgs"
-  add_foreign_key "annotations", "questions"
-  add_foreign_key "answers", "plans"
-  add_foreign_key "answers", "questions"
-  add_foreign_key "answers", "users"
-  add_foreign_key "guidance_groups", "orgs"
-  add_foreign_key "guidances", "guidance_groups"
-  add_foreign_key "notes", "answers"
-  add_foreign_key "notes", "users"
-  add_foreign_key "org_identifiers", "identifier_schemes"
-  add_foreign_key "org_identifiers", "orgs"
-  add_foreign_key "org_token_permissions", "orgs"
-  add_foreign_key "org_token_permissions", "token_permission_types"
-  add_foreign_key "orgs", "languages"
-  add_foreign_key "orgs", "regions"
-  add_foreign_key "phases", "templates"
-  add_foreign_key "plans", "templates"
-  add_foreign_key "plans_guidance_groups", "guidance_groups"
-  add_foreign_key "plans_guidance_groups", "plans"
-  add_foreign_key "question_options", "questions"
-  add_foreign_key "questions", "question_formats"
-  add_foreign_key "questions", "sections"
-  add_foreign_key "roles", "plans"
-  add_foreign_key "roles", "users"
-  add_foreign_key "sections", "phases"
-  add_foreign_key "templates", "orgs"
-  add_foreign_key "themes_in_guidance", "guidances"
-  add_foreign_key "themes_in_guidance", "themes"
-  add_foreign_key "user_identifiers", "identifier_schemes"
-  add_foreign_key "user_identifiers", "users"
-  add_foreign_key "users", "languages"
-  add_foreign_key "users", "orgs"
 end

--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -21,7 +21,7 @@ class AnswersControllerTest < ActionDispatch::IntegrationTest
       template = question.section.phase.template
       
       plan = Plan.create(title: "Testing Answer For #{format.title}", 
-                         template: template)
+                         template: template, visibility: :is_test)
       
       Role.create!(user_id: @user.id, plan_id: plan.id, access: 4)
       plan.reload

--- a/test/functional/phases_controller_test.rb
+++ b/test/functional/phases_controller_test.rb
@@ -10,7 +10,7 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
     # Get the first Org Admin
     scaffold_org_admin(@template.org)
     
-    @plan = Plan.create!(template: @template, title: 'Test Plan', 
+    @plan = Plan.create!(template: @template, title: 'Test Plan', visibility: :privately_visible,
                          roles: [Role.new(user: @user, creator: true)])
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,7 +100,7 @@ class ActiveSupport::TestCase
     @plan = Plan.new(template: @template, title: 'Test Plan', grant_number: 'Grant-123',
                         principal_investigator: 'me', principal_investigator_identifier: 'me-1234',
                         description: "this is my plan's informative description",
-                        identifier: '1234567890', data_contact: 'me@example.com', visibility: 0,
+                        identifier: '1234567890', data_contact: 'me@example.com', visibility: :privately_visible,
                         roles: [Role.new(user: User.last, creator: true)])
 
     assert @plan.valid?, "unable to create new Plan: #{@plan.errors.map{|f, m| f.to_s + ' ' + m}.join(', ')}"

--- a/test/unit/answer_test.rb
+++ b/test/unit/answer_test.rb
@@ -63,7 +63,7 @@ class AnswerTest < ActiveSupport::TestCase
   
   # ---------------------------------------------------
   test "answer's template must match the plan's template" do
-    plan = Plan.new(title: 'Wrong plan test', template: Template.where.not(id: @plan.template.id).first)
+    plan = Plan.new(title: 'Wrong plan test', template: Template.where.not(id: @plan.template.id).first, visibility: :is_test)
     q = @plan.template.questions.select{|q| !q.question_format.option_based }.first
 
     # TODO: This should pass. We shouldn't be able to add an answer to a plan for a question on the wrong template!

--- a/test/unit/plan_test.rb
+++ b/test/unit/plan_test.rb
@@ -14,7 +14,7 @@ class PlanTest < ActiveSupport::TestCase
     @plan = Plan.create(title: 'Test Plan', template: @template, grant_number: 'Plan12345',
                         identifier: '000912', description: 'This is a test plan',
                         principal_investigator: 'John Doe', principal_investigator_identifier: 'ABC',
-                        data_contact: 'john.doe@example.com', visibility: 1)
+                        data_contact: 'john.doe@example.com', visibility: :privately_visible)
 
     @plan.assign_creator(@creator.id)
     @plan.save!
@@ -270,7 +270,7 @@ class PlanTest < ActiveSupport::TestCase
     #       default but perhaps there is a use-case for someone creating plans for another user
     #assert_equal @creator, @plan.owner, "expected the owner to match the creator"
 
-    plan = Plan.create!(template: Template.last, title: 'Testing no creator')
+    plan = Plan.create!(template: Template.last, title: 'Testing no creator', visibility: :is_test)
     assert plan.owner.nil?, "expected a new plan with no creator assigned to return nil"
   end
 
@@ -283,7 +283,7 @@ class PlanTest < ActiveSupport::TestCase
 
   # ---------------------------------------------------
   test "can CRUD Plan" do
-    obj = Plan.create(title: 'Testing CRUD', template: Template.where.not(id: @template.id).first,
+    obj = Plan.create(title: 'Testing CRUD', template: Template.where.not(id: @template.id).first, visibility: :is_test,
                       roles: [Role.new(user: User.last, creator: true)], description: "should change")
     assert_not obj.id.nil?, "was expecting to be able to create a new Plan! - #{obj.errors.map{|f, m| f.to_s + ' ' + m}.join(', ')}"
 
@@ -315,7 +315,7 @@ class PlanTest < ActiveSupport::TestCase
 
   # ---------------------------------------------------
   test "can manage belongs_to relationship with Template" do
-    plan = Plan.new(title: 'Tester')
+    plan = Plan.new(title: 'Tester', visibility: :is_test)
     verify_belongs_to_relationship(plan, Template.first)
   end
 

--- a/test/unit/question_option_test.rb
+++ b/test/unit/question_option_test.rb
@@ -8,7 +8,7 @@ class QuestionOptionTest < ActiveSupport::TestCase
     
     @question = QuestionFormat.find_by(option_based: true).questions.first
     
-    @plan = Plan.create(title: 'Test Plan', template: @question.section.phase.template)
+    @plan = Plan.create(title: 'Test Plan', template: @question.section.phase.template, visibility: :privately_visible)
     
     @option = QuestionOption.create(question: @question, text: 'Test QuestionOption', number: 1)
   end

--- a/test/unit/role_test.rb
+++ b/test/unit/role_test.rb
@@ -17,7 +17,7 @@ class RoleTest < ActiveSupport::TestCase
     assert_not Role.new(user: @user, access: 1).valid?, "expected the 'plan' field to be required"
     
     # Ensure the bar minimum and complete versions are valid
-    plan = Plan.create(title: 'Test Plan', template: Template.last)
+    plan = Plan.create(title: 'Test Plan', template: Template.last, visibility: :is_test)
     a = Role.new(user: @user, plan: plan, access: 15)
     assert a.valid?, "expected the 'user', 'plan' and 'access' fields to be enough to create an Role! - #{a.errors.map{|f, m| f.to_s + ' ' + m}.join(', ')}"
   end
@@ -58,7 +58,7 @@ class RoleTest < ActiveSupport::TestCase
   
   # ---------------------------------------------------
   test "can CRUD Role" do
-    plan = Plan.create(title: 'Test Plan', template: Template.last)
+    plan = Plan.create(title: 'Test Plan', template: Template.last, visibility: :is_test)
     obj = Role.create(user: @user, plan: plan, access: 1)
     assert_not obj.id.nil?, "was expecting to be able to create a new Role: #{obj.errors.map{|f, m| f.to_s + ' ' + m}.join(', ')}"
 

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -110,7 +110,7 @@ class TemplateTest < ActiveSupport::TestCase
   
   # ---------------------------------------------------
   test "can manage has_many relationship with Plan" do
-    plan = Plan.new(title: 'Test Plan')
+    plan = Plan.new(title: 'Test Plan', visibility: :is_test)
     verify_has_many_relationship(@template, plan, @template.plans.count)
   end
 


### PR DESCRIPTION
DB migration to remove the DB default value for plans.visibility. The default visibility is configurable per installation
- Added rails migration to to remove default from plans.visibility
- Added visibility to all Plan.create calls in tests
- Updated user_mailer views to use the default Rails contact_us_url route helper if an override is not defined in branding.yml