### PR TITLE
Org Admin provide feedback

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -11,7 +11,7 @@ class NotesController < ApplicationController
     # create answer if we don't have one already
     @answer = nil # if defined within the transaction block, was not accessable afterward
     # ensure user has access to plan BEFORE creating/finding answer
-    rails Pundit::NotAuthorizedError unless Plan.find(params[:note][:plan_id]).readable_by?(@note.user_id)
+    raise Pundit::NotAuthorizedError unless Plan.find(params[:note][:plan_id]).readable_by?(@note.user_id)
     Answer.transaction do
       if params[:note][:answer_id].present?
         @answer = Answer.find(params[:note][:answer_id])

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -1,0 +1,25 @@
+module OrgAdmin
+  class PlansController < ApplicationController
+    after_action :verify_authorized
+
+    def index
+      authorize Plan
+    
+      vals = Role.access_values_for(:reviewer)
+      @feedback_plans = Plan.joins(:roles).where('roles.user_id = ? and roles.access IN (?)', current_user.id, vals)
+      @plans = current_user.org.plans
+    end
+    
+    # GET org_admin/plans/:id/feedback_complete
+    def feedback_complete
+      plan = Plan.find(params[:id])
+      authorize plan
+      
+      if plan.complete_feedback(current_user)
+        redirect_to org_admin_plans_path, notice: _('%{plan_owner} has been notified that you have finished providing feedback') % { plan_owner: plan.owner.name(false) }
+      else
+        redirect_to org_admin_plans_path, alert: _('Unable to notify user that you have finished providing feedback.')
+      end
+    end
+  end
+end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -342,22 +342,19 @@ class PlansController < ApplicationController
   end
 
   def request_feedback
-    @plan = Plan.find(params[:id])
-    authorize @plan
+    plan = Plan.find(params[:id])
+    authorize plan
     alert = _('Unable to submit your request for feedback at this time.')
 
     begin
-     if @plan.request_feedback(current_user)
-       flash[:notice] = _('Your request for feedback has been submitted.')
+     if plan.request_feedback(current_user)
+       redirect_to share_plan_path(plan), notice: _('Your request for feedback has been submitted.')
      else
-       flash[:alert] = alert
+       redirect_to share_plan_path(plan), alert: alert
      end
     rescue Exception
-      flash[:alert] = alert
+      redirect_to share_plan_path(plan), alert: alert
     end
-    # Get the roles where the user is not a reviewer
-    @plan_roles = @plan.roles.select{ |r| !r.reviewer? }
-    render 'share'
   end
 
   private

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -63,6 +63,17 @@ class UserMailer < ActionMailer::Base
     end
   end
   
+  def feedback_complete(recipient, plan, requestor)
+    @requestor = requestor
+    @user = recipient
+    @plan = plan
+      
+    FastGettext.with_locale FastGettext.default_locale do
+      mail(to: recipient.email, 
+           subject: _("%{application_name}: Expert feedback has been provided for %{plan_title}") % {application_name: Rails.configuration.branding[:application][:name], plan_title: @plan.title})
+    end
+  end
+  
   def feedback_confirmation(recipient, plan, requestor)
     user = requestor
 

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -146,6 +146,11 @@ class Org < ActiveRecord::Base
     User.joins(:perms).where("users.org_id = ? AND perms.name IN (?)", self.id, 
       ['grant_permissions', 'modify_templates', 'modify_guidance', 'change_org_details'])
   end
+  
+  def plans
+    Plan.includes(:template, :phases, :roles, :users).joins(:roles, :users).where('users.org_id = ? AND roles.access IN (?)', 
+      self.id, Role.access_values_for(:owner).concat(Role.access_values_for(:administrator)))
+  end
 
   private
     ##

--- a/app/policies/org_admin/plan_policy.rb
+++ b/app/policies/org_admin/plan_policy.rb
@@ -1,0 +1,10 @@
+class PlanPolicy < ApplicationPolicy
+  attr_reader :user
+
+  def initialize(user)
+    raise Pundit::NotAuthorizedError, _("must be logged in") unless user 
+    raise Pundit::NotAuthorizedError, _("are not authorized to view that plan") unless user.can_org_admin?
+    @user = user
+  end
+
+end

--- a/app/policies/plan_policy.rb
+++ b/app/policies/plan_policy.rb
@@ -58,6 +58,10 @@ class PlanPolicy < ApplicationPolicy
   end
 
   def request_feedback?
-    @plan.owned_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.administerable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+  end
+  
+  def feedback_complete?
+    @plan.reviewable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
   end
 end

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -41,6 +41,11 @@
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu" aria-labelledby="admin-menu">
+            <% if current_user.can_org_admin? %>
+              <li <%= 'class=active' if isActivePage(org_admin_plans_path) %>>
+                <%= link_to _('Plans'), org_admin_plans_path %>
+              </li>
+            <% end %>
             <% if current_user.can_modify_templates? %>
                 <li <%= 'class=active' if isActivePage(admin_index_template_path(current_user.org_id)) %>>
                   <%= link_to _('Templates'), admin_index_template_path(current_user.org_id) %>

--- a/app/views/org_admin/plans/index.html.erb
+++ b/app/views/org_admin/plans/index.html.erb
@@ -1,0 +1,78 @@
+<div class="row">
+  <div class="col-md-12">    
+    <h1><%= _('%{org_name} Plans') % { org_name: current_user.org.name } %></h1>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <% if @feedback_plans.length > 0 %>
+      <h2><%= _('Notifications') %></h2>
+      <div class="panel panel-default">
+        <div class="panel-body notifications">
+          <table class="table">
+            <thead>
+              <th><%= _('Plan') %></th>
+              <th><%= _('Requestor') %></th>
+              <th><%= _('Type') %></th>
+              <th><%= _('Actions') %></th>
+            </thead>
+            <tbody>
+              <% @feedback_plans.each do |notice| %>
+                <!-- Using the plan owner as the requestor even though it could have been issued by a co-owner -->
+                <!-- TODO: correct this behavior once the notification table is in place -->
+                <tr>
+                  <td><%= link_to notice.name, plan_path(notice) %></td>
+                  <td><%= notice.owner.name(false) %></td>
+                  <td><%= _('Feedback requested') %></td>
+                  <td><%= link_to _('Complete'), feedback_complete_org_admin_plan_path(notice), 'data-toggle': 'tooltip', title: _('Notify the plan owner that I have finished providing feedback') %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @plans.length > 0 %>
+      <div class="table-responsive">
+        <table class="table table-hover tablesorter" id="my-plans">
+          <thead>
+            <% if @plans.length > TABLE_FILTER_MIN_ROWS %>
+              <tr>
+                <th colspan="6" class="sorter-false">
+                  <%= render(partial: "shared/table_filter",
+                             locals: { placeholder: _('Filter plans')}) %>
+                </th>
+              </tr>
+            <% end %>
+            <tr>
+              <th><%= _('Project Title') %></th>
+              <th><%= _('Template') %></th>
+              <th><%= _('Research Organisation') %></th>
+              <th><%= _('Owner') %></th>
+              <th><%= _('Updated') %></th>
+              <th><%= _('Visibility') %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @plans.each do |plan| %>
+              <tr>
+                <td>
+                  <%= "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}" %>
+                </td>
+                <td><%= plan.template.title %></td>
+                <td><%= plan.users.first.org.name %></td>
+                <td><%= plan.users.first.name(false) %></td>
+                <td><%= l(plan.latest_update.to_date, formats: :short) %></td>
+                <td class="plan-visibility">
+                  <%= plan.visibility === 'is_test' ? _('Test') : raw(display_visibility(plan.visibility)) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -88,7 +88,7 @@
   <div class="clearfix"></div>
 <% end %>
 
-<% if plan.owner_and_coowners.include?(current_user) && current_user.org.feedback_enabled? %>
+<% if plan.owner_and_coowners.include?(current_user) && current_user.org.present? && current_user.org.feedback_enabled? %>
   <h2><%= _('Request expert feedback') %></h2>
   <p><%= _('Click below to give data management staff at your organisation access to read and comment on your plan.') %></p>
   <p><%= _('You can continue to edit and download the plan in the interim.') %></p>

--- a/app/views/user_mailer/_email_signature.html.erb
+++ b/app/views/user_mailer/_email_signature.html.erb
@@ -1,6 +1,7 @@
 <% 
   tool_name = Rails.configuration.branding[:application][:name]
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
+  email_subject = email_subject || _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 
   # Override the default Rails route helper for the contact_us page IF an alternate contact_us url was defined
   # in the branding config file

--- a/app/views/user_mailer/api_token_granted_notification.html.erb
+++ b/app/views/user_mailer/api_token_granted_notification.html.erb
@@ -2,7 +2,6 @@
   tool_name = Rails.configuration.branding[:application][:name]
   username = @user.name
   api_documentation_url = Rails.configuration.branding[:application][:api_documentation_url]
-  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>
@@ -11,5 +10,5 @@
   <p>
     <%= raw(_('You have been granted permission by your organisation to use our API. Your API token and instructions for using the API endpoints can be found at: %{link}') %{ :link => link_to(api_documentation_url, api_documentation_url) }) %>
   </p>
-  <%= render partial: 'email_signature', locals: { email_subject: email_subject } %>
+  <%= render partial: 'email_signature' %>
 <% end %>

--- a/app/views/user_mailer/feedback_complete.html.erb
+++ b/app/views/user_mailer/feedback_complete.html.erb
@@ -1,0 +1,11 @@
+<% 
+  requestor = @requestor.name(false)
+  recipient_name = @user.name(false) 
+  plan_name = @plan.title
+  tool_name = Rails.configuration.branding[:application][:name]
+%>
+
+<p><%= _('Hello %{recipient_name}') % { recipient_name: recipient_name } %></p>
+<p><%= _('%{commenter} has finished providing feedback on the plan “%{plan_title}”. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan.') % { commenter: requestor, plan_title: plan_name, tool_name: tool_name } %></p>
+
+<%= render partial: 'email_signature' %>

--- a/app/views/user_mailer/feedback_notification.html.erb
+++ b/app/views/user_mailer/feedback_notification.html.erb
@@ -4,12 +4,9 @@
     requestor_name = @user.name(false)
     plan_name = @plan.title
     tool_name = Rails.configuration.branding[:application][:name]
-    helpdesk = Rails.configuration.branding[:application][:email]
-    contact_url = "<a href='#{new_contact_url}'>#{new_contact_url}</a>" 
   %>
 
   <p><%= _('Hello %{user_name},') % {user_name: recipient_name} %></p>
   <p><%= _('%{requestor} has requested feedback on a plan "%{plan_name}." To add comments, please visit the \'Plans\' page under the Admin menu in %{application_name} and open the plan.') % {requestor: requestor_name, plan_name: plan_name, application_name: tool_name} %></p>
-  <p><%= raw(_('All the best,<br />The %{application_name} team') % {application_name: tool_name}) %></p>
-  <p><%= raw(_('You may change your notification preferences on your profile page. Please do not reply to this email. If you have questions or need help, please contact us at %{help_desk} or visit %{contact_url}') % {help_desk: helpdesk, contact_url: contact_url}) %></p>
+  <%= render partial: 'email_signature' %>
 <% end %>

--- a/app/views/user_mailer/new_comment.html.erb
+++ b/app/views/user_mailer/new_comment.html.erb
@@ -3,9 +3,6 @@
   commenter_name = @commenter.name
   plan_title = @plan.title
   user_name = @plan.owner.name
-  helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
-  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>
@@ -16,12 +13,5 @@
     'please visit the My Dashboard page in %{tool_name} and open your plan.') %{ :plan_title => plan_title,
     :commenter_name => commenter_name, :tool_name => tool_name } %>
   </p>
-  <p>
-    <%= _('All the best') %>
-    <br />
-    <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
-  </p>
-  <p>
-    <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us, contact_us) }) %>
-  </p>
+  <%= render partial: 'email_signature' %>
 <% end %>

--- a/app/views/user_mailer/permissions_change_notification.html.erb
+++ b/app/views/user_mailer/permissions_change_notification.html.erb
@@ -3,7 +3,6 @@
   username = @user.name
   plan_title = @role.plan.title
   access = nil
-  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
   access_level = @role.access_level()
   access_level_messages = Role.access_level_messages
 %>
@@ -14,5 +13,5 @@
   <p>
     <%= _('Your permissions relating to %{plan_title} have changed. You now have %{type} access. This means you can %{placeholder1} %{placeholder2}') %{ :plan_title => plan_title, :type => access_level_messages[access_level][:type], :placeholder1 => access_level_messages[access_level][:placeholder1], :placeholder2 => access_level_messages[access_level][:placeholder2] } %>
   </p>
-  <%= render partial: 'email_signature', locals: { email_subject: email_subject } %>
+  <%= render partial: 'email_signature' %>
 <% end %>

--- a/app/views/user_mailer/plan_visibility.html.erb
+++ b/app/views/user_mailer/plan_visibility.html.erb
@@ -3,9 +3,6 @@
   username = @user.name
   plan_title = @plan.title
   plan_visibility = Plan.visibility_message(@plan.visibility.to_sym)
-  helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
-  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>
@@ -25,12 +22,5 @@
   <p>
     <%= _('If you have questions pertaining to this action, please visit the My Dashboard page in %{tool_name}' %{ :tool_name => tool_name }) %>
   </p>
-  <p>
-    <%= _('All the best') %>
-    <br />
-    <%= _('The %{tool_name} team') %{ :tool_name => tool_name } %>
-  </p>
-  <p>
-    <%=  _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us => link_to(contact_us, contact_us) }) %>
-  </p>
+  <%= render partial: 'email_signature' %>
 <% end %>

--- a/app/views/user_mailer/project_access_removed_notification.html.erb
+++ b/app/views/user_mailer/project_access_removed_notification.html.erb
@@ -1,6 +1,5 @@
 <% FastGettext.with_locale FastGettext.default_locale do %>
 <p><%= _('Hello ') %><%= @user.email %>,</p>
 <p><%= _('Your access to ') %>"<%= @plan.title %>"<%= _(' has been removed by ') %><%= "#{@current_user.name(false)}"%>.</p>
-<p><%=_('All the best,')%><br /><%= _('The ')%><%= Rails.configuration.branding[:application][:name] %><%=_(' team')%>.</p>
-
+<%= render partial: 'email_signature' %>
 <% end %>

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -2,7 +2,6 @@
   tool_name = Rails.configuration.branding[:application][:name]
   user_email = @user.email
   link = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
-  email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>
@@ -14,6 +13,6 @@
   <p>
     <%= raw(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') %{ :click_here => link_to(_('Click here'), link), :link => link }) %>
   </p>
-  <%= render partial: 'email_signature', locals: { email_subject: email_subject } %>
+  <%= render partial: 'email_signature' %>
 <% end %>
 

--- a/app/views/users/_notification_preferences.html.erb
+++ b/app/views/users/_notification_preferences.html.erb
@@ -26,7 +26,21 @@
         <%= check_box_tag 'prefs[users][admin_privileges]', true, @prefs[:users][:admin_privileges] %><%= _('Admin privileges granted to me')  %>
       </label>
     </div>
-  
+    <% if @user.org.present? && @user.org.feedback_enabled %>
+      <div class="checkbox">
+        <label for="prefs[users][feedback_requested]">
+          <%= hidden_field_tag 'prefs[users][feedback_requested]', false %>
+          <%= check_box_tag 'prefs[users][feedback_requested]', true, @prefs[:users][:feedback_requested] %><%= _('Feedback has been requested for my DMP') %>
+        </label>
+      </div>
+      <div class="checkbox">
+        <label for="prefs[users][feedback_provided]">
+          <%= hidden_field_tag 'prefs[users][feedback_provided]', false %>
+          <%= check_box_tag 'prefs[users][feedback_provided]', true, @prefs[:users][:feedback_provided] %><%= _('Feedback has been provided for my DMP')  %>
+        </label>
+      </div>
+    <% end %>
+
     <p class="form-control-static"><strong>DMP owners and co-owners</strong></p>
   
     <div class="checkbox">

--- a/config/branding_example.yml
+++ b/config/branding_example.yml
@@ -47,6 +47,8 @@ defaults: &defaults
         new_comment: true
         admin_privileges: true
         added_as_coowner: true
+        feedback_requested: true
+        feedback_provided: true 
       owners_and_coowners:
         visibility_changed: true
       admins:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,4 +267,14 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
         get 'index/:page', action: :index, on: :collection, as: :index
       end
     end
+
+    # ORG ADMIN specific pages
+    namespace :org_admin do
+      resources :plans, only: [:index] do
+        member do
+          get 'feedback_complete'
+        end
+      end
+    end
+
 end

--- a/db/migrate/20171122195828_change_prefs_settings_to_text.rb
+++ b/db/migrate/20171122195828_change_prefs_settings_to_text.rb
@@ -1,0 +1,9 @@
+class ChangePrefsSettingsToText < ActiveRecord::Migration
+  def up
+    change_column :prefs, :settings, :text
+  end
+
+  def down
+    change_column :prefs, :settings, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171102185518) do
+ActiveRecord::Schema.define(version: 20171122195828) do
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "question_id", limit: 4
@@ -35,9 +35,9 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.integer  "lock_version", limit: 4,     default: 0
   end
 
-  add_index "answers", ["plan_id"], name: "fk_rails_84a6005a3e"
-  add_index "answers", ["question_id"], name: "fk_rails_3d5ed4418f"
-  add_index "answers", ["user_id"], name: "fk_rails_584be190c2"
+  add_index "answers", ["plan_id"], name: "fk_rails_84a6005a3e", using: :btree
+  add_index "answers", ["question_id"], name: "fk_rails_3d5ed4418f", using: :btree
+  add_index "answers", ["user_id"], name: "fk_rails_584be190c2", using: :btree
 
   create_table "answers_question_options", id: false, force: :cascade do |t|
     t.integer "answer_id",          limit: 4, null: false
@@ -84,9 +84,9 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.datetime "created_at"
   end
 
-  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", unique: true
-  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
-  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
+  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", unique: true, using: :btree
+  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
 
   create_table "guidance_groups", force: :cascade do |t|
     t.string   "name",            limit: 255
@@ -149,8 +149,8 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.integer  "identifier_scheme_id", limit: 4
   end
 
-  add_index "org_identifiers", ["identifier_scheme_id"], name: "fk_rails_189ad2e573"
-  add_index "org_identifiers", ["org_id"], name: "fk_rails_36323c0674"
+  add_index "org_identifiers", ["identifier_scheme_id"], name: "fk_rails_189ad2e573", using: :btree
+  add_index "org_identifiers", ["org_id"], name: "fk_rails_36323c0674", using: :btree
 
   create_table "org_token_permissions", force: :cascade do |t|
     t.integer  "org_id",                   limit: 4
@@ -187,8 +187,8 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.text     "feedback_email_msg",     limit: 65535
   end
 
-  add_index "orgs", ["language_id"], name: "fk_rails_5640112cab"
-  add_index "orgs", ["region_id"], name: "fk_rails_5a6adf6bab"
+  add_index "orgs", ["language_id"], name: "fk_rails_5640112cab", using: :btree
+  add_index "orgs", ["region_id"], name: "fk_rails_5a6adf6bab", using: :btree
 
   create_table "perms", force: :cascade do |t|
     t.string   "name",       limit: 255
@@ -196,8 +196,8 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.datetime "updated_at",             null: false
   end
 
-  add_index "perms", ["name"], name: "index_perms_on_name"
-  add_index "perms", ["name"], name: "index_roles_on_name_and_resource_type_and_resource_id"
+  add_index "perms", ["name"], name: "index_perms_on_name", using: :btree
+  add_index "perms", ["name"], name: "index_roles_on_name_and_resource_type_and_resource_id", using: :btree
 
   create_table "phases", force: :cascade do |t|
     t.string   "title",       limit: 255
@@ -210,7 +210,7 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.boolean  "modifiable"
   end
 
-  add_index "phases", ["template_id"], name: "index_phases_on_template_id"
+  add_index "phases", ["template_id"], name: "index_phases_on_template_id", using: :btree
 
   create_table "plans", force: :cascade do |t|
     t.string   "title",                             limit: 255
@@ -225,7 +225,7 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.string   "principal_investigator_identifier", limit: 255
     t.string   "data_contact",                      limit: 255
     t.string   "funder_name",                       limit: 255
-    t.integer  "visibility",                        limit: 4,     null: false
+    t.integer  "visibility",                        limit: 4,                     null: false
     t.string   "data_contact_email",                limit: 255
     t.string   "data_contact_phone",                limit: 255
     t.string   "principal_investigator_email",      limit: 255
@@ -233,15 +233,15 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.boolean  "feedback_requested",                              default: false
   end
 
-  add_index "plans", ["template_id"], name: "index_plans_on_template_id"
+  add_index "plans", ["template_id"], name: "index_plans_on_template_id", using: :btree
 
   create_table "plans_guidance_groups", force: :cascade do |t|
     t.integer "guidance_group_id", limit: 4
     t.integer "plan_id",           limit: 4
   end
 
-  add_index "plans_guidance_groups", ["guidance_group_id"], name: "fk_rails_ec1c5524d7"
-  add_index "plans_guidance_groups", ["plan_id"], name: "fk_rails_13d0671430"
+  add_index "plans_guidance_groups", ["guidance_group_id"], name: "fk_rails_ec1c5524d7", using: :btree
+  add_index "plans_guidance_groups", ["plan_id"], name: "fk_rails_13d0671430", using: :btree
 
   create_table "prefs", force: :cascade do |t|
     t.string  "settings", limit: 255
@@ -280,8 +280,8 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.boolean  "modifiable"
   end
 
-  add_index "questions", ["question_format_id"], name: "fk_rails_4fbc38c8c7"
-  add_index "questions", ["section_id"], name: "index_questions_on_section_id"
+  add_index "questions", ["question_format_id"], name: "fk_rails_4fbc38c8c7", using: :btree
+  add_index "questions", ["section_id"], name: "index_questions_on_section_id", using: :btree
 
   create_table "questions_themes", id: false, force: :cascade do |t|
     t.integer "question_id", limit: 4, null: false
@@ -321,7 +321,7 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.boolean  "modifiable"
   end
 
-  add_index "sections", ["phase_id"], name: "index_sections_on_phase_id"
+  add_index "sections", ["phase_id"], name: "index_sections_on_phase_id", using: :btree
 
   create_table "settings", force: :cascade do |t|
     t.string   "var",         limit: 255,   null: false
@@ -332,7 +332,7 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.datetime "updated_at",                null: false
   end
 
-  add_index "settings", ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true
+  add_index "settings", ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true, using: :btree
 
   create_table "splash_logs", force: :cascade do |t|
     t.string   "destination", limit: 255
@@ -357,8 +357,8 @@ ActiveRecord::Schema.define(version: 20171102185518) do
     t.boolean  "dirty",                          default: false
   end
 
-  add_index "templates", ["org_id", "dmptemplate_id"], name: "template_organisation_dmptemplate_index"
-  add_index "templates", ["org_id"], name: "index_templates_on_org_id"
+  add_index "templates", ["org_id", "dmptemplate_id"], name: "template_organisation_dmptemplate_index", using: :btree
+  add_index "templates", ["org_id"], name: "index_templates_on_org_id", using: :btree
 
   create_table "themes", force: :cascade do |t|
     t.string   "title",       limit: 255
@@ -440,42 +440,42 @@ ActiveRecord::Schema.define(version: 20171102185518) do
   add_index "users_perms", ["perm_id"], name: "fk_rails_457217c31c", using: :btree
   add_index "users_perms", ["user_id"], name: "index_users_perms_on_user_id", using: :btree
 
-  add_foreign_key "annotations", "orgs"
-  add_foreign_key "annotations", "questions"
-  add_foreign_key "answers", "plans"
-  add_foreign_key "answers", "questions"
-  add_foreign_key "answers", "users"
-  add_foreign_key "answers_question_options", "answers"
-  add_foreign_key "answers_question_options", "question_options"
-  add_foreign_key "guidance_groups", "orgs"
-  add_foreign_key "guidances", "guidance_groups"
-  add_foreign_key "notes", "answers"
-  add_foreign_key "notes", "users"
-  add_foreign_key "org_identifiers", "identifier_schemes"
-  add_foreign_key "org_identifiers", "orgs"
-  add_foreign_key "org_token_permissions", "orgs"
-  add_foreign_key "org_token_permissions", "token_permission_types"
-  add_foreign_key "orgs", "languages"
-  add_foreign_key "orgs", "regions"
-  add_foreign_key "phases", "templates"
-  add_foreign_key "plans", "templates"
-  add_foreign_key "plans_guidance_groups", "guidance_groups"
-  add_foreign_key "plans_guidance_groups", "plans"
-  add_foreign_key "question_options", "questions"
-  add_foreign_key "questions", "question_formats"
-  add_foreign_key "questions", "sections"
-  add_foreign_key "questions_themes", "questions"
-  add_foreign_key "questions_themes", "themes"
-  add_foreign_key "roles", "plans"
-  add_foreign_key "roles", "users"
-  add_foreign_key "sections", "phases"
-  add_foreign_key "templates", "orgs"
-  add_foreign_key "themes_in_guidance", "guidances"
-  add_foreign_key "themes_in_guidance", "themes"
-  add_foreign_key "user_identifiers", "identifier_schemes"
-  add_foreign_key "user_identifiers", "users"
-  add_foreign_key "users", "languages"
-  add_foreign_key "users", "orgs"
-  add_foreign_key "users_perms", "perms"
+  add_foreign_key "annotations", "orgs"		
+  add_foreign_key "annotations", "questions"		
+  add_foreign_key "answers", "plans"		
+  add_foreign_key "answers", "questions"		
+  add_foreign_key "answers", "users"		
+  add_foreign_key "answers_question_options", "answers"		
+  add_foreign_key "answers_question_options", "question_options"		
+  add_foreign_key "guidance_groups", "orgs"		
+  add_foreign_key "guidances", "guidance_groups"		
+  add_foreign_key "notes", "answers"		
+  add_foreign_key "notes", "users"		
+  add_foreign_key "org_identifiers", "identifier_schemes"		
+  add_foreign_key "org_identifiers", "orgs"		
+  add_foreign_key "org_token_permissions", "orgs"		
+  add_foreign_key "org_token_permissions", "token_permission_types"		
+  add_foreign_key "orgs", "languages"		
+  add_foreign_key "orgs", "regions"		
+  add_foreign_key "phases", "templates"		
+  add_foreign_key "plans", "templates"		
+  add_foreign_key "plans_guidance_groups", "guidance_groups"		
+  add_foreign_key "plans_guidance_groups", "plans"		
+  add_foreign_key "question_options", "questions"		
+  add_foreign_key "questions", "question_formats"		
+  add_foreign_key "questions", "sections"		
+  add_foreign_key "questions_themes", "questions"		
+  add_foreign_key "questions_themes", "themes"		
+  add_foreign_key "roles", "plans"		
+  add_foreign_key "roles", "users"		
+  add_foreign_key "sections", "phases"		
+  add_foreign_key "templates", "orgs"		
+  add_foreign_key "themes_in_guidance", "guidances"		
+  add_foreign_key "themes_in_guidance", "themes"		
+  add_foreign_key "user_identifiers", "identifier_schemes"		
+  add_foreign_key "user_identifiers", "users"		
+  add_foreign_key "users", "languages"		
+  add_foreign_key "users", "orgs"		
+  add_foreign_key "users_perms", "perms"		
   add_foreign_key "users_perms", "users"
 end

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -61,6 +61,20 @@ thead th {
     }
 }
 
+/* NOTIFICATION TABLE STYLING */
+.notifications {
+  table { 
+    border: none;
+
+    thead > tr > th { 
+      border: none; 
+      background-color: $white;
+      color: $black; 
+     }
+     tbody > tr > td { border: none; }
+  }
+}
+
 /* TABS STYLING */
 
 .nav-tabs{

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -8,6 +8,9 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     @user = User.last
 
     scaffold_plan
+    # Assign the user to the plan as a commenter/reader
+    @plan.assign_reader(@user.id)
+    @plan.save!
 
     @question = Question.create(text: 'Answer Testing', number: 9,
                                 section: @plan.template.phases.first.sections.first,

--- a/test/functional/phases_controller_test.rb
+++ b/test/functional/phases_controller_test.rb
@@ -76,14 +76,15 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "get the phase's status" do
     # Should redirect user to the root path if they are not logged in!
-    get status_plan_phase_path(plan_id: @plan.id, id: @template.phases.first.id)
+    get status_plan_phase_path(plan_id: @plan.id, id: @template.phases.first.id), format: :json
     assert_unauthorized_redirect_to_root_path
     
+    @plan.assign_creator(@user)
+    @plan.save!
     sign_in @user
     
-    get status_plan_phase_path(@plan, @template.phases.first), format: :json
+    get status_plan_phase_path(plan_id: @plan.id, id: @template.phases.first.id), format: :json
     assert_response :success
-    
     assert assigns(:plan)
   end
   


### PR DESCRIPTION
- Add Plans page to Org Admin section #434
- Add 'Complete' action to feedback notification area or Org Admin plans page #728
- Refactored old methods used to check a user's access level for a plan (e.g. Plan.readable_by?) They did not allow for multiple roles
- Added new Email preferences for `[users][feedback_requested]` and `[users][feedback_provided]`
- Refactored emails to use the _email_signature partial
- Fixed Notes Controller which was not assigning a role for the test user on the test plan

**Run db:migrate and update you branding.yml with the new email prefs**