### PR TITLE
fixed '&' bug in autocomplete and fix Plan create styling

### DIFF
--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -19,7 +19,8 @@
                 'data-toggle': 'tooltip',
                 title: _('If applying for funding, state the project title exactly as in the proposal.')) %>
         </div>
-        <div class="col-xs-6 checkbox">
+        <div class="col-md-1">&nbsp;</div>
+        <div class="col-xs-5 checkbox create-plan-mock">
           <%= label_tag(:is_test, raw("#{check_box_tag(:is_test, "1", false)} #{_('mock project for testing, practice, or educational purposes')}")) %>
         </div>
       </div>
@@ -27,7 +28,7 @@
       <!-- Organisation selection -->
       <h2 id="research-org"><%= _('Select the primary research organisation') %></h2>
       <div class="form-group row">
-        <div class="col-xs-6">
+        <div class="col-md-6">
           <%= render partial: "shared/accessible_combobox", 
                      locals: {name: 'plan[org_name]',
                               id: 'plan_org_name',
@@ -38,8 +39,11 @@
                               error: _('You must select a research organisation from the list.'),
                               tooltip: _('Please select a valid research organisation from the list.')} %>
         </div>
-        <div class="col-xs-6 checkbox">
-          <%= label_tag(:plan_no_org, raw("#{check_box_tag(:plan_no_org)} #{_('My research organisation is not on the list')} <em>#{_(' or ')}</em> #{_('no research organisation is associated with this plan')}")) %>
+        <div class="col-md-1 pad-top-10 create-plan-or"><strong>- <%= _('or') %> -</strong></div>
+        <div class="col-md-5 create-plan-checkbox">
+          <div class="checkbox">
+            <%= label_tag(:plan_no_org, raw("#{check_box_tag(:plan_no_org)} #{_('My research organisation is not on the list')} <em>#{_(' or ')}</em> #{_('no research organisation is associated with this plan')}")) %>
+          </div>
         </div>
       </div>
   
@@ -57,8 +61,11 @@
                               error: _('You must select a funding organisation from the list.'),
                               tooltip: _('Please select a valid funding organisation from the list.')} %>
         </div>
-        <div class="col-xs-6 checkbox">
-          <%= label_tag(:plan_no_funder, raw("#{check_box_tag(:plan_no_funder)} #{_('No funder associated with this plan')}")) %>
+        <div class="col-md-1 create-plan-or"><strong>- <%= _('or') %> -</strong></div>
+        <div class="col-xs-5 create-plan-checkbox">
+          <div class="checkbox">
+            <%= label_tag(:plan_no_funder, raw("#{check_box_tag(:plan_no_funder)} #{_('No funder associated with this plan')}")) %>
+          </div>
         </div>
       </div>
 

--- a/app/views/shared/_accessible_combobox.html.erb
+++ b/app/views/shared/_accessible_combobox.html.erb
@@ -5,7 +5,7 @@
   <% error = error ||= _('Please select an item from the list.') %>
 
   <% json = {} %>
-  <% models.map{|m| json[m[attribute]] = m.id} %>
+  <% models.map{|m| json["#{m[attribute]}"] = m.id} %>
 
   <input type="text" name="<%= name %>" id="<%= id %>" 
          class="js-combobox form-control <%= classes %>" list="<%= id %>_list" 
@@ -24,7 +24,7 @@
   </datalist>
 
   <!-- Complete content of combobox -->
-  <input type="hidden" id="<%= id %>_crosswalk" value="<%= escape_javascript json.to_json %>" />
+  <input type="hidden" id="<%= id %>_crosswalk" value="<%= escape_javascript JSON.generate(json) %>" />
 
   <!-- The JQuery accessible combobox doesn't allow for an id to be present in the value attribute -->
   <!-- so we use this hidden input to store the selected id -->

--- a/lib/assets/javascripts/utils/autoComplete.js
+++ b/lib/assets/javascripts/utils/autoComplete.js
@@ -15,8 +15,25 @@ const updateIdField = (el) => {
   if (isObject(crosswalk) && isObject($(idField))) {
     const json = JSON.parse(`${$(crosswalk).val().replace(/\\"/g, '"').replace(/\\'/g, '\'')}`);
     const selection = (json[$(el).val()] === undefined ? '' : json[$(el).val()]);
-    $(el).parent().siblings(`#${idField}`).val(selection);
+    $(el).parent().siblings(`#${idField}`).val(selection)
+      .change();
   }
+};
+
+/*
+ * The accessible autocomplete box escapes characters so we need to decode any valid ones
+ * so that they appear correctly to the user and are able to be matched to the JSON list
+ * so we can retrieve the correct org id.
+ * We only decode certain characters here by design.
+ */
+const decodeHtml = (el) => {
+  if (isObject(el)) {
+    return $(el).val()
+      .replace(/&amp;/g, '&')
+      .replace(/&apos;/g, '\'')
+      .replace(/&quot;/g, '"');
+  }
+  return '';
 };
 
 /*
@@ -51,8 +68,10 @@ export default () => {
     }, 100);
 
     // When the value in the combobox changes update the hidden id field
-    $(el).on('keyup blur', (e) => {
-      debounced($(e.currentTarget));
+    $(el).on('keyup focus', (e) => {
+      const txt = $(e.target);
+      $(txt).val(decodeHtml(txt));
+      debounced(txt);
     });
 
     // Clear the text and hide the button when the user clicks the clear button

--- a/lib/assets/javascripts/views/plans/new.js
+++ b/lib/assets/javascripts/views/plans/new.js
@@ -97,7 +97,7 @@ $(() => {
   });
 
   // Make sure the checkbox is unchecked if we're entering text
-  $('#new_plan #plan_org_name, #new_plan #plan_funder_name').on('keyup blur', (e) => {
+  $('#new_plan #plan_org_id, #new_plan #plan_funder_id').change((e) => {
     const whichOne = $(e.currentTarget).prop('id').split('_')[1];
     $(`#plan_no_${whichOne}`).prop('checked', false);
     handleComboboxChange();

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -408,11 +408,11 @@ $tooltip-background: $grey;
   top: 0;
   right: 0;
   margin-top: 2px;
-  margin-right: -35px;
+  margin-right: -28px;
   border: none;
   background: transparent;
   color: $grey;
-  padding-top: 3px;
+  padding-top: 4px;
   font-size: 16pt;
 }
 
@@ -435,3 +435,14 @@ $tooltip-background: $grey;
   strong { margin: 0 10px; }
 }
 
+/* Plan creation */
+.create-plan-or {
+  padding: 5px 0 0 15px;
+}
+.create-plan-checkbox {
+  margin-left: -40px;
+  margin-top: -5px;
+}
+.create-plan-mock {
+  margin-left: -40px;
+}


### PR DESCRIPTION
- Fixes autocomplete bug with '&' character (also now allowing single/double quotes) #396 
- Discovered and fixed timing issue for when template options are loaded
- Fixed alignment of controls on create plan page #920
