### PR TITLE
Added Request Feedback button to the share plan page

### DIFF
--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -142,6 +142,11 @@ class Org < ActiveRecord::Base
     end
   end
 
+  def org_admins
+    User.joins(:perms).where("users.org_id = ? AND perms.name IN (?)", self.id, 
+      ['grant_permissions', 'modify_templates', 'modify_guidance', 'change_org_details'])
+  end
+
   private
     ##
     # checks size of logo and resizes if necessary

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -15,6 +15,7 @@ class Role < ActiveRecord::Base
             2 => :administrator,      # 2
             3 => :editor,             # 4
             4 => :commenter,          # 8
+            5 => :reviewer,           # 16
             column: 'access'
 
   validates :user, :plan, :access, presence: {message: _("can't be blank")}
@@ -22,6 +23,7 @@ class Role < ActiveRecord::Base
 
   ##
   # return the access level for the current project group
+  # 5 if the user is a reviewer
   # 3 if the user is an administrator
   # 2 if the user is an editor
   # 1 if the user can only read
@@ -29,7 +31,9 @@ class Role < ActiveRecord::Base
   #
   # @return [Integer]
   def access_level
-    if self.administrator?
+    if self.reviewer?
+      return 5
+    elsif self.administrator?
       return 3
     elsif self.editor?
       return 2
@@ -41,6 +45,11 @@ class Role < ActiveRecord::Base
   # This method becomes useful for generatic template messages (e.g. permissions change notification mailer)
   def self.access_level_messages
     {
+      5 => {
+        :type => _('reviewer'),
+        :placeholder1 => _('read the plan and provide feedback.'),
+        :placeholder2 => nil
+        },
       3 => {
         :type => _('co-owner'),
         :placeholder1 => _('write and edit the plan in a collaborative manner.'),
@@ -83,3 +92,19 @@ end
 # 13 - creator + editor + commenter
 # 14 - administrator + editor + commenter
 # 15 - creator + administrator + editor + commenter
+# 16 - reviewer
+# 17 - creator + reviewer
+# 18 - administrator + reviewer
+# 19 - creator + administrator + reviewer
+# 20 - editor + reviewer
+# 21 - creator + editor + reviewer
+# 22 - administraor + editor + reviewer
+# 23 - creator + editor + administrator + reviewer
+# 24 - commenter + reviewer
+# 25 - creator + commenter + reviewer
+# 26 - administrator + commenter + reviewer
+# 27 - creator + administrator + commenter + reviewer
+# 28 - editor + commenter + reviewer
+# 29 - creator + editor + commenter + reviewer
+# 30 - administrator + editor + commenter + reviewer
+# 31 - creator + administrator + editor + commenter + reviewer

--- a/app/policies/plan_policy.rb
+++ b/app/policies/plan_policy.rb
@@ -53,4 +53,7 @@ class PlanPolicy < ApplicationPolicy
     @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
   end
 
+  def request_feedback?
+    @plan.owned_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+  end
 end

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -11,12 +11,11 @@
     <div class="row">
       <div class="form-group col-xs-8">
         <%= f.label :feedback_email_subject, _('Subject'), class: "control-label" %>
-        <%= f.text_field :feedback_email_subject, class: "form-control",
-              placeholder: "#{_('A user has requested feedback for their DMP in')} #{Rails.configuration.branding[:application][:name]}" %>
+        <%= f.text_field :feedback_email_subject, class: "form-control" %>
       </div>
     </div>
     <div class="row">
-      <div class="form-group col-xs-8">
+      <div class="form-group col-xs-8" data-toggle="tooltip" data-html="true" title="<%= _('You may use the following keywords in your email: <ul><li>%{application_name} - the name of this tool</li><li>%{user_name} - the plan\'s owner</li><li>%{plan_name} - the plan\'s title</li><li>%{organisation_email} - the administrative contact email for your organisation</li></ul>') %>">
         <%= f.label :feedback_email_msg, _('Message'), class: "control-label" %>
         <%= f.text_area :feedback_email_msg, class: "form-control" %>
       </div>
@@ -26,8 +25,8 @@
     <div class="form-group col-xs-8">
       <%= f.button(_('Save'), id:"save_org_submit", class: "btn btn-primary", type: "submit") %>
       <%= f.button(_('Reset to defaults'), id:"reset-to-default-feedback-email", class: "btn btn-default", type: "button") %>
-      <div id="feedback-email-default-subject" class="hide"><%= EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_SUBJECT %></div>
-      <div id="feedback-email-default-message" class="hide"><%= EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_MESSAGE %></div>
+      <div id="feedback-email-default-subject" class="hide"><%= UserMailer.feedback_confirmation_default_subject %></div>
+      <div id="feedback-email-default-message" class="hide"><%= UserMailer.feedback_confirmation_default_message %></div>
     </div>
   </div>
 <% end %>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -74,7 +74,7 @@
   </div>
 
   <% if current_user.can_super_admin? %>
-    <div class="bordered col-xs-8" data-toggle="tooltip" title="<%= _('This information can be changed in the Super Admin section.') %>">
+    <div class="bordered col-xs-8" data-toggle="tooltip" title="<%= _('This information can only be changed by a system administrator. Contact the Help Desk if you have questions or to request changes.') %>">
       <h3><%= _('Organisational Configuration Information') %></h3>
       <dl>
         <% shibboleth = @org.org_identifiers.select{ |ids| ids.identifier_scheme == IdentifierScheme.find_by(name: 'shibboleth')} %>

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -30,8 +30,7 @@
       </tr>
     </thead>
     <tbody>
-      <% plan_roles = @plan.roles.where(active: true) %>
-      <%  plan_roles.each do |role| %>
+      <% @plan_roles.each do |role| %>
         <tr>
           <td><%= role.user.name %></td>
           <td>
@@ -86,5 +85,16 @@
 
     <%= f.button(_('Submit'), class: "btn btn-primary", type: "submit") %>
   </div>
+  <div class="clearfix"></div>
+<% end %>
 
+<% if plan.owner_and_coowners.include?(current_user) && current_user.org.feedback_enabled? %>
+  <h2><%= _('Request expert feedback') %></h2>
+  <p><%= _('Click below to give data management staff at your organisation access to read and comment on your plan.') %></p>
+  <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
+
+  <div class="form-group col-xs-8">
+    <%= link_to _('Request feedback'), request_feedback_plan_path, class: "btn btn-default#{' disabled' if @plan.feedback_requested?}" %>
+    <span><%= _("Feedback has been requested.") if @plan.feedback_requested? %></span>
+  </div>
 <% end %>

--- a/app/views/user_mailer/feedback_notification.html.erb
+++ b/app/views/user_mailer/feedback_notification.html.erb
@@ -1,6 +1,15 @@
 <% FastGettext.with_locale FastGettext.default_locale do %>
-<% if @org.feedback_email_msg.present? %>
-  <%= raw @org.feedback_email_msg %>
-<% else %>
-  <%= raw EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_MESSAGE %>
+  <% 
+    recipient_name = @recipient.name(false) 
+    requestor_name = @user.name(false)
+    plan_name = @plan.title
+    tool_name = Rails.configuration.branding[:application][:name]
+    helpdesk = Rails.configuration.branding[:application][:email]
+    contact_url = "<a href='#{new_contact_url}'>#{new_contact_url}</a>" 
+  %>
+
+  <p><%= _('Hello %{user_name},') % {user_name: recipient_name} %></p>
+  <p><%= _('%{requestor} has requested feedback on a plan "%{plan_name}." To add comments, please visit the \'Plans\' page under the Admin menu in %{application_name} and open the plan.') % {requestor: requestor_name, plan_name: plan_name, application_name: tool_name} %></p>
+  <p><%= _('All the best,<br />The %{application_name} team') % {application_name: tool_name} %></p>
+  <p><%= _('You may change your notification preferences on your profile page. Please do not reply to this email. If you have questions or need help, please contact us at %{help_desk} or visit %{contact_url}') % {help_desk: helpdesk, contact_url: contact_url} %></p>
 <% end %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,11 +1,3 @@
 LANGUAGES = (ActiveRecord::Base.connection.table_exists? 'languages') ? Language.sorted_by_abbreviation : []
 MANY_LANGUAGES = LANGUAGES.length > 1
 TABLE_FILTER_MIN_ROWS = 10
-
-# Default Feedback Request Email sent to the requesting user
-# This email can be overriden by local Org Admins on the Org Details page
-# TODO: Move this to a location that gets loaded AFTER FastGettext so that we can  use fastgettext to manage localisations
-EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_SUBJECT = 'Your DMP has been submitted for feedback in %{application_name}'
-EMAIL_FEEDBACK_REQUESTED_CONFIRMATION_MESSAGE = '<p>Hello [user_name],</p>'\
-  '<p>Your DMP "[plan_name]" has been submitted for feedback from an administrator at your institution.  If you have questions pertaining to this action, please contact your local administrator at [organisation_email].</p>'\
-  '<p>All the best,<br />The %{application_name} team.</p>'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,6 +220,7 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
         post 'invite'
         post 'visibility', constraints: {format: [:json]}
         post 'set_test', constraints: {format: [:json]}
+        get 'request_feedback'
       end
 
       collection do

--- a/db/migrate/20171102185518_add_feedback_requested_to_plans.rb
+++ b/db/migrate/20171102185518_add_feedback_requested_to_plans.rb
@@ -1,0 +1,5 @@
+class AddFeedbackRequestedToPlans < ActiveRecord::Migration
+  def change
+    add_column :plans, :feedback_requested, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171102164156) do
+ActiveRecord::Schema.define(version: 20171102185518) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "question_id", limit: 4
@@ -230,6 +230,7 @@ ActiveRecord::Schema.define(version: 20171102164156) do
     t.string   "data_contact_phone",                limit: 255
     t.string   "principal_investigator_email",      limit: 255
     t.string   "principal_investigator_phone",      limit: 255
+    t.boolean  "feedback_requested",                              default: false
   end
 
   add_index "plans", ["template_id"], name: "index_plans_on_template_id"


### PR DESCRIPTION
issue #727
- added new `plans.feedback_requested` flag to DB
- added 'Request Feedback' button to share plan page
- added confirmation email for owner and co-owners
- added notification email for org admins
- minor modifications to tooltips and email defaults (moved email constants to user_mailer)