### PR TITLE
Convert 'Remove' links to rails/jquery-ujs

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -13,13 +13,13 @@ module OrgAdmin
 
       # If the user is an Org Admin look for customizations to funder templates
       customizations = {}
-      unless current_user.can_super_admin?
+      if current_user.can_org_admin?
         funder_templates.each do |funder_template|
           customization = Template.org_customizations(funder_template.dmptemplate_id, current_user.org_id)
-          customizations[customization.dmptemplate_id] = customization if customization.present?
+          customizations[customization.customization_of] = customization if customization.present?
         end
       end
-      
+
       # Gather up all of the publication dates for the live versions of each template.
       published = {}
       [funder_templates, org_templates].each do |collection|
@@ -53,6 +53,7 @@ module OrgAdmin
       @template = Template.new(params[:template])
       @template.org_id = current_user.org.id
       @template.description = params['template-desc']
+      @template.links = (params["template-links"].present? ? JSON.parse(params["template-links"]) : {"funder": [], "sample_plan": []})
 
       if @template.save
         redirect_to edit_org_admin_template_path(@template), notice: success_message(_('template'), _('created'))

--- a/app/views/org_admin/templates/_funder_templates_list.html.erb
+++ b/app/views/org_admin/templates/_funder_templates_list.html.erb
@@ -82,7 +82,10 @@
                   <% end %>
                   <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
                   <% if template.plans.length <= 0 %>
-                    <li><%= link_to _('Remove'), org_admin_template_path(id: template.id), class: 'remove-template', data: template.id, method: 'DELETE' %></li>
+                    <li>
+                      <%= link_to _('Remove'), org_admin_template_path(id: template.id), 'data-method': 'delete', rel: 'nofollow',
+                          'data-confirm': _('Are you sure you want to remove "%{template_title}"?') % { template_title: template.title} %>
+                    </li>
                   <% end %>
 
                 <% else %>
@@ -99,7 +102,10 @@
                         <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template) %></li>
                       <% end %>
                       <% if customization.plans.length <= 0 %>
-                        <li><%= link_to _('Remove'), org_admin_template_path(id: customization.id), class: 'remove-template', data: template.id, method: 'DELETE' %></li>
+                        <li>
+                          <%= link_to _('Remove'), org_admin_template_path(id: customization.id), 'data-method': 'delete', rel: 'nofollow',
+                              'data-confirm': _('Are you sure you want to remove your customization of "%{template_title}"?') % { template_title: customization.title} %>
+                        </li>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/app/views/org_admin/templates/_templates_list.html.erb
+++ b/app/views/org_admin/templates/_templates_list.html.erb
@@ -62,7 +62,10 @@
                 <% end %>
                 <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
                 <% if template.plans.length <= 0 %>
-                  <li><%= link_to _('Remove'), org_admin_template_path(id: template.id), class: 'remove-template', data: template.id, method: 'DELETE' %></li>
+                  <li>
+                    <%= link_to _('Remove'), org_admin_template_path(id: template.id), 'data-method': 'delete', rel: 'nofollow',
+                                'data-confirm': _('Are you sure you want to remove "%{template_title}"?') % { template_title: template.title} %>
+                  </li>
                 <% end %>
               </ul>
             </div>


### PR DESCRIPTION
Converted Remove links on Plans and Templates pages over to the rails/jquery-ujs approach. 
- Fixes issues with cancel button on remove confirmation #870 and #933
- Also fixed a bug #953 that caused template creation to fail if user did not belong to a funder org
- Also fixed issue with identifying customizations on templates page
