### PR TITLE
Fix for create plan page ajax request

### DIFF
--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -64,7 +64,7 @@
 
       <!-- Template selection -->
       <div id="available-templates" style="visibility: none;">
-        <%= hidden_field_tag 'template-option-target', template_options_template_url(current_user) %>
+        <%= hidden_field_tag 'template-option-target', template_options_template_path(current_user) %>
         <h2 id="template-selection"><%= _('Which DMP template would you like to use?') %></h2>
         <div class="form-group row">
           <div class="col-xs-6">


### PR DESCRIPTION
switched to `_path` style helper. `_url` style was using the http protocol on stage due to a reverse proxy between apache and passenger. This approach uses the relative path and prevents issues with variations in protocol and domain.