### PR TITLE
Org Admins/Super Admins can view plans

### DIFF
--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -9,15 +9,15 @@ class NotePolicy < ApplicationPolicy
   end
 
   def create?
-    @note.answer.plan.readable_by?(@user.id)
+    @note.answer.plan.commentable_by?(@user.id)
   end
 
   def update?
-    Plan.find(@note.answer.plan_id).readable_by?(@user.id)
+    Plan.find(@note.answer.plan_id).commentable_by?(@user.id)
   end
 
   def archive?
-    Plan.find(@note.answer.plan_id).readable_by?(@user.id)
+    Plan.find(@note.answer.plan_id).commentable_by?(@user.id)
   end
 
 end

--- a/app/policies/plan_policy.rb
+++ b/app/policies/plan_policy.rb
@@ -10,62 +10,62 @@ class PlanPolicy < ApplicationPolicy
   end
 
   def show?
-    @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.readable_by?(@user.id)
   end
 
   def share?
-    @plan.editable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.editable_by?(@user.id)
   end
 
   def export?
-    @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.readable_by?(@user.id)
   end
 
   def download?
-    @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.readable_by?(@user.id)
   end
 
   def edit?
-    @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.readable_by?(@user.id)
   end
 
   def update?
-    @plan.editable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.editable_by?(@user.id)
   end
 
   def destroy?
-    @plan.editable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.editable_by?(@user.id)
   end
 
   def status?
-    @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.readable_by?(@user.id)
   end
 
   def duplicate?
-    @plan.editable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.editable_by?(@user.id)
   end
 
   def visibility?
-    @plan.administerable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.administerable_by?(@user.id)
   end
 
   def set_test?
-    @plan.administerable_by?(@user.id)&& Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.administerable_by?(@user.id)
   end
 
   def answer?
-    @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.readable_by?(@user.id)
   end
 
   def request_feedback?
-    @plan.administerable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.administerable_by?(@user.id)
   end
   
   def feedback_complete?
-    @plan.reviewable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.reviewable_by?(@user.id)
   end
 
   def overview?
-    @plan.readable_by?(@user.id) && Role.find_by(user_id: @user.id, plan_id: @plan.id).active
+    @plan.readable_by?(@user.id)
   end
 end

--- a/app/views/notes/_layout.html.erb
+++ b/app/views/notes/_layout.html.erb
@@ -5,17 +5,19 @@
     <%= render partial: "/notes/list", locals: { question_id: question.id, notes: notes, plan: plan }, formats: [:html] %>  
   </div>
 </div>
-<div class="row">
-  <div class="col-md-12">
-    <div class="note_new" id="<%= "note_new#{question.id}" %>" data-question-id="<%= question.id %>">
-        <%= render partial: "/notes/new", locals: { question: question, answer: answer, plan: plan }, formats: [:html] %>
+<% if plan.commentable_by?(current_user) %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="note_new" id="<%= "note_new#{question.id}" %>" data-question-id="<%= question.id %>">
+          <%= render partial: "/notes/new", locals: { question: question, answer: answer, plan: plan }, formats: [:html] %>
+      </div>
     </div>
   </div>
-</div>
-<div class="row">
-  <div class="col-md-12">
-    <div class="pull-right">
-      <%= link_to(_('Add Comment'), "#note_new#{question.id}", class: "btn btn-default note_new_link", role: "button", style: "visibility: hidden") %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-right">
+        <%= link_to(_('Add Comment'), "#note_new#{question.id}", class: "btn btn-default note_new_link", role: "button", style: "visibility: hidden") %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/notes/_list.html.erb
+++ b/app/views/notes/_list.html.erb
@@ -14,13 +14,15 @@
                         <div class="pull-right"><!-- note actions -->
                             <ul class="list-inline">
                                 <li><%= link_to(_('Show'), "#note_show#{note.id}", class: 'note_show_link') %></li>
-                                <% if current_user.id == note.user_id %>
-                                    <li><%= link_to(_('Edit'), "#note_edit#{note.id}", class: 'note_edit_link') %></li>
-                                    <li><%= link_to(_('Remove'), "#note_archive#{note.id}", class: 'note_archive_link') %></li>
-                                <% else  %>
-                                    <% if plan.administerable_by?(current_user.id) %>
-                                        <li><%= link_to(_('Remove'), "#note_archive#{note.id}", class: 'note_archive_link') %></li>
-                                    <% end %>
+                                <% if plan.commentable_by?(current_user) %>
+                                  <% if current_user.id == note.user_id %>
+                                      <li><%= link_to(_('Edit'), "#note_edit#{note.id}", class: 'note_edit_link') %></li>
+                                      <li><%= link_to(_('Remove'), "#note_archive#{note.id}", class: 'note_archive_link') %></li>
+                                  <% else  %>
+                                      <% if plan.administerable_by?(current_user.id) %>
+                                          <li><%= link_to(_('Remove'), "#note_archive#{note.id}", class: 'note_archive_link') %></li>
+                                      <% end %>
+                                  <% end %>
                                 <% end %>
                             </ul>
                         </div>

--- a/app/views/org_admin/plans/index.html.erb
+++ b/app/views/org_admin/plans/index.html.erb
@@ -59,7 +59,7 @@
             <% @plans.each do |plan| %>
               <tr>
                 <td>
-                  <%= "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}" %>
+                  <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
                 </td>
                 <td><%= plan.template.title %></td>
                 <td><%= plan.users.first.org.name %></td>

--- a/test/functional/plans_controller_test.rb
+++ b/test/functional/plans_controller_test.rb
@@ -102,7 +102,8 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test 'show the plan page' do
     # Should redirect user to the root path if they are not logged in!
-    try_no_user_and_unauthorized(plan_path(@plan))
+    get plan_path(@plan)
+    assert_unauthorized_redirect_to_root_path
 
     sign_in @user
     get plan_path(@plan)
@@ -230,7 +231,8 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "get the share plan page" do
     # Should redirect user to the root path if they are not logged in!
-    try_no_user_and_unauthorized(share_plan_path(@plan))
+    get share_plan_path(@plan)
+    assert_unauthorized_redirect_to_root_path
 
     sign_in @user
     get share_plan_path(@plan)
@@ -242,7 +244,8 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "get the plan status" do
     # Should redirect user to the root path if they are not logged in!
-    try_no_user_and_unauthorized(status_plan_path(@plan, format: :json))
+    get status_plan_path(@plan, format: :json)
+    assert_unauthorized_redirect_to_root_path
 
     sign_in @user
     get status_plan_path(@plan, format: :json)
@@ -254,7 +257,8 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "get the answer to the specified question for the plan" do
     # Should redirect user to the root path if they are not logged in!
-    try_no_user_and_unauthorized(answer_plan_path(@plan, format: :json))
+    get answer_plan_path(@plan, format: :json)
+    assert_unauthorized_redirect_to_root_path
 
     sign_in @user
     get answer_plan_path(@plan, format: :json)
@@ -266,7 +270,9 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "export the plan" do
     # Should redirect user to the root path if they are not logged in!
-    try_no_user_and_unauthorized(export_plan_path(@plan))
+    get export_plan_path(@plan), {'format': 'pdf'}
+    assert_unauthorized_redirect_to_root_path
+    
     export_params = {"utf8"=>"✓",
        "phase_id"=>"5470",
        "export"=>{"project_details"=>"true",
@@ -295,7 +301,8 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "show the download plan page" do
     # Should redirect user to the root path if they are not logged in!
-    try_no_user_and_unauthorized(download_plan_path(@plan))
+    get download_plan_path(@plan)
+    assert_unauthorized_redirect_to_root_path
 
     sign_in @user
     get download_plan_path(@plan)
@@ -320,19 +327,4 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     get overview_plan_path(@plan)
     assert_response(:success)
   end
-
-  private
-    def try_no_user_and_unauthorized(target)
-      # Should redirect user to the root path if they are not logged in!
-      get target
-      assert_unauthorized_redirect_to_root_path
-
-      # User who is does not have access to the plan
-      sign_in User.first
-      get target
-      assert_equal _('You are not authorized to perform this action.'), flash[:alert]
-      assert_response :redirect
-      assert_redirected_to plans_url
-    end
-
 end


### PR DESCRIPTION
addresses change request on #434 
- Made plan title on Admin -> Plans page a link to the plan details page
- Modified `plan.readable_by?` so that a super admin, org admin who belongs to the owner or one of the co-owners orgs can read the plan
- Added a new `plan.commentable_by?` method and updated the notes_controller and views to use it
- Removed Role.active checks from plans_policy and placed it in the Plan.has_role method