### PR TITLE
Fix for contact_us_url on devise mailers

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,7 +2,7 @@
   tool_name = Rails.configuration.branding[:application][:name]
   link = accept_invitation_url(@resource, :invitation_token => @token)
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
+  contact_us = (Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url)
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
@@ -21,6 +21,6 @@
     <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
   </p>
   <p>
-    <%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us_url, contact_us_url) }) %>
+    <%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us, contact_us) }) %>
   </p>
 <% end %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,7 +1,7 @@
 <%
   tool_name = Rails.configuration.branding[:application][:name]
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
-  contact_us_url = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
+  contact_us = Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
@@ -19,6 +19,6 @@
     <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
   </p>
   <p>
-    <%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us_url, contact_us_url) }) %>
+    <%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us_url => link_to(contact_us, contact_us) }) %>
   </p>
 <% end %>


### PR DESCRIPTION
The `contact_us_url` keyword was causing failures when the value was not defined in the branding.yml. Updated to use a different variable name