### PR TITLE
Fixes for visibility, comment and feedback emails

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -73,7 +73,7 @@ class UserMailer < ActionMailer::Base
       message = feedback_constant_to_text(@org.feedback_email_msg.present? ? @org.feedback_email_msg : feedback_confirmation_default_message)
       
       FastGettext.with_locale FastGettext.default_locale do
-        mail(to: recipient.email, subject: subject, body: message)
+        mail(to: recipient.email, subject: subject, body: raw(message))
       end
     end
   end

--- a/app/views/user_mailer/feedback_notification.html.erb
+++ b/app/views/user_mailer/feedback_notification.html.erb
@@ -10,6 +10,6 @@
 
   <p><%= _('Hello %{user_name},') % {user_name: recipient_name} %></p>
   <p><%= _('%{requestor} has requested feedback on a plan "%{plan_name}." To add comments, please visit the \'Plans\' page under the Admin menu in %{application_name} and open the plan.') % {requestor: requestor_name, plan_name: plan_name, application_name: tool_name} %></p>
-  <p><%= _('All the best,<br />The %{application_name} team') % {application_name: tool_name} %></p>
-  <p><%= _('You may change your notification preferences on your profile page. Please do not reply to this email. If you have questions or need help, please contact us at %{help_desk} or visit %{contact_url}') % {help_desk: helpdesk, contact_url: contact_url} %></p>
+  <p><%= raw(_('All the best,<br />The %{application_name} team') % {application_name: tool_name}) %></p>
+  <p><%= raw(_('You may change your notification preferences on your profile page. Please do not reply to this email. If you have questions or need help, please contact us at %{help_desk} or visit %{contact_url}') % {help_desk: helpdesk, contact_url: contact_url}) %></p>
 <% end %>

--- a/app/views/user_mailer/new_comment.html.erb
+++ b/app/views/user_mailer/new_comment.html.erb
@@ -4,7 +4,7 @@
   plan_title = @plan.title
   user_name = @plan.owner.name
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url]
+  contact_us = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
@@ -22,6 +22,6 @@
     <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
   </p>
   <p>
-    <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us_url, contact_us_url) }) %>
+    <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us, contact_us) }) %>
   </p>
 <% end %>

--- a/app/views/user_mailer/plan_visibility.html.erb
+++ b/app/views/user_mailer/plan_visibility.html.erb
@@ -4,7 +4,7 @@
   plan_title = @plan.title
   plan_visibility = Plan.visibility_message(@plan.visibility.to_sym)
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url]
+  contact_us = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
@@ -31,6 +31,6 @@
     <%= _('The %{tool_name} team') %{ :tool_name => tool_name } %>
   </p>
   <p>
-    <%=  _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us_url, contact_us_url) }) %>
+    <%=  _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us => link_to(contact_us, contact_us) }) %>
   </p>
 <% end %>


### PR DESCRIPTION
- Visibility email: Allow contact_us_url to be undefined in branding.yml (use Rails' built-in route helper if not defined) #732 
- Comment email: Allow contact_us_url to be undefined in branding.yml (use Rails' built-in route helper if not defined) #733 
- Feedback emails: Add `raw` to feedback emails to properly handle inline HTML #727