### PR TITLE
Fixed Org Links & Banner now shows Org Name if no logo

### DIFF
--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -2,12 +2,14 @@ class Org < ActiveRecord::Base
   include GlobalHelpers
   include FlagShihTzu
   extend Dragonfly::Model::Validations
-
+  validates_with OrgLinksValidator
+  
   ##
   # Sort order: Name ASC
   default_scope { order(name: :asc) }
 
-  # Stores links as an JSON array: [{"link":"http://www.myorg.edu","text":"My Org"},...]
+  # Stores links as an JSON object: { org: [{"link":"www.example.com","text":"foo"}, ...] }
+  # The links are validated against custom validator allocated at validators/template_links_validator.rb
   serialize :links, JSON
 
   ##
@@ -34,7 +36,6 @@ class Org < ActiveRecord::Base
                   :language, :org_type, :region, :token_permission_types, 
                   :guidance_group_ids, :is_other, :region_id, :logo_uid, :logo_name,
                   :feedback_enabled, :feedback_email_subject, :feedback_email_msg
-
   ##
   # Validators
   validates :contact_email, email: true, allow_nil: true

--- a/app/validators/org_links_validator.rb
+++ b/app/validators/org_links_validator.rb
@@ -1,0 +1,13 @@
+class OrgLinksValidator < ActiveModel::Validator
+  include JSONLinkValidator
+  def validate(record)
+    links = record.links
+    if links.is_a?(Hash)
+      if !links.has_key?('org')
+        record.errors[:links] << _('A key "org" is expected for links hash') %{ :key => k }
+      end
+    else
+      record.errors[:links] << _('A hash is expected for links')
+    end
+  end
+end

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -8,25 +8,31 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <% if user_signed_in? && !current_user.org.nil? && current_user.org.logo.present? %>
-        <%= link_to(image_tag(current_user.org.logo.thumb('100x100%').url,
-                              alt: current_user.org.name,
-                              class: "org-logo",
-                              title: current_user.org.name),
-                    current_user.org.target_url) %>
+      <% if user_signed_in? && !current_user.org.nil? %>
+        <% if current_user.org.logo.present? %>
+          <%= link_to(image_tag(current_user.org.logo.thumb('100x100%').url,
+                                alt: current_user.org.name,
+                                class: "org-logo",
+                                title: current_user.org.name),
+                      current_user.org.target_url) %>
+        <% else %>
+          <h4 id="banner-org-name"><%= current_user.org.name %></h4>
+        <% end %>
       <% end %>
     </div>
 
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="org-navbar-menu">
-      <% if user_signed_in? && !current_user.org.nil? %>
-          <ul class="nav navbar-nav">
-            <% current_user.org.links.each do |url| %>
-              <% unless url['link'].blank? %>
-                <li><%= link_to (url['text'].blank? ? url['link'] : url['text']), url['link'] %>
+      <% if user_signed_in? && !current_user.org.nil? && current_user.org.links.present? %>
+        <% if current_user.org.links['org'].present? %>
+            <ul class="nav navbar-nav">
+              <% current_user.org.links['org'].each do |url| %>
+                <% unless url['link'].blank? %>
+                  <li><%= link_to (url['text'].blank? ? url['link'] : url['text']), url['link'] %>
+                <% end %>
               <% end %>
-            <% end %>
-          </ul>
+            </ul>
+        <% end %>
       <% end %>
 
     <!-- Navigation for organisation admin -->

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -30,25 +30,15 @@
     </div>
   </div>
 
-  <div id="org-link-section">
-    <%= f.hidden_field :links %>
-    <div class="row">
-      <div class="form-group col-xs-8">
-        <h3><%= _("Organisation URL") %> <small>(<%= _('Up to ') %><span id="max-nbr-urls"></span>)</small></h3>
-      </div>
-    </div>
-    <% if @org.links.length > 0 %>
-      <% @org.links.each do |url| %>
-        <%= render partial: 'org_link', locals: {link: url['link'], text: url['text']} %>
-      <% end %>
-    <% else %>
-      <%= render partial: 'org_link', locals: {link: '', text: ''} %>
-    <% end %>
-    <div class="row">
-      <div class="form-group col-xs-8">
-        <a href="#" id="add-org-link"><%= _('+ Add an additional URL') %></a>
-      </div>
-    </div>
+  <div class="form-group col-xs-8">
+    <%= render(partial: '/shared/links',
+               locals: { 
+                 context: 'org',
+                 title: _('Organisation URLs'),
+                 links: @org.links['org'],
+                 max_number_links: MAX_NUMBER_LINKS_FUNDER,
+                 tooltip: _('Links will be displayed next to your organisation\'s logo') }) %>
+    <%= hidden_field_tag('org_links', value: @org.links) %>
   </div>
 
   <div class="row">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -165,17 +165,16 @@ token_permission_types.map{ |tpt| TokenPermissionType.create!(tpt) if TokenPermi
 orgs = [
   {name: Rails.configuration.branding[:organisation][:name],
    abbreviation: Rails.configuration.branding[:organisation][:abbreviation],
-   banner_text: 'This is an example organisation',
-   org_type: 3,
+   org_type: 3, links: {"org":[]},
    language_id: Language.find_by(abbreviation: 'en_GB'),
    token_permission_types: TokenPermissionType.all},
   {name: 'Government Agency',
    abbreviation: 'GA',
-   org_type: 2,
+   org_type: 2, links: {"org":[]},
    language: Language.find_by(abbreviation: 'en_GB')},
   {name: 'University of Exampleland',
    abbreviation: 'UOS',
-   org_type: 1,
+   org_type: 1, links: {"org":[]},
    language: Language.find_by(abbreviation: 'en_GB')}
 ]
 orgs.map{ |o| Org.create!(o) if Org.find_by(abbreviation: o[:abbreviation]).nil? }
@@ -353,15 +352,19 @@ templates = [
    is_default: true,
    version: 0,
    migrated: false,
-   dmptemplate_id: 1},
+   dmptemplate_id: 1,
+   visibility: Template.visibilities[:publicly_visible],
+   links: '{"funder":[],"sample_plan":[]}'},
   
   {title: "OLD - Department of Testing Award",
-    published: false,
-    org: Org.find_by(abbreviation: 'GA'),
-    is_default: false,
-    version: 0,
-    migrated: false,
-   dmptemplate_id: 2},
+   published: false,
+   org: Org.find_by(abbreviation: 'GA'),
+   is_default: false,
+   version: 0,
+   migrated: false,
+   visibility: Template.visibilities[:organisationally_visible],
+   dmptemplate_id: 2,
+   links: '{"funder":[],"sample_plan":[]}'},
      
   {title: "Department of Testing Award",
    published: true,
@@ -369,7 +372,9 @@ templates = [
    is_default: false,
    version: 0,
    migrated: false,
-   dmptemplate_id: 3}
+   visibility: Template.visibilities[:organisationally_visible],
+   dmptemplate_id: 3,
+   links: '{"funder":[],"sample_plan":[]}'}
 ]
 # Template creation calls defaults handler which sets is_default and 
 # published to false automatically, so update them after creation
@@ -378,6 +383,7 @@ templates.map do |t|
     tmplt = Template.create!(t) 
     tmplt.published = t[:published]
     tmplt.is_default = t[:is_default]
+    tmplt.visibility = t[:visibility]
     tmplt.save!
   end
 end

--- a/lib/assets/javascripts/views/orgs/admin_edit.js
+++ b/lib/assets/javascripts/views/orgs/admin_edit.js
@@ -3,6 +3,7 @@ import 'number-to-text/converters/en-us';
 import { convertToText } from 'number-to-text/index';
 import ariatiseForm from '../../utils/ariatiseForm';
 import { Tinymce } from '../../utils/tinymce';
+import { eachLinks } from '../../utils/links';
 import { MAX_NUMBER_ORG_URLS } from '../../constants';
 
 $(() => {
@@ -53,15 +54,12 @@ $(() => {
 
   // Serialize URLs to JSON for form submission
   $('#edit_org_profile_form').submit(() => {
-    const json = Array.from($('#org-link-section div.org-link')).map((el) => {
-      const link = $(el).find('#org_links_url');
-      const text = $(el).find('#org_links_text');
-      return {
-        link: (link.length > 0 ? $(link).val() : ''),
-        text: (text.length > 0 ? $(text).val() : ''),
-      };
+    const links = {};
+    eachLinks((ctx, value) => {
+      links[ctx] = value;
+    }).done(() => {
+      $('#org_links').val(JSON.stringify(links));
     });
-    $('#org_links').val(JSON.stringify(json));
   });
 
   // Initialises tinymce for any target element with class tinymce_answer

--- a/lib/assets/javascripts/views/shared/my_org.js
+++ b/lib/assets/javascripts/views/shared/my_org.js
@@ -28,7 +28,9 @@ $(() => {
   });
 
   // Display the other org textbox if the value is filled out and no org id is selected
-  if ($(id).val().length <= 0 && isValidText($(text).val())) {
-    toggleInputs(false);
+  if ($(id).val() && $(text).val()) {
+    if ($(id).val().length <= 0 && isValidText($(text).val())) {
+      toggleInputs(false);
+    }
   }
 });

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -251,6 +251,10 @@ $header-background: linear-gradient(#ED6406, #F59503);
 #org-navbar {
   border-radius: 0px;
   margin-top: -20px;
+
+  #banner-org-name {
+    margin-top: 40px;
+  }
 }
 @media (min-width: 768px) {
   #org-navbar .navbar-nav li a {

--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -3,6 +3,7 @@ namespace :bugfix do
   desc "Upgrade to 1.0"
   task v1_0_0: :environment do
     Rake::Task['bugfix:set_template_visibility'].execute
+    Rake::Task['bugfix:set_org_link_defaults'].execute
   end
 
   desc "Bug fixes for version v0.3.3"
@@ -57,5 +58,21 @@ namespace :bugfix do
     Template.update_all visibility: Template.visibilities[:organisationally_visible]
     Template.where(org_id: funders).update_all visibility: Template.visibilities[:publicly_visible]
     Template.default.update visibility: Template.visibilities[:publicly_visible]
+  end
+  
+  desc "Set all orgs.links defaults"
+  task set_org_link_defaults: :environment do
+    Org.all.each do |org|
+      org.links = '{"org":[]}'
+      org.save!
+    end
+  end
+  
+  desc "Set all template.links defaults"
+  task set_org_link_defaults: :environment do
+    Template.all.each do |template|
+      template.links = '{"funder":[],"sample_plan":[]}'
+      template.save!
+    end
   end
 end

--- a/test/functional/orgs_controller_test.rb
+++ b/test/functional/orgs_controller_test.rb
@@ -25,7 +25,7 @@ class OrgsControllerTest < ActionDispatch::IntegrationTest
   #   admin_update_org  PUT      /org/admin/:id/admin_update    orgs#admin_update
   
   setup do
-    @org = Org.first
+    @org = Org.create!(name: 'Testing', abbreviation: 'TST', links: {"org":[]})
     scaffold_org_admin(@org)
   end
 
@@ -47,7 +47,7 @@ class OrgsControllerTest < ActionDispatch::IntegrationTest
   # PUT /org/admin/:id/admin_update (admin_update_org_path)
   # ----------------------------------------------------------
   test 'update the org' do
-    params = {name: 'Testing UPDATE'}
+    params = {name: 'Testing UPDATE', links: {"org": []}}
     
     # Should redirect user to the root path if they are not logged in!
     put admin_update_org_path(@org), {org: params}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,7 +50,8 @@ class ActiveSupport::TestCase
   # ----------------------------------------------------------------------
   def scaffold_template
     template = Template.new(title: 'Test template',
-                            description: 'My test template',
+                            description: 'My test template', 
+                            links: '{"funder":[],"sample_plan":[]}',
                             org: Org.first, migrated: false, dmptemplate_id: "0000009999")
 
     template.phases << Phase.new(title: 'Test phase',

--- a/test/unit/guidance_test.rb
+++ b/test/unit/guidance_test.rb
@@ -36,7 +36,7 @@ class GuidanceTest < ActiveSupport::TestCase
 
   # ---------------------------------------------------
   test "retrieves guidance by org" do
-    org = Org.create(name: 'Tester 123', abbreviation: 'TEST', org_type: 1)
+    org = Org.create!(name: 'Tester 123', abbreviation: 'TEST', org_type: 1, links: {"org":[]})
     assert Guidance.by_org(org.id).empty?, "expected the newly created org to have no guidance"
 
     assert_not Guidance.by_org(@user.org.id).empty?, "expected the org to have guidance"

--- a/test/unit/language_test.rb
+++ b/test/unit/language_test.rb
@@ -42,7 +42,7 @@ class LanguageTest < ActiveSupport::TestCase
 
   # ---------------------------------------------------
   test "can manage has_many relationship with Organisations" do
-    org = Org.create(name: 'testing', abbreviation: "TEST")
+    org = Org.create(name: 'testing', abbreviation: "TEST", links: {"org":[]})
     verify_has_many_relationship(Language.last, org, Language.last.orgs.count)
   end
 

--- a/test/unit/org_test.rb
+++ b/test/unit/org_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class OrgTest < ActiveSupport::TestCase
   setup do
-    @org = Org.first
+    @org = Org.create!(name: 'Testing', abbreviation: 'TST', links: {"org":[]})
     
     @language = Language.find_by(abbreviation: I18n.default_locale)
   end
@@ -13,6 +13,7 @@ class OrgTest < ActiveSupport::TestCase
     assert_not(org.valid?)
     
     org.name = 'ABCD'
+    org.links = {"org":[]}
     assert(org.valid?)
   end
   
@@ -145,7 +146,7 @@ class OrgTest < ActiveSupport::TestCase
   
   # ---------------------------------------------------
   test "can CRUD" do
-    org = Org.create(name: 'testing')
+    org = Org.create(name: 'testing', links: {"org":[]})
     assert_not org.id.nil?, "was expecting to be able to create a new Org: #{org.errors.map{|f, m| f.to_s + ' ' + m}.join(', ')}"
 
     org.abbreviation = 'TEST'

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -63,7 +63,7 @@ class QuestionTest < ActiveSupport::TestCase
     assert_equal 'Test 1', @question.annotations.where(org_id: @user.org.id).first.text, "expected the correct annotation"
     assert_equal 'Test 2', @question.annotations.where(org_id: Org.first.id).first.text, "expected the correct annotation"
 
-    org = Org.create(name: 'New One')
+    org = Org.create(name: 'New One', links: {"org":[]})
     assert_equal nil, @question.get_example_answer(org.id), "expected no annotation for a new org"
   end
 

--- a/test/unit/token_permission_type_test.rb
+++ b/test/unit/token_permission_type_test.rb
@@ -36,7 +36,7 @@ class TokenPermissionTypeTest < ActiveSupport::TestCase
 
   # ---------------------------------------------------
   test "can manage has_many relationship with Org" do
-    org = Org.new(name: 'Testing')
+    org = Org.new(name: 'Testing', links: {"org":[]})
     verify_has_many_relationship(@tpt, org, @tpt.orgs.count)
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -317,7 +317,7 @@ class UserTest < ActiveSupport::TestCase
 
   # ---------------------------------------------------
   test "can manage belongs_to relationship with Org" do
-    org = Org.new(name: 'Tester', abbreviation: 'TST')
+    org = Org.new(name: 'Tester', abbreviation: 'TST', links: {"org":[]})
     verify_belongs_to_relationship(@user, org)
   end
 


### PR DESCRIPTION
- Fixed issues with Links on Org details page by switching to use logic used for Template Links (funder and sample plans). #866
- Updated banner to show Org name if no logo is available #910
- Added rake tasks to seed default values for links in both Orgs and Templates tables