### PR TITLE
Add popover/tooltip for template visibility

### DIFF
--- a/app/views/org_admin/templates/_edit_template.html.erb
+++ b/app/views/org_admin/templates/_edit_template.html.erb
@@ -14,6 +14,9 @@
 
   <div class="form-group col-xs-8">
     <%= f.label _('Visibility'), class: 'control-label' %>
+    <%= render partial: 'shared/popover', 
+               locals: { message: _('Checking this box prevents the template from appearing in the public list of templates.'),
+                         placement: 'right' }%>
     <div class="checkbox">
       <%= f.label(:visibility,
           raw("#{check_box_tag('template_visibility', '0', (template.visibility == 'organisationally_visible'))} #{_('for internal %{org_name} use only') % {org_name: @template.org.name}}")) %>


### PR DESCRIPTION
Added a '?' button to the visibility field on the template details page #845