### PR TITLE
fixes org details redirect issue and duplicate email on feedback request

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -213,7 +213,7 @@ class Plan < ActiveRecord::Base
             UserMailer.feedback_confirmation(r, self, user).deliver_now
           end
           # Send an email to all of the org admins as well as the Org's administrator email
-          if user.org.contact_email.present?
+          if user.org.contact_email.present? && !admins.collect{ |u| u.email }.include?(user.org.contact_email)
             admins << User.new(email: user.org.contact_email, firstname: user.org.contact_name)
           end
           deliver_if(recipients: admins, key: 'admins.feedback_requested') do |r|


### PR DESCRIPTION
Addresses redirect error that was preventing Org Details page from saving #904. This is a temporary fix. The links are still not saving. I will address that issue tomorrow when converting to use the same logic that the funder links and sample plans use in #866 

Also addresses the duplicate email issue that happens when the Org's contact email is the same as an org admins. #895