### PR TITLE
added funder links and sample plans to public templates page

### DIFF
--- a/app/helpers/template_helper.rb
+++ b/app/helpers/template_helper.rb
@@ -1,8 +1,8 @@
 module TemplateHelper
-  def links_to_a_elements(links)
+  def links_to_a_elements(links, separator = ', ')
     a = links.map do |l|
       "<a href=\"#{l['link']}\">#{l['text']}</a>"
     end
-    a.join(", ")
+    a.join(separator)
   end
 end

--- a/app/views/public_pages/template_index.html.erb
+++ b/app/views/public_pages/template_index.html.erb
@@ -18,7 +18,7 @@
         <thead>
          <% if @templates.count > TABLE_FILTER_MIN_ROWS %>
             <tr>
-              <th colspan="3" class="sorter-false">
+              <th colspan="5" class="sorter-false">
                 <%= render(partial: "shared/table_filter",
                            locals: {path: public_templates_path, placeholder: _('Filter templates')}) %>
               </th>
@@ -26,18 +26,27 @@
           <% end %>
           <tr>
             <th><%= _('Template Name') %></th>
-            <th><%= _('Organisation Name') %></th>
             <th class="sorter-false text-center"><%= _('Download') %></th>
+            <th><%= _('Organisation Name') %></th>
+            <th class="sorter-false"><%= _('Funder Links') %></th>
+            <th class="sorter-false"><%= _('Sample Plans') %></th>
           </tr>
         </thead>
         <tbody>
           <% @templates.each do |template| %>
             <tr>
               <td><%= template.title %></td>
-              <td><%= template.org.name %></td>
               <td class="text-center">
                 <%= link_to _('DOCX'), template_export_path(template.dmptemplate_id, format: :docx), target: '_blank' %>
+                <br>
                 <%= link_to _('PDF'), template_export_path(template.dmptemplate_id, format: :pdf), target: '_blank' %>
+              </td>
+              <td><%= template.org.name %></td>
+              <td>
+                <%= raw links_to_a_elements(template.links['funder'], '<br>') %>
+              </td>
+              <td>
+                <%= raw links_to_a_elements(template.links['sample_plan'], '<br>') %>
               </td>
             </tr>
           <% end %>

--- a/app/views/shared/_links.html.erb
+++ b/app/views/shared/_links.html.erb
@@ -26,7 +26,7 @@
           </div>
           <div class="form-group col-xs-5">
             <%= label_tag "link_text#{i}", _('Link text'), class: "control-label" %>
-            <%= text_field_tag 'link_text', l['link'], class: "form-control", id: "link_text#{i}" %>
+            <%= text_field_tag 'link_text', l['text'], class: "form-control", id: "link_text#{i}" %>
           </div>
           <div class="form-group col-xs-2">
             <a href="#" class="delete" aria-label="<%= _('Remove this link') %>">


### PR DESCRIPTION
- Added funder links and sample plans to the public DMPTemplates page #880 
- Updated `templates.links` field to be TEXT instead of VARCHAR (was not large enough to store more than one of each link type)
- Added default to `models/template.rb` since a BLOB/TEXT field is not able to have a default value in MySQL