### PR TITLE
Added ability to set template visibility for funders

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -4,7 +4,7 @@ class PublicPagesController < ApplicationController
   # GET template_index
   # -----------------------------------------------------
   def template_index
-    template_ids = Template.where(org_id: Org.funders.pluck(:id)).valid.pluck(:dmptemplate_id).uniq << Template.where(is_default: true, published: true).pluck(:dmptemplate_id)
+    template_ids = Template.where(org_id: Org.funders.pluck(:id), visibility: Template.visibilities[:publicly_visible]).valid.pluck(:dmptemplate_id).uniq << Template.where(is_default: true, published: true).pluck(:dmptemplate_id)
     @templates = []
     template_ids.flatten.each do |tid|
       t = Template.live(tid)

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -274,6 +274,14 @@ class TemplatesController < ApplicationController
 
       @template.description = params["template-desc"]
       @template.links = JSON.parse(params["template-links"]) if params["template-links"].present?
+
+      # If the visibility checkbox is not checked and the user's org is a funder set the visibility to public
+      # otherwise default it to organisationally_visible
+      if current_user.org.funder? && params[:template_visibility].nil?
+        @template.visibility = Template.visibilities[:publicly_visible]
+      else
+        @template.visibility = Template.visibilities[:organisationally_visible]
+      end
       
       if @template.update_attributes(params[:template])
         flash[:notice] = success_message(_('template'), _('saved'))

--- a/app/views/templates/_edit_template.html.erb
+++ b/app/views/templates/_edit_template.html.erb
@@ -13,6 +13,14 @@
   </div>
 
   <div class="form-group col-xs-8">
+    <%= f.label _('Visibility'), class: 'control-label' %>
+    <div class="checkbox">
+      <%= f.label(:visibility,
+          raw("#{check_box_tag('template_visibility', '0', (template.visibility == 'organisationally_visible'))} #{_('for internal %{org_name} use only') % {org_name: @template.org.name}}")) %>
+    </div>
+  </div>
+
+  <div class="form-group col-xs-8">
     <%= label_tag(:status, _('Status'), class: "control-label") %>
       <p class="form-control-static">
         <% if template_hash[:live].nil? %>

--- a/app/views/templates/_show_template.html.erb
+++ b/app/views/templates/_show_template.html.erb
@@ -18,6 +18,10 @@
       <%= _('Published') %>
     <% end %>
   </dd>
+  <% if template.org.funder? %>
+    <dt><%= _('Visibility') %></dt>
+    <dd><%= (template.visibility == 'organisationally_visible' ? _('for internal %{org_name} use only') % {org_name: @template.org.name} : _('available to the public') + (template_hash[:live].nil? ? ' (once published)' : '')) %></dd>
+  <% end %>
   <dt><%= _('Created at') %></dt>
   <dd><%= l template.created_at.to_date, formats: :short %></dd>
   <dt><%= _('Last updated') %></dt>

--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -1,5 +1,10 @@
 namespace :bugfix do
 
+  desc "Upgrade to 1.0"
+  task v1_0_0: :environment do
+    Rake::Task['bugfix:set_template_visibility'].execute
+  end
+
   desc "Bug fixes for version v0.3.3"
   task v0_3_3: :environment do
     Rake::Task['bugfix:fix_question_formats'].execute
@@ -46,4 +51,11 @@ namespace :bugfix do
     end
   end
 
+  desc "Set all funder templates (and the default template) to 'public' visibility and all others to 'organisational'"
+  task set_template_visibility: :environment do
+    funders = Org.funders.pluck(:id)
+    Template.update_all visibility: Template.visibilities[:organisationally_visible]
+    Template.where(org_id: funders).update_all visibility: Template.visibilities[:publicly_visible]
+    Template.default.update visibility: Template.visibilities[:publicly_visible]
+  end
 end


### PR DESCRIPTION
per issue #845
- enabled use of existing templates.visibility field
- updated edit/show template details page to show checkbox 
- updated public DMP Templates page to look at visibility when generating list
- added rake task to automatically set funder templates and the default template to publicly_visible and all others to organisationally_visible