### PR TITLE
Changes to annotations when customizing template

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -19,23 +19,23 @@ class AnnotationsController < ApplicationController
       template.dirty = true
       template.save!
     end
-    redirect_to controller: :phases, action: :admin_show, id: question.section.phase.id
+    redirect_to "#{admin_show_phase_path(question.section.phase.id)}?section_id=#{question.section.id}"
   end
 
   #delete an annotation
   def admin_destroy
     annotation = Annotation.find(params[:id])
     authorize annotation
-    phase_id = Annotation.joins("INNER JOIN questions ON annotations.question_id = questions.id").joins("INNER JOIN sections ON questions.section_id = sections.id").joins("INNER JOIN phases ON sections.phase_id = phases.id").where("annotations.id": params[:id]).pluck("phases.id").first #annotation.question.section.phase.id
+    parent_ids = Annotation.joins("INNER JOIN questions ON annotations.question_id = questions.id").joins("INNER JOIN sections ON questions.section_id = sections.id").joins("INNER JOIN phases ON sections.phase_id = phases.id").where("annotations.id": params[:id]).pluck("phases.id", "sections.id").first #annotation.question.section.phase.id
     if annotation.present?
       type = (annotation.type == Annotation.types[:example_answer] ? 'example answer' : 'guidance')
       if annotation.destroy!
-        flash[:notice] = success_message(type, _('removed'))
+        flash[:notice] = success_message(type, _('deleted'))
       else
         flash[:alert] = failed_destroy_error(annotation, type)
       end
     end
-    redirect_to controller: :phases, action: :admin_show, id: phase_id
+    redirect_to "#{admin_show_phase_path(parent_ids[0])}?section_id=#{parent_ids[1]}"
   end
 
   private

--- a/app/views/annotations/_new_edit.html.erb
+++ b/app/views/annotations/_new_edit.html.erb
@@ -15,7 +15,7 @@
       <div class="pull-right">
         <%= submit_tag _('Save'), class: 'btn btn-primary' %>
         <%= hidden_field_tag :question_id, question.id, class: "question_id" %>
-        <%= link_to _('Cancel'), "#edit_annotations_div_#{question.id}", class: 'btn cancel btn-default cancel_edit_annotations', role: 'button' %>
+        <%= link_to _('Cancel'), "#annotations_div_#{question.id}", class: 'btn cancel btn-default cancel_edit_annotations', role: 'button' %>
       </div>
     </div>
   </div>

--- a/app/views/questions/_show_question.html.erb
+++ b/app/views/questions/_show_question.html.erb
@@ -75,14 +75,6 @@
               <div id="add_annotations_button_<%= question.id %>" class="pull-right">
                 <%= link_to _('%{add_or_edit} Annotations') % { add_or_edit: (editing ? 'Edit' : 'Add') }, 
                             "#annotations_div_#{question.id}", class: "btn btn-default annotations_button", role:"button" %>
-                <% if example_answer.present? %>
-                  <%= link_to _('Delete Example Answer'), admin_destroy_annotation_path(id: example_answer.id), 'data-method': 'delete', 
-                              rel: 'nofollow', class: "btn btn-default", 'data-confirm': _("Are you sure you would like to remove the example answer for this question?") %>
-                <% end %>
-                <% if guidance.present? %>
-                  <%= link_to _('Delete Guidance'), admin_destroy_annotation_path(id: guidance.id), 'data-method': 'delete',
-                              rel: 'nofollow', class: "btn btn-default", 'data-confirm': _("Are you sure you would like to remove the guidance for this question?") %>
-                <% end %>
               </div>
             <% end %>
           </div>

--- a/test/functional/annotations_controller_test.rb
+++ b/test/functional/annotations_controller_test.rb
@@ -30,7 +30,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     put admin_update_annotation_path(id: @question.section.phase.id), @create_hash
     assert_response :redirect
-    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}"
+    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}?section_id=#{@question.section.id}"
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('example answer') && flash[:notice].include?('guidance')
     assert_equal 'New example', Annotation.find_by(@example_answer_qry).text, "expected example answer to have been created."
     assert_equal 'New guidance', Annotation.find_by(@guidance_qry).text, "expected guidance to have been created."
@@ -40,7 +40,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     put admin_update_annotation_path(id: @question.section.phase.id), {question_id: @question.id, example_answer_text: "New example"}
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('updated')
     assert_response :redirect
-    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}"
+    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}?section_id=#{@question.section.id}"
     assert_equal 'New example', Annotation.find_by(@example_answer_qry).text, "expected example answer to have been created."
     assert Annotation.find_by(@guidance_qry).nil?, "expected no guidance to have been created."
   end
@@ -49,7 +49,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     put admin_update_annotation_path(id: @question.section.phase.id), {question_id: @question.id, guidance_text: "New guidance"}
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('updated')
     assert_response :redirect
-    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}"
+    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}?section_id=#{@question.section.id}"
     assert Annotation.find_by(@example_answer_qry).nil?, "expected no example answer to have been created."
     assert_equal 'New guidance', Annotation.find_by(@guidance_qry).text, "expected guidance to have been created."
   end
@@ -60,7 +60,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     put admin_update_annotation_path(id: @question.section.phase.id), {question_id: @question.id, example_answer_text: "Updated example", guidance_text: "Updated guidance"}
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('updated')
     assert_response :redirect
-    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}"
+    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}?section_id=#{@question.section.id}"
     assert_equal 'Updated example', Annotation.find_by(@example_answer_qry).text, "expected example answer to have been updated."
     assert_equal 'Updated guidance', Annotation.find_by(@guidance_qry).text, "expected guidance to have been updated."
   end
@@ -70,7 +70,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     put admin_update_annotation_path(id: @question.section.phase.id), {question_id: @question.id, guidance_text: "Updated guidance"}
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('updated')
     assert_response :redirect
-    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}"
+    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}?section_id=#{@question.section.id}"
     assert Annotation.find_by(@example_answer_qry).nil?, "expected example answer to have been removed."
     assert_equal 'Updated guidance', Annotation.find_by(@guidance_qry).text, "expected guidance to have been updated."
   end
@@ -80,7 +80,7 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     put admin_update_annotation_path(id: @question.section.phase.id), {question_id: @question.id, example_answer_text: "Updated example"}
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('updated')
     assert_response :redirect
-    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}"
+    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}?section_id=#{@question.section.id}"
     assert_equal 'Updated example', Annotation.find_by(@example_answer_qry).text, "expected example answer to have been updated."
     assert Annotation.find_by(@guidance_qry).nil?, "expected guidance to have been removed."
   end
@@ -89,9 +89,9 @@ class AnnotationsControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     put admin_update_annotation_path(id: @question.section.phase.id), @create_hash
     delete admin_destroy_annotation_path(Annotation.find_by(@example_answer_qry))
-    assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('removed')
+    assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('deleted')
     assert_response :redirect
-    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}"
+    assert_redirected_to "#{admin_show_phase_path(@question.section.phase.id)}?section_id=#{@question.section.id}"
     assert Annotation.find_by(@example_answer_qry).nil?
     assert_equal 'New guidance', Annotation.find_by(@guidance_qry).text, "expected guidance to have been unchanged."
   end


### PR DESCRIPTION
Per #938 
- Updated annotations controller to pass the current section in the redirect so that it is auto-expanded when the page reloads
- Fixed issue with Cancel button
- deleted the 'delete example answer' and 'delete guidance' buttons. The user can click 'edit' and then blank out the individual fields and click Save to remove them. This makes the behavior similar to the way example answers and guidance are saved on the normal template edit page. I left the controller endpoint in place in case there are objections and we need to reimplement