### PR TITLE
removed 'None' from the Guidances and Templates pages

### DIFF
--- a/app/views/guidances/_guidance_form.html.erb
+++ b/app/views/guidances/_guidance_form.html.erb
@@ -5,12 +5,12 @@
 <div class="form-group">
   <%= f.label _('Themes'), for: :theme_ids, class: 'control-label' %>
   <%= f.collection_select(:theme_ids, themes,
-            :id, :title, {prompt: false, include_blank: 'None'}, {multiple: true, 'data-toggle': 'tooltip', title: _('Select which theme(s) this guidance relates to.'), class: 'form-control', 'aria-required': true}) %>
+            :id, :title, {prompt: false}, {multiple: true, 'data-toggle': 'tooltip', title: _('Select which theme(s) this guidance relates to.'), class: 'form-control', 'aria-required': true}) %>
 </div>
 <div class="form-group">
   <%= f.label _('Guidance group'), for: :guidance_group_id, class: 'control-label' %>
   <%= f.collection_select(:guidance_group_id, guidance_groups,
-          :id, :name, {prompt: false, include_blank: 'None'}, {multiple: false, 'data-toggle': 'tooltip', title: _('Select which group this guidance relates to.'), class: 'form-control', 'aria-required': true})%>
+          :id, :name, {prompt: false}, {multiple: false, 'data-toggle': 'tooltip', title: _('Select which group this guidance relates to.'), class: 'form-control', 'aria-required': true})%>
 </div>
 <div class="checkbox">
   <%= f.label :published, raw("#{f.check_box :published, as: :check_boxes, 'data-toggle': 'tooltip', title: _("Check this box when you are ready for this guidance to appear on user's plans.")} #{_('Published?')}") %>

--- a/app/views/questions/_add_question.html.erb
+++ b/app/views/questions/_add_question.html.erb
@@ -82,7 +82,7 @@ in the admin interface.
     <%= f.label(:theme_ids, _('Themes'), class: "control-label") %>
     <%= f.collection_select(:theme_ids,
           Theme.all.order("title"),
-          :id, :title, {prompt: false, include_blank: _('None')}, {multiple: true, 'data-toggle': 'tooltip', 'data-html': true, title: _("<p>Select themes that are relevant to this question.</p> <p>This allows your generic institution-level guidance to be drawn in, as well as that from other sources e.g. the %{organisation_abbreviation} or any Schools/Departments that you provide guidance for. </p> <p>You can select multiple themes by using the CTRL button.</p>"), class: 'form-control'}) %>
+          :id, :title, {prompt: false}, {multiple: true, 'data-toggle': 'tooltip', 'data-html': true, title: _("<p>Select themes that are relevant to this question.</p> <p>This allows your generic institution-level guidance to be drawn in, as well as that from other sources e.g. the %{organisation_abbreviation} or any Schools/Departments that you provide guidance for. </p> <p>You can select multiple themes by using the CTRL button.</p>"), class: 'form-control'}) %>
   </div>
 
   <div class="form-group">

--- a/app/views/questions/_edit_question.html.erb
+++ b/app/views/questions/_edit_question.html.erb
@@ -90,7 +90,7 @@ in the admin interface.
             <%= f.label(:theme_ids, _('Themes'), class: "control-label") %>
             <%= f.collection_select(:theme_ids,
                   Theme.all.order("title"),
-                  :id, :title, {prompt: false, include_blank: _('None')}, {multiple: true, 'data-toggle': 'tooltip', 'data-html': true, title: _("<p>Select themes that are relevant to this question.</p> <p>This allows your generic institution-level guidance to be drawn in, as well as that from other sources e.g. the %{organisation_abbreviation} or any Schools/Departments that you provide guidance for. </p> <p>You can select multiple themes by using the CTRL button.</p>"), class: 'form-control'}) %>
+                  :id, :title, {prompt: false}, {multiple: true, 'data-toggle': 'tooltip', 'data-html': true, title: _("<p>Select themes that are relevant to this question.</p> <p>This allows your generic institution-level guidance to be drawn in, as well as that from other sources e.g. the %{organisation_abbreviation} or any Schools/Departments that you provide guidance for. </p> <p>You can select multiple themes by using the CTRL button.</p>"), class: 'form-control'}) %>
           </div>
 
           <div class="col-md-4 col-md-offset-8">


### PR DESCRIPTION
Fixes #907 .
- Removed the option 'None' from the Themes multi-select box on the Guidance Add/Edit and Question Add/Edit pages
- Removed the option 'None' from the Guidance Group select box on the Guidance Add/Edit pages