### PR TITLE
added lists to plugins and set max container height

### DIFF
--- a/lib/assets/javascripts/utils/tinymce.js
+++ b/lib/assets/javascripts/utils/tinymce.js
@@ -4,6 +4,7 @@ import tinymce from 'tinymce/tinymce';
 import 'tinymce/themes/modern/theme';
 // Plugins
 import 'tinymce/plugins/table';
+import 'tinymce/plugins/lists';
 import 'tinymce/plugins/autoresize';
 import 'tinymce/plugins/link';
 import 'tinymce/plugins/paste';
@@ -23,7 +24,7 @@ export const defaultOptions = {
   statusbar: false,
   menubar: false,
   toolbar: 'bold italic | bullist numlist | link | table',
-  plugins: 'table autoresize link paste advlist',
+  plugins: 'table autoresize link paste advlist lists',
   advlist_bullet_styles: 'circle,disc,square', // Only disc bullets display on htmltoword
   target_list: false,
   autoresize_min_height: 130,
@@ -36,6 +37,7 @@ export const defaultOptions = {
   paste_remove_styles_if_webkit: true,
   paste_remove_spans: true,
   paste_strip_class_attributes: 'all',
+  max_height: 350,
   table_default_attributes: {
     border: 1,
   },


### PR DESCRIPTION
Tinymce references bulleted/numbered lists in its toolbar declaration but was not loading the plugin for them. Added the plugin to the JS config. #885

Also set a max height on the container in an attempt to correct an issue we have begun seeing where the editor box's height makes it span beyond the full page height until you click on it (it receives focus) at which point it resizes to the normal height #874