### PR TITLE
Modal dialog for confirmation messages

### DIFF
--- a/app/views/guidances/admin_index.html.erb
+++ b/app/views/guidances/admin_index.html.erb
@@ -71,7 +71,8 @@
                   <% else %>
                     <li><%= link_to _('Publish'),  admin_update_publish_guidance_group_path(guidance_gr), method: :put %></li>
                   <% end %>
-                    <li><%= link_to _('Remove'), admin_destroy_guidance_group_path(guidance_gr), data: {confirm: _("You are about to delete '%{guidance_group_name}'. This will affect guidance. Are you sure?") % { :guidance_group_name => guidance_gr.name }}, method: :delete %></li>
+                    <li><%= link_to _('Remove'), '#', 'confirm-href': admin_destroy_guidance_group_path(guidance_gr),
+                                    'confirm-method': :delete, 'data-toggle': 'modal', 'data-target': '#confirm-guidance-group-delete' %></li>
                   </ul>
                 </div>
               </td>
@@ -79,6 +80,8 @@
           <% end %>
         </tbody>
       </table>
+      <%= render partial: 'shared/confirmation', 
+                 locals: { id: "confirm-guidance-group-delete", message: _('Are you sure you want to remove the guidance group?')} %>
     </div>
     <%end%>
   
@@ -168,9 +171,8 @@
                     <% else %>
                       <li><%= link_to _('Publish'), admin_publish_guidance_path(guidance), method: :put %></li>
                     <% end %>
-                      <li><%= link_to _('Remove'), admin_destroy_guidance_path(guidance),
-                              data: {confirm: _("You are about to delete '%{guidance_summary}'. Are you sure?") % { :guidance_summary => truncate(sanitize(guidance.text,tags: %w(br a)), length: 20 , omission: _('... (continued)'))} }, 
-                              method: :delete %></li>
+                      <li><%= link_to _('Remove'), '#', 'confirm-href': admin_destroy_guidance_path(guidance),
+                                      'confirm-method': :delete, 'data-toggle': 'modal', 'data-target': '#confirm-guidance-delete' %></li>
                     </ul>
                   </div>
                 </td>
@@ -179,6 +181,8 @@
           <% end %>
         </tbody>
       </table>
+      <%= render partial: 'shared/confirmation', 
+                 locals: { id: "confirm-guidance-delete", message: _('Are you sure you want to remove the guidance?')} %>
     </div>
     <% end %>
   

--- a/app/views/org_admin/templates/_funder_templates_list.html.erb
+++ b/app/views/org_admin/templates/_funder_templates_list.html.erb
@@ -82,7 +82,8 @@
                   <% end %>
                   <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
                   <% if template.plans.length <= 0 %>
-                    <li><%= link_to _('Remove'), org_admin_template_path(id: template.id), class: 'remove-template', data: template.id, method: 'DELETE' %></li>
+                    <li><%= link_to _('Remove'), '#', 'confirm-href': org_admin_template_path(id: template.id),
+                                    'confirm-method': :delete, 'data-toggle': 'modal', 'data-target': '#confirm-template-delete' %></li>
                   <% end %>
 
                 <% else %>
@@ -99,7 +100,8 @@
                         <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template) %></li>
                       <% end %>
                       <% if customization.plans.length <= 0 %>
-                        <li><%= link_to _('Remove'), org_admin_template_path(id: customization.id), class: 'remove-template', data: template.id, method: 'DELETE' %></li>
+                        <li><%= link_to _('Remove'), '#', 'confirm-href': org_admin_template_path(id: customization.id),
+                                        'confirm-method': :delete, 'data-toggle': 'modal', 'data-target': '#confirm-customization-delete' %></li>
                       <% end %>
                     <% end %>
                   <% end %>
@@ -111,4 +113,6 @@
       <% end %>
     </tbody>
   </table>
+  <%= render partial: 'shared/confirmation', 
+             locals: { id: "confirm-customization-delete", message: _('Are you sure you want to remove the customization?')} %>
 </div>

--- a/app/views/org_admin/templates/_templates_list.html.erb
+++ b/app/views/org_admin/templates/_templates_list.html.erb
@@ -62,7 +62,8 @@
                 <% end %>
                 <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
                 <% if template.plans.length <= 0 %>
-                  <li><%= link_to _('Remove'), org_admin_template_path(id: template.id), class: 'remove-template', data: template.id, method: 'DELETE' %></li>
+                  <li><%= link_to _('Remove'), '#', 'confirm-href': org_admin_template_path(id: template.id),
+                                  'confirm-method': :delete, 'data-toggle': 'modal', 'data-target': '#confirm-template-delete' %></li>
                 <% end %>
               </ul>
             </div>
@@ -71,4 +72,6 @@
       <% end %>
     </tbody>
   </table>
+  <%= render partial: 'shared/confirmation', 
+             locals: { id: "confirm-template-delete", message: _('Are you sure you want to remove the template?')} %>
 </div>

--- a/app/views/paginable/plans/_privately_visible.html.erb
+++ b/app/views/paginable/plans/_privately_visible.html.erb
@@ -76,9 +76,8 @@
                       <li><%= link_to _('Download'), download_plan_path(plan) %></li>
                     <% end %>
                     <% role = plan.roles.where(user_id: current_user.id).first %>
-                    <% conf = (role.creator? && plan.publicly_visible?) ? _("Are you sure you wish to remove this public plan? This will remove it from the Public DMPs page but any collaborators will still be able to access it.") : _("Are you sure you wish to remove this plan? Any collaborators will still be able to access it.") %>
-                    <li><%= link_to _('Remove'), deactivate_role_path(role),
-                                    method: :put, data: {confirm: conf} %></li>
+                    <li><%= link_to _('Remove'), '#', 'confirm-href': deactivate_role_path(role), 
+                                    'confirm-method': :put, 'data-toggle': 'modal', 'data-target': '#confirm-plan-delete' %></li>
                   </ul>
                 </div>
                 </td>
@@ -86,4 +85,6 @@
             <% end %>
           </tbody>
         </table>
+        <%= render partial: 'shared/confirmation', 
+                   locals: { id: "confirm-plan-delete", message: _('Are you sure you want to remove the plan?')} %>
       </div>

--- a/app/views/shared/_confirmation.html.erb
+++ b/app/views/shared/_confirmation.html.erb
@@ -1,0 +1,17 @@
+<!-- requires local variables:
+  id: to identify the modal container
+  message: the confirmation message to display
+-->
+<div class="modal fade confirmation-modal" id="<%= id %>" tabindex="-1" role="dialog" aria-labelledby="modal-title">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <%= message %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary confirmation-cancel" data-dismiss="modal"><%= _('Cancel') %></button>
+        <a href="#" data-method="GET" class="btn btn-default confirmation-continue"><%= _('Continue') %></a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -6,6 +6,7 @@ import './utils/links';
 import './utils/tabHelper';
 import './utils/tableHelper';
 import './utils/tooltipHelper';
+import './utils/confirmation';
 
 // Page specific JS
 import './views/answers/edit';

--- a/lib/assets/javascripts/utils/confirmation.js
+++ b/lib/assets/javascripts/utils/confirmation.js
@@ -1,0 +1,16 @@
+/*
+ * Confirmation modal expects the link/button that triggers the confirmation
+ * to define the folowing attributes: 'confirm-href' and 'confirm-method'
+ *
+ * e.g. <a href="#" data-toggle="modal" data-target="#confirm-it" 
+ *         confirm-method="put" confirm-href="plans/1234">Remove</a>
+ *
+ * 'data-target' should match the name of the modal dialog.
+ */
+$(() => {
+  $('.confirmation-modal').on('show.bs.modal', (e) => {
+    $($(e.relatedTarget).attr('data-target')).find('.confirmation-continue')
+      .attr('href', $(e.relatedTarget).attr('confirm-href'))
+      .attr('data-method', $(e.relatedTarget).attr('confirm-method'));
+  });
+});

--- a/lib/assets/javascripts/utils/confirmation.js
+++ b/lib/assets/javascripts/utils/confirmation.js
@@ -2,7 +2,7 @@
  * Confirmation modal expects the link/button that triggers the confirmation
  * to define the folowing attributes: 'confirm-href' and 'confirm-method'
  *
- * e.g. <a href="#" data-toggle="modal" data-target="#confirm-it" 
+ * e.g. <a href="#" data-toggle="modal" data-target="#confirm-it"
  *         confirm-method="put" confirm-href="plans/1234">Remove</a>
  *
  * 'data-target' should match the name of the modal dialog.


### PR DESCRIPTION
Discovered that existing confirmation messages were performing a delete even if the user clicked 'Cancel'. Addresses #870, #933
- Added a modal confirmation dialog that allows user to Cancel or Continue
- Updated Templates, Plans, Guidance Groups, and Guidance to use it

@jollopre you will need to apply to the theme page for #939