### PR TITLE
Issue 893

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -66,9 +66,8 @@ class Answer < ActiveRecord::Base
       else  # (e.g. textarea or textfield question formats)
         return self.text.present?
       end
-    else
-      return false
     end
+    return false
   end
   # Returns all the notes for an instance answer whose archived is nil or false. The Array is ordered by updated_at (descending)
   def non_archived_notes

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -20,13 +20,6 @@ class Plan < ActiveRecord::Base
 
   has_many :roles
 
-  # Active Record Callbacks
-  # Creates answers for plan question and persists them whenever a new plan is created and successfully saved
-  after_create do
-    Answer.create(
-      self.questions.map{ |q| { lock_version: 1, text: q.default_value, plan_id: self.id, question_id: q.id }})
-  end
-
 # COMMENTED OUT THE DIRECT CONNECTION HERE TO Users to prevent assignment of users without an access_level specified (currently defaults to creator)
 #  has_many :users, through: :roles
 
@@ -754,6 +747,11 @@ class Plan < ActiveRecord::Base
   def visibility_allowed?
     value=(self.num_answered_questions().to_f/self.num_questions()*100).round(2)
     !self.is_test? && value >= Rails.application.config.default_plan_percentage_answered
+  end
+
+  # Determines whether or not a question (given its id) exists for the self plan
+  def question_exists?(question_id)
+    Plan.joins(:questions).exists?(id: self.id, "questions.id": question_id)
   end
 
   private

--- a/app/policies/answer_policy.rb
+++ b/app/policies/answer_policy.rb
@@ -8,7 +8,7 @@ class AnswerPolicy < ApplicationPolicy
     @answer = answer
   end
 
-  def update?
+  def create_or_update?
     # TODO: Remove the owner check after the Roles have been updated
     # is the plan editable by the user or the user is the owner of the plan
     @answer.plan.editable_by?(@user.id) || @user == @answer.plan.owner

--- a/app/views/answers/_new_edit.html.erb
+++ b/app/views/answers/_new_edit.html.erb
@@ -2,11 +2,9 @@
 <!--
   This partial creates a form for each type of question. The local variables are: plan, answer, question, readonly
 -->
-<%= form_for answer, url: {controller: :answers, action: :update}, html: {method: :put, 'data-autosave': question.id, class: 'form-answer' } do |f| %>
+<%= form_for answer, url: {controller: :answers, action: :create_or_update}, html: {method: :post, 'data-autosave': question.id, class: 'form-answer' } do |f| %>
   <% if !readonly %>
-    <%= f.hidden_field :id %>
     <%= f.hidden_field :plan_id %>
-    <%= f.hidden_field :user_id %>
     <%= f.hidden_field :question_id %>
     <%= f.hidden_field :lock_version %>
   <% end %>

--- a/app/views/answers/_status.html.erb
+++ b/app/views/answers/_status.html.erb
@@ -4,10 +4,9 @@
     <%= _('Saving...')%>
 </p>
 <p class="bg-warning unsaved-message" style="display: none;"></p>
-<% if answer.is_valid? && answer.user.present? %>
-    <% if answer.updated_at.present? %>
-      <p class="bg-info">
-        <%= _('Answered')%> <time class="timeago" datetime="<%= answer.updated_at.iso8601 %>"></time><%= _(' by')%> <%= answer.user.name %>
-      </p>
-    <% end %>
+<% if answer.is_valid? %>
+    <p class="bg-info">
+      <%= _('Answered')%> <time class="timeago" datetime="<%= answer.updated_at.iso8601 %>"></time>
+      <%= _(' by %{user_name}') %{ :user_name => answer.user.name } if answer.user.present? %>
+    </p>
 <% end %>

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -65,9 +65,8 @@
                 answers = question.plan_answers(plan.id)  if plan.present?
                 if answers.present?
                   answer = answers.first
-                  answer.user_id = current_user.id
                 else
-                  answer = Answer.new({ plan: plan, question: question, user: current_user, text: question.default_value })
+                  answer = Answer.new({ plan: plan, question: question })
                 end
               %>
               <div class="row">

--- a/app/views/questions/_new_edit_question_textarea.html.erb
+++ b/app/views/questions/_new_edit_question_textarea.html.erb
@@ -1,5 +1,5 @@
 <%# locals: { f, question, answer } %>
 <div class="form-group">
     <%= f.label(:text, raw(question.text), class: 'control-label') %>
-    <%= text_area_tag('answer[text]', answer.text, id: "answer-text-#{question.id}", class: "form-control tinymce_answer") %>
+    <%= text_area_tag('answer[text]', answer.text || question.default_value, id: "answer-text-#{question.id}", class: "form-control tinymce_answer") %>
 </div>

--- a/app/views/questions/_new_edit_question_textfield.html.erb
+++ b/app/views/questions/_new_edit_question_textfield.html.erb
@@ -1,5 +1,5 @@
 <%# locals: { f, question, answer } %>
 <div class="form-group">
     <%= f.label(:text, raw(question.text), class: 'control-label') %>
-    <%= text_field_tag('answer[text]', strip_tags(answer.text), class: 'form-control') %>
+    <%= text_field_tag('answer[text]', strip_tags(answer.text || question.default_value), class: 'form-control') %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,9 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
       end
     end
 
-    resources :answers, only: :update
+    resources :answers, only: [] do
+      post 'create_or_update', on: :collection
+    end
 
     resources :notes, only: [:create, :update, :archive] do
       member do

--- a/test/functional/answers_controller_test.rb
+++ b/test/functional/answers_controller_test.rb
@@ -6,13 +6,11 @@ class AnswersControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     @user = User.last
-
     scaffold_plan
   end
 
-  # PUT/PATCH /answer/[:id]
-  # ----------------------------------------------------------
-  test "should be able to update an answer" do
+  # POST /answers/create_or_update
+  test "should be able to create an answer" do
     sign_in @user
 
     # Test an answer for each Querstion Format
@@ -24,35 +22,25 @@ class AnswersControllerTest < ActionDispatch::IntegrationTest
                          template: template, visibility: :is_test)
 
       Role.create!(user_id: @user.id, plan_id: plan.id, access: 4)
-      plan.reload
 
-      referrer = "/#{FastGettext.locale}/plans/#{plan.id}/phases/#{question.section.phase.id}/edit"
-
-      answer = Answer.find_by(plan: plan, question: question)
-      assert_not answer.id.nil?, "expected the answer to have been created and for an id to be present after creating a #{format.title} question!"
-
-      # Try editing it
       form_attributes = {
-                          answer: {id: answer.id,
-                            user_id: @user.id,
-                            plan_id: answer.plan.id,
-                            question_id: answer.question.id,
+                          answer: {
+                            plan_id: plan.id,
+                            question_id: question.id,
                             text: "Tested",
-                            lock_version: answer.lock_version}
+                            lock_version: 0 }
                           }
         
-      put_answer(answer, form_attributes, referrer)
-      answer.reload
+      post_create_or_update_answer(form_attributes)
+      answer = Answer.find_by(plan: plan, question: question)
       assert_not answer.id.nil?, "expected the answer to have been updated and for an id to be present after creating a #{format.title} question!"
       assert_equal "Tested", answer.text, "expected the text to have been updated for a #{format.title} question!"
     end
   end
 
-
   private
-    def put_answer(answer, attributes, referrer)
-      put answer_path(FastGettext.locale, answer, format: "json"), attributes, {'HTTP_REFERER': referrer}
-
+    def post_create_or_update_answer(attributes)
+      post create_or_update_answers_path(params: attributes)
       assert_response :success
       assert_equal "application/json", @response.content_type
     end

--- a/test/integration/answer_locking_test.rb
+++ b/test/integration/answer_locking_test.rb
@@ -9,37 +9,42 @@ class AnswerLockingTest < ActionDispatch::IntegrationTest
     @question = Question.create(text: 'Test question', section: @plan.template.phases.first.sections.first,
                                 question_format: QuestionFormat.where(option_based: false).first, number: 99)
 
-    @collaborator = (User.first == @plan.owner ? User.last : User.first)
+    @owner = @plan.owner
+    users = User.all
+    @collaborator = users[users.find_index{ |u| u != @owner }]
 
     # Make the 2nd user an editor of the plan
     Role.create!(user_id: @collaborator.id, plan_id: @plan.id, access: 4)
     @plan.reload
   end
 
-  # ----------------------------------------------------------
-  test 'user receives not found when trying to save a non-existent answer' do
-    userA = Answer.new(user: @plan.owner, plan: @plan, question: @question,
-                       text: "Initial answer - by UserA")
+  test 'answer#create_or_update responds not_found when a plan does not exist' do
+    userA = Answer.create!(user: @owner, question: @question,
+                           text: "Initial answer - by UserA").attributes
+    sign_in @owner
+    params = obj_to_params(userA)
+    params[:answer][:plan_id] = 'foo'
+    post create_or_update_answers_path(params)
+    assert_response :not_found
+    assert_equal(_('There is no plan with id %{id} for which to create or update an answer') %{ :id => 'foo' }, ActiveSupport::JSON.decode(@response.body)['msg'])
+  end
 
-    userB = Answer.new(user: @collaborator, plan: @plan, question: @question,
-                       text: "Version conflict at onset - by UserB")
-
-    # Signin as UserA and insert the new answer
-    sign_in @plan.owner
-    put answer_path(FastGettext.locale, userA, format: "json"), obj_to_params(userA.attributes)
-    assert_response :success
-    assert_equal "application/json", @response.content_type
-
-    # Signin as UserB and try to insert the new answer but fail
-    sign_in @collaborator
-    put answer_path(FastGettext.locale, userB, format: "json"), obj_to_params(userB.attributes)
-    assert_response :success
-    assert_equal "application/json", @response.content_type
+  test 'answer#create_or_update responds not found when a question does not exist for a plan' do
+    userA = Answer.create!(user: @owner, plan: @plan,
+                           text: "Initial answer - by UserA").attributes
+    sign_in @owner
+    params = obj_to_params(userA)
+    params[:answer][:question_id] = 'foo'
+    post create_or_update_answers_path(params)
+    assert_response :not_found
+    assert_equal(
+      _("There is no question with id %{question_id} associated to plan id %{plan_id}"\
+        "for which to create or update an answer") %{ :question_id => 'foo', :plan_id => @plan.id }, ActiveSupport::JSON.decode(@response.body)['msg'])
   end
 
   # ----------------------------------------------------------
   test 'user receives a lock notification if the answer was UPDATED while they were working' do
-    userA = Answer.create!(user: @plan.owner, plan: @plan, question: @question,
+    userA = Answer.create!(user: @owner, plan: @plan, question: @question,
                            text: "Initial answer - by UserA").attributes
     userB = userA.clone
 
@@ -47,7 +52,7 @@ class AnswerLockingTest < ActionDispatch::IntegrationTest
     sign_in @plan.owner
     userA['text'] += " - Updated by userA"
 
-    put answer_path(FastGettext.locale, userA['id'], format: "json"), obj_to_params(userA)
+    post create_or_update_answers_path(obj_to_params(userA))
     assert_response :success
     assert_equal "application/json", @response.content_type
     updated = Answer.find_by(plan: @plan, question: @question)
@@ -63,7 +68,7 @@ class AnswerLockingTest < ActionDispatch::IntegrationTest
     sign_in @collaborator
     userB['text'] += " - Updated by userB"
 
-    put answer_path(FastGettext.locale, userB['id'], format: "json"), obj_to_params(userB)
+    post create_or_update_answers_path(obj_to_params(userB))
     assert_response :success
     assert_equal "application/json", @response.content_type
     updated = Answer.find_by(plan: @plan, question: @question)
@@ -80,12 +85,11 @@ class AnswerLockingTest < ActionDispatch::IntegrationTest
   private
     def obj_to_params(attributes)
       {
-       answer: {id: attributes['id'],
-                user_id: attributes['user_id'],
-                plan_id: attributes['plan_id'],
-                question_id: attributes['question_id'],
-                text: attributes['text'],
-                lock_version: attributes['lock_version']}
+       answer: {
+        plan_id: attributes['plan_id'],
+        question_id: attributes['question_id'],
+        text: attributes['text'],
+        lock_version: attributes['lock_version']}
       }
     end
 end

--- a/test/unit/answer_test.rb
+++ b/test/unit/answer_test.rb
@@ -150,4 +150,34 @@ class AnswerTest < ActiveSupport::TestCase
     note = Note.new(text: 'Test Note', user: @user)
     verify_has_many_relationship(@answer, note, @answer.notes.count)
   end
+
+  test 'is_valid? returns false when no question is associated to an answer' do
+    answer = Answer.new(user: @user, plan: @plan)
+    refute(answer.is_valid?)
+  end
+
+  test 'is_valid? returns false when an option based answer is empty' do
+    q = @plan.template.questions[@plan.template.questions.find_index{ |q| q.question_format.option_based? }]
+    answer = Answer.new(user: @user, plan: @plan, question: q)
+    refute(answer.is_valid?)
+  end
+
+  test 'is_valid? returns false when a non-option based answer is empty' do
+    q = @plan.template.questions[@plan.template.questions.find_index{ |q| !q.question_format.option_based? }]
+    answer = Answer.new(user: @user, plan: @plan, question: q)
+    refute(answer.is_valid?)
+  end
+
+  test 'is_valid? returns true when an option based answer is not empty' do
+    q = @plan.template.questions[@plan.template.questions.find_index{ |q| q.question_format.option_based? }]
+    answer = Answer.new(user: @user, plan: @plan, question: q)
+    answer.question_options << q.question_options.first
+    assert(answer.is_valid?)
+  end
+
+  test 'is_valid? returns true when a non-option based answer is not empty' do
+     q = @plan.template.questions[@plan.template.questions.find_index{ |q| !q.question_format.option_based? }]
+    answer = Answer.new(user: @user, plan: @plan, question: q, text: 'foo')
+    assert(answer.is_valid?)
+  end
 end


### PR DESCRIPTION
- removed after_create callback for answers since no longer is needed after introducing transactions. DMPRoadmap/roadmap#893
- unit test for answer#is_valid?. DMPRoadmap/roadmap#893
- answer#update based on current_user. input text for answer based on either answer.text or question.default_text. DMPRoadmap/roadmap#893
- renamed answers#update to answers#create_or_update and added new tests. DMPRoadmap/roadmap#893
