### PR TITLE
Revert org selection changes

### DIFF
--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -42,23 +42,19 @@
   <% @identifier_schemes.each do |scheme| %>
     <div class="form-group col-xs-8">
       <% if scheme.name == 'shibboleth' %>
-        <% if current_user.org.present? %>
-          <label class='control-label'>
-            <span class="aria-only" aria-hidden="false"><%= _('Institutional credentials') %></span>
-            <i class="fa fa-user" title="<%= _('Institutional credentials') %>" aria-hidden="true"></i>
-          </label>
-        <% end %>
+        <label class='control-label'>
+          <span class="aria-only" aria-hidden="false"><%= _('Institutional credentials') %></span>
+          <i class="fa fa-user" title="<%= _('Institutional credentials') %>" aria-hidden="true"></i>
+        </label>
       <% else %>
         <%= label_tag(:scheme_name, scheme.name.capitalize, class: 'control-label') %>
       <% end %>
 
-      <% if scheme.name != 'shibboleth' || (scheme.name == 'shibboleth' && current_user.org.present?) %>
-        <div class='identifier-scheme'>
-          <%= render partial: "external_identifier_#{scheme.name}",
-                     locals: { scheme: scheme,
-                               id: current_user.identifier_for(scheme)} %>
-        </div>
-      <% end %>
+      <div class='identifier-scheme'>
+        <%= render partial: "external_identifier_#{scheme.name}",
+                   locals: { scheme: scheme,
+                             id: current_user.identifier_for(scheme)} %>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/shared/_my_org.html.erb
+++ b/app/views/shared/_my_org.html.erb
@@ -7,12 +7,10 @@
                       attribute: 'name'} %>
 
 <% if allow_other_orgs %>
-  <%= f.text_field :other_organisation, autocomplete: "off", class: "form-control", 
-                   placeholder: _('Please enter the name of your organisation') %>
-<% end %>
+  <div class="clearfix"></div>
+  <a href="#" id="other-org-link"><%= _('My organisation isn\'t listed.') %></a>
 
-<% if allow_other_orgs %>
-  <div class="checkbox" id="other_org_toggle">
-    <a href="#"><%= _('My organisation isn\'t listed.') %></a>
-  </div>
+  <div class="clearfix"></div>
+  <%= f.text_field :other_organisation, autocomplete: "off", class: "form-control hide", 
+                   placeholder: _('Please enter the name of your organisation') %>
 <% end %>

--- a/lib/assets/javascripts/constants.js
+++ b/lib/assets/javascripts/constants.js
@@ -23,10 +23,6 @@ export const PLAN_VISIBILITY_WHEN_TEST = 'N/A';
 export const PLAN_VISIBILITY_WHEN_NOT_TEST = 'Private';
 export const PLAN_VISIBILITY_WHEN_NOT_TEST_TOOLTIP = 'Private: restricted to me and people I invite.';
 
-export const DISABLE_ORG_COMBO_MESSAGE = 'You must unlink your account before changing your organisation.';
-export const OTHER_ORG_HIDE_COMBO_MESSAGE = 'My organisation isn\'t listed.';
-export const OTHER_ORG_SHOW_COMBO_MESSAGE = 'Select the organisation from a list.';
-
 export const SHIBBOLETH_DISCOVERY_SERVICE_HIDE_LIST = 'Hide list.';
 export const SHIBBOLETH_DISCOVERY_SERVICE_SHOW_LIST = 'See the full list of partner institutions.';
 

--- a/lib/assets/javascripts/views/shared/my_org.js
+++ b/lib/assets/javascripts/views/shared/my_org.js
@@ -1,39 +1,34 @@
-import { OTHER_ORG_HIDE_COMBO_MESSAGE, OTHER_ORG_SHOW_COMBO_MESSAGE } from '../../constants';
-import { isValidNumber, isValidText } from '../../utils/isValidInputType';
+import { isValidText } from '../../utils/isValidInputType';
 
 $(() => {
-  const combo = $('.combobox-container');
+  const combo = $('input#user_org_name');
   const id = $('input#user_org_id');
   const text = $('input#user_other_organisation');
-  const link = $('#other_org_toggle a');
+  const link = $('a#other-org-link');
 
-  // Toggle between the autocomplete dropdown box and the other org textbox
-  const toggleCombobox = (show) => {
-    if (show) {
-      $(text).hide();
-      $(combo).fadeIn();
-      $(link).text(OTHER_ORG_HIDE_COMBO_MESSAGE);
+  const toggleInputs = (showCombo) => {
+    if (showCombo) {
+      $(text).val('').addClass('hide');
+      $(combo);
     } else {
-      $(combo).hide();
-      $(text).fadeIn();
-      $(link).text(OTHER_ORG_SHOW_COMBO_MESSAGE);
+      $(combo).val('');
+      $(id).val('');
+      $(text).removeClass('hide');
     }
   };
 
-  // Toggle between the combobox and textbox when the link is clicked
+  // Show the other org textbox when the link is clicked
   $(link).click((e) => {
     e.preventDefault();
-    if ($(combo).css('display') === 'none') {
-      $(text).val('').hide();
-      toggleCombobox(true);
-    } else {
-      $(combo).find('.combobox-clear-button').click();
-      toggleCombobox(false);
-    }
+    toggleInputs(false);
   });
 
-  // Display the appropriate input type on page load
-  if ($(id).length > 0 && $(text).length > 0) {
-    toggleCombobox(isValidNumber($(id).val()) || !isValidText($(text).val()));
+  $(combo).keyup(() => {
+    toggleInputs(true);
+  });
+
+  // Display the other org textbox if the value is filled out and no org id is selected
+  if ($(id).val().length <= 0 && isValidText($(text).val())) {
+    toggleInputs(false);
   }
 });


### PR DESCRIPTION
reverting org selection changes back to the DMPonline functionality #740 
- added back in the 'my org not in list' link 
- clicking link displays the other org box and clears value in combobox
- selecting a value from the combobox clears the value in the textbox
- removed restriction that prevented shib link from appearing if user did not have an org selected 