### PR TITLE
updated popover button '?' to display as tooltip

### DIFF
--- a/app/views/shared/_popover.html.erb
+++ b/app/views/shared/_popover.html.erb
@@ -1,8 +1,7 @@
 <%# available locals: message, placement %>
 <% if message.present? %>
-  <a href="#" class="btn btn-default" data-toggle="popover" 
-     title="<%= _('More information') %>" data-content="<%= message %>" 
-     placement="<%= placement %>">
+  <a href="#" class="btn btn-default" data-toggle="tooltip" 
+     title="<%= message %>" placement="<%= placement %>">
     <i class="fa fa-question-circle"></i>
   </a>
 <% end %>

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -185,12 +185,12 @@ $cancel-button-color: #F17D04;
 }
 
 /* Popover button */
-.btn-default[data-toggle=popover],
-.btn-default:hover[data-toggle=popover],
-.btn-default:focus[data-toggle=popover],
-.btn-default:active[data-toggle=popover],
-.btn-default:visited[data-toggle=popover],
-.btn-default:active:hover[data-toggle=popover] {
+.btn-default[data-toggle=tooltip],
+.btn-default:hover[data-toggle=tooltip],
+.btn-default:focus[data-toggle=tooltip],
+.btn-default:active[data-toggle=tooltip],
+.btn-default:visited[data-toggle=tooltip],
+.btn-default:active:hover[data-toggle=tooltip] {
   color: $grey;
   background-color: $white;
   border: none;


### PR DESCRIPTION
Updated shared '?' button to be a tooltip instead of a popover #911