### PR TITLE
Templates table revisions #900

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -7,31 +7,29 @@ module OrgAdmin
     # -----------------------------------------------------
     def index
       authorize Template
+      
       # Apply scoping
-      orgs_hash = apply_scoping(params[:scope] || 'all')
-      funders_hash = apply_scoping(params[:scope] || 'all', true)
+      all_templates_hash = apply_scoping(params[:scope] || 'all', false, true)
+      own_hash = apply_scoping(params[:scope] || 'all', false, false)
+      customizable_hash = apply_scoping(params[:scope] || 'all', true, false)
 
       # Apply pagination
-      orgs_hash[:templates] = orgs_hash[:templates].page(1)
-      funders_hash[:templates] = funders_hash[:templates].page(1)
+      all_templates_hash[:templates] = all_templates_hash[:templates].page(1)
+      own_hash[:templates] = own_hash[:templates].page(1)
+      customizable_hash[:templates] = customizable_hash[:templates].page(1)
 
       # Gather up all of the publication dates for the live versions of each template.
-      published = {}
-      [funders_hash[:templates], orgs_hash[:templates]].each do |collection|
-        collection.each do |template|
-          live = Template.live(template.dmptemplate_id)
-          published[template.dmptemplate_id] = live.updated_at if live.present?
-        end
-      end
+      published = get_publication_dates(all_templates_hash[:scopes][:dmptemplate_ids])
       
       render 'index', locals: {
-        funder_templates: funders_hash[:templates], 
-        org_templates: orgs_hash[:templates],
-        customized_templates: funders_hash[:customizations],
+        all_templates: all_templates_hash[:templates],
+        customizable_templates: customizable_hash[:templates], 
+        own_templates: own_hash[:templates],
+        customized_templates: customizable_hash[:customizations],
         published: published,
         current_org: current_user.org, 
         orgs: Org.all,
-        scopes: { orgs: orgs_hash[:scopes], funders: funders_hash[:scopes] }
+        scopes: { all: all_templates_hash[:scopes], orgs: own_hash[:scopes], funders: customizable_hash[:scopes] }
       }
     end
     
@@ -284,23 +282,40 @@ module OrgAdmin
       redirect_to edit_org_admin_template_path(new_customization)
     end
     
+    # GET /org_admin/templates/all/:page  (AJAX)
+    # -----------------------------------------------------
+    def all
+      authorize Template
+      # Apply scoping
+      hash = apply_scoping(params[:scope] || 'all', false, true)
+
+      # Apply pagination
+      hash[:templates] = hash[:templates].page(params[:page]) if params[:page] != 'ALL'
+      
+      # Gather up all of the publication dates for the live versions of each template.
+      published = get_publication_dates(hash[:scopes][:dmptemplate_ids])
+      
+      paginable_renderise partial: 'templates_list',
+                          scope: hash[:templates],
+                          locals: { current_org: current_user.org.id,
+                                    customizations: hash[:customizations],
+                                    published: published,
+                                    scopes: hash[:scopes],
+                                    hide_actions: true }
+    end
     
     # GET /org_admin/templates/funders/:page  (AJAX)
     # -----------------------------------------------------
     def funders
       authorize Template
       # Apply scoping
-      hash = apply_scoping(params[:scope] || 'all', true)
+      hash = apply_scoping(params[:scope] || 'all', true, false)
 
       # Apply pagination
       hash[:templates] = hash[:templates].page(params[:page]) if params[:page] != 'ALL'
       
       # Gather up all of the publication dates for the live versions of each template.
-      published = {}
-      hash[:templates].each do |template|
-        live = Template.live(template.dmptemplate_id)
-        published[template.dmptemplate_id] = live.updated_at if live.present?
-      end
+      published = get_publication_dates(hash[:scopes][:dmptemplate_ids])
       
       paginable_renderise partial: 'funder_templates_list',
                           scope: hash[:templates],
@@ -315,24 +330,21 @@ module OrgAdmin
     def orgs
       authorize Template
       # Apply scoping
-      hash = apply_scoping(params[:scope] || 'all')
+      hash = apply_scoping(params[:scope] || 'all', false, false)
       
       # Apply pagination
       hash[:templates] = hash[:templates].page(params[:page]) if params[:page] != 'ALL'
       
       # Gather up all of the publication dates for the live versions of each template.
-      published = {}
-      hash[:templates].each do |template|
-        live = Template.live(template.dmptemplate_id)
-        published[template.dmptemplate_id] = live.updated_at if live.present?
-      end
+      published = get_publication_dates(hash[:scopes][:dmptemplate_ids])
       
       paginable_renderise partial: 'templates_list',
                           scope: hash[:templates],
                           locals: { current_org: current_user.org.id,
                                     customizations: hash[:customizations],
                                     published: published,
-                                    scopes: hash[:scopes] }
+                                    scopes: hash[:scopes],
+                                    hide_actions: false }
     end
     
     # PUT /org_admin/templates/:id/copy  (AJAX)
@@ -362,30 +374,29 @@ module OrgAdmin
     # PUT /org_admin/templates/:id/publish  (AJAX)
     # -----------------------------------------------------
     def publish
-      @template = Template.find(params[:id])
-      authorize @template
+      template = Template.find(params[:id])
+      authorize template
 
-      current = Template.current(@template.dmptemplate_id)
+      current = Template.current(template.dmptemplate_id)
 
       # Only allow the current version to be updated
-      if current != @template
+      if current != template
         redirect_to org_admin_templates_path, alert: _('You can not publish a historical version of this template.')
 
       else
         # Unpublish the older published version if there is one
-        live = Template.live(@template.dmptemplate_id)
+        live = Template.live(template.dmptemplate_id)
         if !live.nil? and self != live
           live.published = false
           live.save!
         end
         # Set the dirty flag to false
-        @template.dirty = false
-        @template.published = true
-        @template.save
+        template.dirty = false
+        template.published = true
+        template.save
 
         flash[:notice] = _('Your template has been published and is now available to users.')
-
-        redirect_to org_admin_templates_path
+        redirect_to "#{org_admin_templates_path}#{template.customization_of.present? ? '#funder-templates' : '#organisation-templates'}"
       end
     end
 
@@ -395,18 +406,15 @@ module OrgAdmin
       template = Template.find(params[:id])
       authorize template
 
-      # Unpublish the live version
-      @template = Template.live(template.dmptemplate_id)
-
-      if @template.nil?
+      if template.nil?
         flash[:alert] = _('That template is not currently published.')
       else
-        @template.published = false
-        @template.save
+        template.published = false
+        template.save
         flash[:notice] = _('Your template is no longer published. Users will not be able to create new DMPs for this template until you re-publish it')
       end
 
-      redirect_to org_admin_templates_path
+      redirect_to "#{org_admin_templates_path}#{template.customization_of.present? ? '#funder-templates' : '#organisation-templates'}"
     end
     
     # PUT /org_admin/template_options  (AJAX)
@@ -464,13 +472,15 @@ module OrgAdmin
     end
     
     # Applies scoping to the template list
-    def apply_scoping(scope, funders = false)
-      if funders
-        templates = Template.get_latest_template_versions(Org.funder)
-
+    def apply_scoping(scope, customizable = false, all = false)
+      if customizable
+        # Retrieve all of the publicly visible published funder templates
+        orgs = Org.funder.where.not(id: current_user.org.id)
         # Include the default template in the list of funder templates
-        templates << Template.default
-
+        orgs << Template.default.org unless current_user.org == Template.default.org
+        
+        templates = Template.get_public_published_template_versions(orgs)
+        
         # If the user is an Org Admin look for customizations to funder templates
         customizations = {}
         if current_user.can_org_admin?
@@ -495,10 +505,14 @@ module OrgAdmin
             templates = Template.where(id: scoped.collect(&:id))
           end
         end
-        
+
       else
-        valid_orgs = current_user.can_super_admin? ? Org.not_funder : Org.find(current_user.org)
-        templates = Template.get_latest_template_versions(valid_orgs)
+        # If we're collecting all templates
+        if all
+          templates = Template.get_latest_template_versions(Org.all)
+        else
+          templates = Template.get_latest_template_versions(Org.where(id: current_user.org.id))
+        end
         
         scopes = calculate_table_scopes(templates, {})
         
@@ -507,7 +521,7 @@ module OrgAdmin
           templates = templates.where(published: false) if params[:scope] == 'unpublished'
         end
       end
-      
+
       { templates: templates,
         customizations: customizations || {},
         scopes: scopes }
@@ -515,10 +529,10 @@ module OrgAdmin
     
     # Gets the nbr of templates and nbr of published/unpublished templates
     def calculate_table_scopes(templates, customizations)
-      scopes = { all: templates.length, published: 0, unpublished: 0 }
+      scopes = { all: templates.length, published: 0, unpublished: 0, dmptemplate_ids: templates.collect(&:dmptemplate_id).uniq }
       templates.each do |t|
         # If we have customizations use their status
-        if customizations.length > 0
+        if customizations.respond_to?(:keys)
           c = customizations[t.dmptemplate_id]
           # If the template was not customized then its unpublished
           if c.nil?
@@ -534,6 +548,15 @@ module OrgAdmin
         end
       end
       scopes
+    end
+    
+    def get_publication_dates(family_ids)
+      published = {}
+      lives = Template.live(family_ids)
+      lives.each do |live|
+        published[live.dmptemplate_id] = live.updated_at
+      end
+      published
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
     redirect_to "#{edit_user_registration_path}\#notification-preferences", notice: success_message(_('preferences'), _('saved'))
   end
 
-  # PUT /users/:id/org_swap  (AJAX)
+  # PUT /users/:id/org_swap
   # -----------------------------------------------------
   def org_swap
     # Allows the user to swap their org affiliation on the fly
@@ -87,16 +87,12 @@ class UsersController < ApplicationController
     if org.present?
       current_user.org = org
       if current_user.save!
-        render json: {
-          msg: _('Your organisation affiliation has been changed. You may now edit templates for %{org_name}.') % {org_name: current_user.org.name}
-        }.to_json
+        redirect_to request.referer, notice: _('Your organisation affiliation has been changed. You may now edit templates for %{org_name}.') % {org_name: current_user.org.name}
       else
-        render json: {
-          err: _('Unable to change your organisation affiliation at this time.')
-        }.to_json
+        redirect_to request.referer, alert: _('Unable to change your organisation affiliation at this time.')
       end
     else
-      render json: {}.to_json
+      redirect_to request.referer, alert: _('Unknown organisation.')
     end
   end
   

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -25,7 +25,7 @@ class Template < ActiveRecord::Base
   #   -relies on protected_attributes gem as syntax depricated in rails 4.2
   attr_accessible :id, :org_id, :description, :published, :title, :locale, :customization_of,
                   :is_default, :guidance_group_ids, :org, :plans, :phases, :dmptemplate_id,
-                  :migrated, :version, :visibility, :published, :as => [:default, :admin]
+                  :migrated, :version, :visibility, :published, :links, :as => [:default, :admin]
 
   # A standard template should be organisationally visible. Funder templates that are 
   # meant for external use will be publicly visible. This allows a funder to create 'funder' as
@@ -67,11 +67,27 @@ class Template < ActiveRecord::Base
       select("MAX(version) AS version", :dmptemplate_id).group(:dmptemplate_id)
     end
   }
+  # Retrieves the maximum version for the array of customization_ofs passed. If customization_ofs is missing, every maximum
+  # version for each different customization_of will be retrieved
+  scope :customization_ofs_with_max_version, -> (customization_ofs=nil) {
+    if customization_ofs.is_a?(Array)
+      select("MAX(version) AS version", :customization_of).where(customization_of: customization_ofs).group(:customization_of)
+    else
+      select("MAX(version) AS version", :customization_of).group(:customization_of)
+    end
+  }
   # Retrieves the latest template version, i.e. the one with maximum version for each dmptemplate_id
   scope :latest_version, -> (dmptemplate_ids=nil) {
     from(dmptemplate_ids_with_max_version(dmptemplate_ids), :current)
     .joins("INNER JOIN templates ON current.version = templates.version"\
       " AND current.dmptemplate_id = templates.dmptemplate_id")
+  }
+  # Retrieves the latest customized version, i.e. the one with maximum version for each customization_of=dmptemplate_id
+  scope :latest_customization, -> (org_id, dmptemplate_ids=nil) {
+    from(customization_ofs_with_max_version(dmptemplate_ids), :current)
+    .joins("INNER JOIN templates ON current.version = templates.version"\
+      " AND current.customization_of = templates.customization_of")
+    .where('templates.org_id = ?', org_id)
   }
   # Retrieves the list of all dmptemplate_ids (template versioning families) for the specified Org
   def self.dmptemplate_ids
@@ -85,7 +101,11 @@ class Template < ActiveRecord::Base
 
   # Retrieves the current published version of the template for the specified Org and dmptemplate_id
   def self.live(dmptemplate_id)
-    Template.where(dmptemplate_id: dmptemplate_id, published: true).valid.first
+    if dmptemplate_id.respond_to?(:each)
+      Template.where(dmptemplate_id: dmptemplate_id, published: true).valid
+    else
+      Template.where(dmptemplate_id: dmptemplate_id, published: true).valid.first
+    end
   end
 
   def self.default
@@ -100,8 +120,9 @@ class Template < ActiveRecord::Base
   # @params  dmptemplate_ids of the original template
   # @params [integer] org_id for the customizing organisation
   # @return [nil, Template] the customized template or nil
-  def self.org_customizations(dmptemplate_id, org_id)
-    Template.where(customization_of: dmptemplate_id, org_id: org_id).order(version: :desc).valid
+  def self.org_customizations(dmptemplate_ids, org_id)
+    template_ids = latest_customization(org_id, dmptemplate_ids).pluck(:id)
+    includes(:org).where(id: template_ids).order('orgs.name, templates.title')
   end
   
   # Retrieves current templates with their org associated for a set of valid orgs
@@ -116,6 +137,19 @@ class Template < ActiveRecord::Base
     end
     template_ids = latest_version(families_ids).pluck(:id)
     includes(:org).where(id: template_ids).order('orgs.name, templates.title')
+  end
+  
+  # Retrieves current templates with their org associated for a set of valid orgs
+  # TODO pass an array of org ids instead of Org instances
+  def self.get_public_published_template_versions(orgs)
+    if orgs.respond_to?(:each)
+      families_ids = families(orgs.map(&:id)).pluck(:dmptemplate_id)
+    elsif orgs.is_a?(Org)
+      families_ids = families([orgs.id]).pluck(:dmptemplate_id)
+    else
+      families_ids = []
+    end
+    includes(:org).where(dmptemplate_id: families_ids, published: true, visibility: Template.visibilities[:publicly_visible]).order('orgs.name, templates.title')
   end
   
   ##

--- a/app/policies/template_policy.rb
+++ b/app/policies/template_policy.rb
@@ -44,6 +44,9 @@ class TemplatePolicy < ApplicationPolicy
   end
   
   # Pagination 
+  def all?
+    user.can_super_admin?
+  end
   def funders?
     user.can_super_admin? || user.can_modify_templates?
   end

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -24,7 +24,7 @@
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="org-navbar-menu">
       <!-- Organisational links -->
-      <% if user_signed_in? && !current_user.org.nil? %>
+      <% if user_signed_in? && !current_user.org.present? && !current_user.org.links.present? && !current_user.org.links['org'].present? %>
         <ul class="nav navbar-nav">
           <% i=1; current_user.org.links['org'].each do |link| %>
             <% if !link.blank? && i <= max_number_links %>

--- a/app/views/org_admin/templates/_funder_templates_list.html.erb
+++ b/app/views/org_admin/templates/_funder_templates_list.html.erb
@@ -13,7 +13,9 @@
       <% if scopes.present? %>
         <tr><th colspan="5" class="sorter-false table-scope"><ul class="nav navbar-nav">
           <% scopes.keys.each do |k| %>
-            <li><%= link_to "#{k.capitalize} (#{scopes[k]})", "#{funders_org_admin_templates_path(1)}?scope=#{k}", class: 'template-scope', 'data-remote': true %></li>
+            <% unless k == :dmptemplate_ids %>
+              <li><%= link_to "#{k.capitalize} (#{scopes[k]})", "#{funders_org_admin_templates_path(1)}?scope=#{k}", class: 'template-scope', 'data-remote': true %></li>
+            <% end %>
           <% end %>
         </ul></th></tr>
       <% end %>
@@ -30,36 +32,28 @@
       <% customization = customizations[template.dmptemplate_id] %>
       <tr>
         <td>
-          <%= template.title %>
+          <%= "#{template.is_default? ? '* ' : ''}#{template.title}" %>
         </td>
           <td>
             <%= raw template.org.name %>
           </td>
           <td>
-            <% if current_user.can_super_admin? %>
-              <% if !published[template.dmptemplate_id].present? %>
-                <%= _('Unpublished') %>
-              <% elsif template.dirty? %>
-                <%= _('Unpublished changes') %>
-              <% else %>
+            <% if customization.present? %>
+              <!-- If the original funder template has been changed -->
+              <% if customization.updated_at < template.updated_at %>
+                <%= _('Original funder template has changed!')%>
+              <% elsif !template.published? %>
+                <!-- The template does not have a live version -->
+                <%= b_label = _('Funder version is un-published') %>
+              <% elsif customization.dirty? %>
+                <%= _('You have un-published changes') %>
+              <% elsif customization.published? %>
                 <%= _('Published') %>
+              <% else %>
+                <%= _('Unpublished') %>
               <% end %>
             <% else %>
-              <% if customization.present? %>
-                <!-- If the original funder template has been changed -->
-                <% if customization.updated_at < template.updated_at %>
-                  <%= _('Original funder template has changed!')%>
-                <% elsif !template.published? %>
-                  <!-- The template does not have a live version -->
-                  <%= b_label = _('Funder version is un-published') %>
-                <% elsif customization.dirty? %>
-                  <%= _('You have un-published changes') %>
-                <% else %>
-                  <%= _('Published') %>
-                <% end %>
-              <% else %>
-                <%= _('Not Customised') %>
-              <% end %>
+              <%= _('Not Customised') %>
             <% end %>
           </td>
           <td>
@@ -67,52 +61,30 @@
             <%= l last_temp_updated.to_date, formats: :short %>
           </td>
           <td>
-            <div class="dropdown<%= (!current_user.can_super_admin? || (current_user.can_super_admin? && current_org == template.org.id)) ? '' : ' hide'%>">
-              <% # Span used to trigger the display of the action dropdowns via JS %>
-              <span class="super-admin-template-org hide"><%= template.org.id %></span>
-
+            <div class="dropdown">
               <button class="btn btn-link dropdown-toggle" type="button"
                       data-toggle="dropdown"
                       aria-haspopup="true" aria-expanded="true">
                 <%= _('Actions') %><span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
-                <% if current_user.can_super_admin? %>
-                  <li><%= link_to _('Edit'), edit_org_admin_template_path(id: template.id, edit: "true") %></li>
-                  <li><%= link_to _('History'), history_org_admin_template_path(id: template.id) %></li>
-                  <% if !published[template.dmptemplate_id].present? %>
-                    <li><%= link_to _('Publish'), publish_org_admin_template_path(template) %></li>
-                  <% elsif template.dirty? %>
-                    <li><%= link_to _('Publish changes'), publish_org_admin_template_path(template) %></li>
+                <% if !customization.present? %>
+                  <li><%= link_to _('Customise'), customize_org_admin_template_path(template) %></li>
+                <% else %>
+                  <% if customization.updated_at < template.updated_at %>
+                    <li><%= link_to _('Transfer customisation'), transfer_customization_org_admin_template_path(template) %></li>
                   <% else %>
-                    <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template) %></li>
-                  <% end %>
-                  <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
-                  <% if template.plans.length <= 0 %>
-                    <li>
-                      <%= link_to _('Remove'), org_admin_template_path(id: template.id), 'data-method': 'delete', rel: 'nofollow',
-                          'data-confirm': _('Are you sure you want to remove "%{template_title}"?') % { template_title: template.title} %>
-                    </li>
-                  <% end %>
-
-                  <% if !customization.present? %>
-                    <li><%= link_to _('Customise'), customize_org_admin_template_path(template) %></li>
-                  <% else %>
-                    <% if customization.updated_at < template.updated_at %>
-                      <li><%= link_to _('Transfer customisation'), transfer_customization_org_admin_template_path(template) %></li>
+                    <li><%= link_to _('Edit customisation'), edit_org_admin_template_path(id: customization.id, edit: "true") %></li>
+                    <% if !customization.published? %>
+                      <li><%= link_to _('Publish'), publish_org_admin_template_path(customization) %></li>
                     <% else %>
-                      <li><%= link_to _('Edit customisation'), edit_org_admin_template_path(id: customization.id, edit: "true") %></li>
-                      <% if !customization.published? %>
-                        <li><%= link_to _('Publish'), publish_org_admin_template_path(customization) %></li>
-                      <% else %>
-                        <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template) %></li>
-                      <% end %>
-                      <% if customization.plans.length <= 0 %>
-                        <li>
-                          <%= link_to _('Remove'), org_admin_template_path(id: customization.id), 'data-method': 'delete', rel: 'nofollow',
-                              'data-confirm': _('Are you sure you want to remove your customization of "%{template_title}"?') % { template_title: customization.title} %>
-                        </li>
-                      <% end %>
+                      <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(customization) %></li>
+                    <% end %>
+                    <% if customization.plans.length <= 0 %>
+                      <li>
+                        <%= link_to _('Remove'), org_admin_template_path(id: customization.id), 'data-method': 'delete', rel: 'nofollow',
+                            'data-confirm': _('Are you sure you want to remove your customization of "%{template_title}"?') % { template_title: customization.title} %>
+                      </li>
                     <% end %>
                   <% end %>
                 <% end %>

--- a/app/views/org_admin/templates/_templates_list.html.erb
+++ b/app/views/org_admin/templates/_templates_list.html.erb
@@ -13,7 +13,9 @@
       <% if scopes.present? %>
         <tr><th colspan="5" class="sorter-false table-scope"><ul class="nav navbar-nav">
           <% scopes.keys.each do |k| %>
-            <li><%= link_to "#{k.capitalize} (#{scopes[k]})", "#{orgs_org_admin_templates_path(1)}?scope=#{k}", class: 'template-scope', 'data-remote': true %></li>
+            <% unless k == :dmptemplate_ids %>
+              <li><%= link_to "#{k.capitalize} (#{scopes[k]})", "#{hide_actions ? all_org_admin_templates_path(1) : orgs_org_admin_templates_path(1)}?scope=#{k}", class: 'template-scope', 'data-remote': true %></li>
+            <% end %>
           <% end %>
         </ul></th></tr>
       <% end %>
@@ -22,7 +24,7 @@
         <th><%= current_user.can_super_admin? ? _('Organisation') : _('Description') %></th>
         <th><%= _('Status') %></th>
         <th><%= _('Edited Date') %></th>
-        <th class="sorter-false"></th>
+        <% if !hide_actions %><th class="sorter-false"></th><% end %>
       </tr>
     </thead>
     <tbody>
@@ -47,36 +49,38 @@
             <% last_temp_updated = template.updated_at %>
             <%= l last_temp_updated.to_date, formats: :short %>
           </td>
-          <td>
-            <div class="dropdown<%= current_org == template.org.id ? '' : ' hide'%>">
-              <% # Span used to trigger the display of the action dropdowns via JS %>
-              <span class="super-admin-template-org hide"><%= template.org.id %></span>
+          <% if !hide_actions %>
+            <td>
+              <div class="dropdown<%= current_org == template.org.id ? '' : ' hide'%>">
+                <% # Span used to trigger the display of the action dropdowns via JS %>
+                <span class="super-admin-template-org hide"><%= template.org.id %></span>
 
-              <button class="btn btn-link dropdown-toggle" type="button"
-                      data-toggle="dropdown"
-                      aria-haspopup="true" aria-expanded="true">
-                <%= _('Actions') %><span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu">
-                <li><%= link_to _('Edit'), edit_org_admin_template_path(id: template.id, edit: "true") %></li>
-                <li><%= link_to _('History'), history_org_admin_template_path(id: template.id) %></li>
-                <% if !published[template.dmptemplate_id].present? %>
-                  <li><%= link_to _('Publish'), publish_org_admin_template_path(template) %></li>
-                <% elsif template.dirty? %>
-                  <li><%= link_to _('Publish changes'), publish_org_admin_template_path(template) %></li>
-                <% else %>
-                  <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template) %></li>
-                <% end %>
-                <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
-                <% if template.plans.length <= 0 %>
-                  <li>
-                    <%= link_to _('Remove'), org_admin_template_path(id: template.id), 'data-method': 'delete', rel: 'nofollow',
-                                'data-confirm': _('Are you sure you want to remove "%{template_title}"?') % { template_title: template.title} %>
-                  </li>
-                <% end %>
-              </ul>
-            </div>
-         </td>
+                <button class="btn btn-link dropdown-toggle" type="button"
+                        data-toggle="dropdown"
+                        aria-haspopup="true" aria-expanded="true">
+                  <%= _('Actions') %><span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                  <li><%= link_to _('Edit'), edit_org_admin_template_path(id: template.id, edit: "true") %></li>
+                  <li><%= link_to _('History'), history_org_admin_template_path(id: template.id) %></li>
+                  <% if !published[template.dmptemplate_id].present? %>
+                    <li><%= link_to _('Publish'), publish_org_admin_template_path(template) %></li>
+                  <% elsif template.dirty? %>
+                    <li><%= link_to _('Publish changes'), publish_org_admin_template_path(template) %></li>
+                  <% else %>
+                    <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template) %></li>
+                  <% end %>
+                  <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
+                  <% if template.plans.length <= 0 %>
+                    <li>
+                      <%= link_to _('Remove'), org_admin_template_path(id: template.id), 'data-method': 'delete', rel: 'nofollow',
+                                  'data-confirm': _('Are you sure you want to remove "%{template_title}"?') % { template_title: template.title} %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
+           </td>
+         <% end %>
        </tr>
       <% end %>
     </tbody>

--- a/app/views/org_admin/templates/index.html.erb
+++ b/app/views/org_admin/templates/index.html.erb
@@ -20,43 +20,63 @@
     </p>
   </div>
 </div>
-
 <div class="row">
   <div class="col-md-12">
     <ul class="nav nav-tabs" role="tablist">
-      <li role="organisation-templates" class="active">
-        <a href="#organisation-templates" role="tab" aria-controls="organisation-templates" data-toggle="tab"><%= current_user.can_super_admin? ? _('Organisation Templates') : _('Own Templates') %></a>
+      <% if current_user.can_super_admin? %>
+        <li role="all-templates" class="active">
+          <a href="#all-templates" role="tab" aria-controls="all-templates" data-toggle="tab"><%= _('All Templates') %></a>
+        </li>
+      <% end %>
+      <li role="organisation-templates" class="<%= !current_user.can_super_admin? ? 'active' : '' %>">
+        <a href="#organisation-templates" role="tab" aria-controls="organisation-templates" data-toggle="tab"><%= current_user.can_super_admin? ? _('%{org_name} Templates') % { org_name: current_user.org.name } : _('Own Templates') %></a>
       </li>
       <li role="funder-templates">
-        <a href="#funder-templates" role="tab" aria-controls="funder-templates" data-toggle="tab"><%= current_user.can_super_admin? ? _('Funder Templates') : _('Customizable Templates') %></a>
+        <a href="#funder-templates" role="tab" aria-controls="funder-templates" data-toggle="tab"><%= _('Customizable Templates') %></a>
       </li>
     </ul>
   
     <div class="tab-content">
-      <div id="organisation-templates" role="tabpanel" class="tab-pane active">
-        <h2><%= _('Organisation Templates') %></h2>
-        <% if org_templates.length > 0 %>
+      <% if current_user.can_super_admin? %>
+        <div id="all-templates" role="tabpanel" class="tab-pane active">
+          <h2><%= _('All Templates') %></h2>
+          <% if all_templates.length > 0 %>
+            <%= paginable_renderise(
+              partial: 'templates_list',
+              controller: 'org_admin/templates',
+              action: 'all', 
+              scope: all_templates,
+              locals: {current_org: current_org.id, published: published, scopes: scopes[:all], hide_actions: true}) %>
+          <% else %>
+            <p><%= _('There are currently no templates.') %></p>
+          <% end %>
+        </div>
+      <% end %>
+      <div id="organisation-templates" role="tabpanel" class="tab-pane<%= !current_user.can_super_admin? ? ' active' : '' %>">
+        <h2><%= current_user.can_super_admin? ? _('%{org_name} Templates') % { org_name: current_user.org.name } : _('Own Templates') %></h2>
+        <% if own_templates.length > 0 %>
           <%= paginable_renderise(
             partial: 'templates_list',
             controller: 'org_admin/templates',
             action: 'orgs', 
-            scope: org_templates,
-            locals: {current_org: current_org.id, published: published, scopes: scopes[:orgs]}) %>
+            scope: own_templates,
+            locals: {current_org: current_org.id, published: published, scopes: scopes[:orgs], hide_actions: false}) %>
         <% else %>
-          <p><%= _('There are currently no templates defined for your organisation.') %>
+          <p><%= _('There are currently no templates defined for your organisation.') %></p>
         <% end %>
       </div>
+      <!-- If the Org is not just a funder then show the customizations table -->
       <div id="funder-templates" role="tabpanel" class="tab-pane">
-        <h2><%= current_user.can_super_admin? ? _('Funder Templates') : _('Customizable Templates') %></h2>
-        <% if funder_templates.length > 0 %>
+        <h2><%= _('Customizable Templates') %></h2>
+        <% if customizable_templates.length > 0 %>
           <%= paginable_renderise(
             partial: 'funder_templates_list',
             controller: 'org_admin/templates',
             action: 'funders', 
-            scope: funder_templates,
+            scope: customizable_templates,
             locals: {current_org: current_org.id, customizations: customized_templates, published: published, scopes: scopes[:funders]}) %>
         <% else %>
-          <p><%= _('There are currently no funder templates.') %>
+          <p><%= _('There are currently no customisable templates.') %></p>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,7 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
         end
           
         # pagination
+        get 'all/:page', action: :all, on: :collection, as: :all
         get 'funders/:page', action: :funders, on: :collection, as: :funders
         get 'orgs/:page', action: :orgs, on: :collection, as: :orgs
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -165,7 +165,7 @@ token_permission_types.map{ |tpt| TokenPermissionType.create!(tpt) if TokenPermi
 orgs = [
   {name: Rails.configuration.branding[:organisation][:name],
    abbreviation: Rails.configuration.branding[:organisation][:abbreviation],
-   org_type: 3, links: {"org":[]},
+   org_type: 4, links: {"org":[]},
    language_id: Language.find_by(abbreviation: 'en_GB'),
    token_permission_types: TokenPermissionType.all},
   {name: 'Government Agency',
@@ -354,7 +354,7 @@ templates = [
    migrated: false,
    dmptemplate_id: 1,
    visibility: Template.visibilities[:publicly_visible],
-   links: '{"funder":[],"sample_plan":[]}'},
+   links: {"funder":[],"sample_plan":[]}},
   
   {title: "OLD - Department of Testing Award",
    published: false,
@@ -364,7 +364,7 @@ templates = [
    migrated: false,
    visibility: Template.visibilities[:organisationally_visible],
    dmptemplate_id: 2,
-   links: '{"funder":[],"sample_plan":[]}'},
+   links: {"funder":[],"sample_plan":[]}},
      
   {title: "Department of Testing Award",
    published: true,
@@ -374,7 +374,7 @@ templates = [
    migrated: false,
    visibility: Template.visibilities[:organisationally_visible],
    dmptemplate_id: 3,
-   links: '{"funder":[],"sample_plan":[]}'}
+   links: {"funder":[],"sample_plan":[]}}
 ]
 # Template creation calls defaults handler which sets is_default and 
 # published to false automatically, so update them after creation

--- a/lib/assets/javascripts/views/org_admin/templates/index.js
+++ b/lib/assets/javascripts/views/org_admin/templates/index.js
@@ -1,49 +1,4 @@
-import * as notifications from '../../../utils/notificationHelper';
-import { isObject } from '../../../utils/isType';
-import { isValidNumber } from '../../../utils/isValidInputType';
-
 $(() => {
-  // enable the Actions dropdown for each template belonging to the current user's org
-  const enableActions = (ctx) => {
-    if (isValidNumber($(ctx).find('#user_org_id').val())) {
-      $('tr .dropdown .super-admin-template-org').map((idx, el) => {
-        if (isValidNumber($(el).text()) && $(ctx).find('#user_org_id').val().toString() === $(el).text()) {
-          $(el).parent().removeClass('hide');
-        } else {
-          $(el).parent().addClass('hide');
-        }
-        return true;
-      });
-    }
-  };
-  const swapOrg = (ctx) => {
-    if (isValidNumber($(ctx).find('#user_org_id').val())) {
-      notifications.hideNotifications();
-      $.ajax({
-        method: $(ctx).attr('method'),
-        url: $(ctx).attr('action'),
-        data: $(ctx).serializeArray(),
-      }).done((data) => {
-        if (data.msg.length > 0) {
-          notifications.renderNotice(data.msg);
-        } else if (data.err.length > 0) {
-          notifications.renderAlert(data.err);
-        }
-        enableActions(ctx);
-      }).fail((err) => {
-        notifications.renderAlert(err);
-      });
-    }
-  };
-
-  if (isObject($('form#super-admin-switch-org'))) {
-    $('form#super-admin-switch-org').on('submit', (e) => {
-      e.preventDefault();
-      swapOrg(e.target);
-    });
-    enableActions($('form#super-admin-switch-org'));
-  }
-
   // Update the contents of the table when user clicks on a scope link
   $('.template-scope').on('ajax:success', 'a[data-remote="true"]', (e, data) => {
     $(e.target).closest('.paginable').html(data);

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,7 +51,7 @@ class ActiveSupport::TestCase
   def scaffold_template
     template = Template.new(title: 'Test template',
                             description: 'My test template', 
-                            links: '{"funder":[],"sample_plan":[]}',
+                            links: {"funder":[],"sample_plan":[]},
                             org: Org.first, migrated: false, dmptemplate_id: "0000009999")
 
     template.phases << Phase.new(title: 'Test phase',


### PR DESCRIPTION
- Made all change outlined in #900 (except for last 2 which are part of table consolidation work)
- Updated 'Change Org affiliation' button on templates page to be a full page refresh instead of ajax call since the entire contents of 2 tabs need to change.
- Added new scopes to Template model to retrieve customizations in fewer queries
- Simplified functionality of the 'Own templates' and 'Customizable templates' tabs on the templates page so that Super Admin and Org Admin functionality is identical (aside from some labeling changes)
- Added a new 'All templates' tab only visible to Super Admins
- Added unit test for Template model change and extensive tests to the Templates Controller tests
- added checks to `views/layouts/_branding.html.erb` to catch instances where Org doesn't have links defined
