### PR TITLE
Updated Request Feedback default on Org details page

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,0 +1,20 @@
+module MailerHelper
+
+  def feedback_confirmation_default_subject
+    _('%{application_name}: Your plan has been submitted for feedback')
+  end
+
+  def feedback_confirmation_default_message
+    _('<p>Hello %{user_name}.</p>'\
+            '<p>Your plan "%{plan_name}" has been submitted for feedback from an administrator at your organisation. '\
+            'If you have questions pertaining to this action, please contact us at %{organisation_email}.</p>')
+  end
+  
+  def feedback_constant_to_text(text, user, plan, org)
+    _("#{text}") % {application_name: Rails.configuration.branding[:application][:name],
+                    user_name: user.name,
+                    plan_name: plan.title,
+                    organisation_email: org.contact_email}
+  end
+
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -202,7 +202,8 @@ class Plan < ActiveRecord::Base
     # Share the plan with each org admin as the reviewer role
     admins = user.org.org_admins
     admins.each do |admin|
-      self.roles << Role.new(user: admin, access: val)
+      role = Role.new(user: admin, access: val)
+      self.roles << role unless self.users.include?(admin)
     end 
 
     if self.save!

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -11,11 +11,13 @@
     <div class="row">
       <div class="form-group col-xs-8">
         <%= f.label :feedback_email_subject, _('Subject'), class: "control-label" %>
-        <%= f.text_field :feedback_email_subject, class: "form-control" %>
+
+        <%= f.text_field :feedback_email_subject, class: "form-control", placeholder: _(feedback_confirmation_default_subject) % { application_name: Rails.configuration.branding[:application][:name] } %>
       </div>
     </div>
     <div class="row">
-      <div class="form-group col-xs-8" data-toggle="tooltip" data-html="true" title="<%= _('You may use the following keywords in your email: <ul><li>%{application_name} - the name of this tool</li><li>%{user_name} - the plan\'s owner</li><li>%{plan_name} - the plan\'s title</li><li>%{organisation_email} - the administrative contact email for your organisation</li></ul>') %>">
+      <% tip = _(feedback_confirmation_default_message) % { user_name: _('%{user_name}'), plan_name: _('%{plan_name}'), organisation_email: @org.contact_email } %>
+      <div class="form-group col-xs-8" data-toggle="tooltip" data-html="true" title="<%= tip %>">
         <%= f.label :feedback_email_msg, _('Message'), class: "control-label" %>
         <%= f.text_area :feedback_email_msg, class: "form-control" %>
       </div>
@@ -24,9 +26,6 @@
   <div class="row">
     <div class="form-group col-xs-8">
       <%= f.button(_('Save'), id:"save_org_submit", class: "btn btn-primary", type: "submit") %>
-      <%= f.button(_('Reset to defaults'), id:"reset-to-default-feedback-email", class: "btn btn-default", type: "button") %>
-      <div id="feedback-email-default-subject" class="hide"><%= UserMailer.feedback_confirmation_default_subject %></div>
-      <div id="feedback-email-default-message" class="hide"><%= UserMailer.feedback_confirmation_default_message %></div>
     </div>
   </div>
 <% end %>

--- a/lib/assets/javascripts/views/orgs/admin_edit.js
+++ b/lib/assets/javascripts/views/orgs/admin_edit.js
@@ -67,13 +67,6 @@ $(() => {
   // Initialises tinymce for any target element with class tinymce_answer
   Tinymce.init({ selector: '#org_feedback_email_msg' });
 
-  $('#reset-to-default-feedback-email').click((e) => {
-    e.preventDefault();
-    $('#org_feedback_email_subject').val($('#feedback-email-default-subject').html());
-    const editor = Tinymce.findEditorById('org_feedback_email_msg');
-    editor.setContent($('#feedback-email-default-message').text());
-  });
-
   // Convert the max number of URLs constant to text and display for user
   $('#max-nbr-urls').text(convertToText(MAX_NUMBER_ORG_URLS).toLowerCase());
 


### PR DESCRIPTION
- Added placeholder and changed tooltip #726 
- Moved feedback confirmation message defaults to `helpers/mailer_helper.rb`
- Updated feedback logic to prevent adding the reviewer role if the user already has a role on the plan (current association allows multiple roles of the same type per user+plan). the user does not need the reviewer role if they are already a commenter, editor or co-owner/owner since they have the same or better permissions than reviewer.  
- Updated `mailers/user_mailer.rb` and `views/orgs/_feedback_form.html.erb` to use MailHelper