### PR TITLE
Add 'and comment' to read-only definition on share plan page

### DIFF
--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -47,7 +47,7 @@
                       <%= form_for role, url: { controller: :roles, action: :update, id: role.id }, remote: true, html: { method: :put } do |f| %>
                       <div class="form-group col-xs-8">
                         <%= f.hidden_field :id %>
-                        <%= f.select :access_level, {"#{_('Co-owner')}": 3, "#{_('Editor')}": 2, "#{_('Read only')}": 1}, {}, {id: "#{role.id}-can-edit", class: "toggle-existing-user-access has-tooltip", 'data-toggle': "tooltip", 'title': _('Editors can contribute to plans. Co-owners have additional rights to edit plan details and control access.') } %>
+                        <%= f.select :access_level, {"#{_('Co-owner')}": 3, "#{_('Editor')}": 2, "#{_('Read only')}": 1}, {}, {id: "#{role.id}-can-edit", class: "toggle-existing-user-access" } %>
                       </div>
                     <% end %>
                 <% else %>
@@ -82,7 +82,7 @@
   <div class="form-group col-xs-8">
     <p><strong><%= _('Permissions') %></strong></p>
     <div class="radio">
-      <%= f.label :access_level, raw("#{f.radio_button :access_level, 1} #{_('Read only: can view but not make changes')}") %>
+      <%= f.label :access_level, raw("#{f.radio_button :access_level, 1} #{_('Read only: can view and comment, but not make changes')}") %>
     </div>
     <div class="radio">
       <%= f.label :access_level, raw("#{f.radio_button :access_level, 2} #{_('Editor: can comment and make changes')}") %>


### PR DESCRIPTION
fixes #848
- remove tooltip from dropdowns
- update description for read-only