### PR TITLE
Issue 859

### DIFF
--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -30,7 +30,9 @@ class Phase < ActiveRecord::Base
 
   validates :title, :number, :template, presence: {message: _("can't be blank")}
 
-  
+  scope :titles, -> (template_id) {
+    Phase.where(template_id: template_id).select(:id, :title)
+  }
   # EVALUATE CLASS AND INSTANCE METHODS BELOW
   #
   # What do they do? do they do it efficiently, and do we need them?

--- a/app/views/plans/_navigation.html.erb
+++ b/app/views/plans/_navigation.html.erb
@@ -1,11 +1,12 @@
+<% phases = Phase.titles(plan.template.id) %>
 <ul class="nav nav-tabs" role="tablist">
   <li role="presentation" class="<%= (isActivePage(plan_path(plan)) ? 'active' : '') %>">
     <a href="<%= plan_path(plan) %>" role="tab" aria-controls="content"><%= _('Project Details') %></a>
   </li>
-  <% plan.template.phases.each do |phase| %>
+  <% phases.each do |phase| %>
     <li role="presentation" class="<%= (isActivePage(edit_plan_phase_path(plan, phase)) ? 'active' : '') %>">
       <a href="<%= edit_plan_phase_path(plan, phase) %>" role="tab" aria-controls="content">
-        <%= (plan.template.phases.length > 1 ? phase.title : _('Write Plan')) %>
+        <%= (phases.size > 1 ? phase.title : _('Write Plan')) %>
       </a>
     </li>
   <% end %>


### PR DESCRIPTION
Plan answers including multi-phase tab. DMPRoadmap/roadmap#859

After introducing Plan.load_for_phase, only one phase was pre-fetched from a template, therefore there was no distinction between multi phase plan vs single phase plan. This temporary fix ensures that all phase titles and ids are retrieved for a given template.


