### PR TITLE
Fixes issue with bad join in Phase load

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -707,14 +707,16 @@ class Plan < ActiveRecord::Base
   end
 
   def self.load_for_phase(id, phase_id)
-    Plan.includes(
-      [template: [
-                   {phases: {sections: {questions: [{answers: :notes}, :annotations, :question_format, :themes]}}},
-                   {customizations: :org},
-                   :org
-                  ],
-       plans_guidance_groups: {guidance_group: {guidances: :themes}}
-      ]).where(id: id, phases: { id: phase_id }).first
+#    Plan.includes(
+#      [template: [
+#                   {phases: {sections: {questions: [{answers: :notes}, :annotations, :question_format, :themes]}}},
+#                   {customizations: :org},
+#                   :org
+#                  ],
+#       plans_guidance_groups: {guidance_group: {guidances: :themes}}
+#      ]).where(id: id, phases: { id: phase_id }).first
+
+    Plan.joins(:phases).where('plans.id = ? AND phases.id = ?', id, phase_id).includes(:template, :sections, :questions, :answers, :notes).first
   end
 
   # deep copy the given plan and all of it's associations


### PR DESCRIPTION
rewrote Plans.load_for_phase query
We discovered that the join from the old query was not considering the plan when retrieving answers. This resulted in a query that returned - (question * ([all answers from any plan]). The page logic was only displaying the correct records but the query itself was causing significant page load times. Here is the query: 
```
FROM `plans` 
  LEFT OUTER JOIN `templates` ON `templates`.`id` = `plans`.`template_id` 
  LEFT OUTER JOIN `phases` ON `phases`.`template_id` = `templates`.`id` 
  LEFT OUTER JOIN `sections` ON `sections`.`phase_id` = `phases`.`id` 
  LEFT OUTER JOIN `questions` ON `questions`.`section_id` = `sections`.`id` 
  LEFT OUTER JOIN `answers` ON `answers`.`question_id` = `questions`.`id` AND `answers`.`plan_id` = `plans`.`id` 
  LEFT OUTER JOIN `notes` ON `notes`.`answer_id` = `answers`.`id` 
  LEFT OUTER JOIN `annotations` ON `annotations`.`question_id` = `questions`.`id` 
  LEFT OUTER JOIN `question_formats` ON `question_formats`.`id` = `questions`.`question_format_id` 
  LEFT OUTER JOIN `questions_themes` ON `questions_themes`.`question_id` = `questions`.`id` 
  LEFT OUTER JOIN `themes` ON `themes`.`id` = `questions_themes`.`theme_id` 
  LEFT OUTER JOIN `templates` `customizations_templates` ON `customizations_templates`.`dmptemplate_id` = `templates`.`id` 
  LEFT OUTER JOIN `orgs` ON `orgs`.`id` = `customizations_templates`.`org_id` 
  LEFT OUTER JOIN `orgs` `orgs_templates` ON `orgs_templates`.`id` = `templates`.`org_id` 
  LEFT OUTER JOIN `plans_guidance_groups` ON `plans_guidance_groups`.`plan_id` = `plans`.`id` 
  LEFT OUTER JOIN `guidance_groups` ON `guidance_groups`.`id` = `plans_guidance_groups`.`guidance_group_id` 
  LEFT OUTER JOIN `guidances` ON `guidances`.`guidance_group_id` = `guidance_groups`.`id` 
  LEFT OUTER JOIN `themes_in_guidance` ON `themes_in_guidance`.`guidance_id` = `guidances`.`id` 
  LEFT OUTER JOIN `themes` `themes_guidances` ON `themes_guidances`.`id` = `themes_in_guidance`.`theme_id`
WHERE `plans`.`id` = 1234 AND `phases`.`id` = 123 AND `plans`.`id` IN (1234)
```

After further review it was also discovered that it was unnecessary to load the guidance_groups and associated guidance in this query since the controller loads it again afterward via the `Plan.guidance_groups` method