### PR TITLE
Add contact_us_url handler for Devise emails

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,7 +2,7 @@
   tool_name = Rails.configuration.branding[:application][:name]
   link = accept_invitation_url(@resource, :invitation_token => @token)
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url]
+  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,7 +1,7 @@
 <%
   tool_name = Rails.configuration.branding[:application][:name]
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url]
+  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>


### PR DESCRIPTION
#839 
Added `|| contact_us_url` to the end of code that tries to retrieve the value from the branding.yml