### PR TITLE
Hide the Organisational plans if use is associated with 'Other' org

### DIFF
--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -30,7 +30,7 @@
 </div>
 <div class="row">
   <div class="col-md-12">
-    <% if @organisationally_or_publicly_visible.length > 0 %>
+    <% if @organisationally_or_publicly_visible.length > 0 && !current_user.org.is_other? %>
       <%= paginable_renderise(
         partial: '/paginable/plans/organisationally_or_publicly_visible',
         controller: 'paginable/plans',


### PR DESCRIPTION
Do not show the Organisational plans table if the user is attached to the default Other org: `Org.find_by(is_other: true)` 