### PR TITLE
added missing index for questions_themes

### DIFF
--- a/db/migrate/20171130195230_add_theme_id_index_to_questions_themes.rb
+++ b/db/migrate/20171130195230_add_theme_id_index_to_questions_themes.rb
@@ -1,0 +1,5 @@
+class AddThemeIdIndexToQuestionThemes < ActiveRecord::Migration
+  def change
+    add_index "questions_themes", ["theme_id"], name: "index_questions_themes_on_theme_id", using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -274,6 +274,7 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   end
 
   add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id", using: :btree
+  add_index "questions_themes", ["theme_id"], name: "index_questions_themes_on_theme_id", using: :btree
 
   create_table "regions", force: :cascade do |t|
     t.string  "abbreviation"


### PR DESCRIPTION
While working with the dmptool migration data I noticed that one of the join tables was missing an index.
