### PR TITLE
Final updates to templates page

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -501,18 +501,13 @@ module OrgAdmin
         
         scopes = calculate_table_scopes(templates, customizations)
 
-        # We scope based on the customizations if the user is NOT a super admin
+        # We scope based on the customizations
         if params[:scope].present? && params[:scope] != 'all'
-          if current_user.can_super_admin?
-            templates = templates.where(published: true) if params[:scope] == 'published'
-            templates = templates.where(published: false) if params[:scope] == 'unpublished'
-          else
-            scoped = templates.select do |t| 
-              c = customizations[t.dmptemplate_id]
-              (params[:scope] == 'unpublished' && (!c.present? || !c.published?)) || (params[:scope] == 'published' && c.present? && c.published?)
-            end
-            templates = Template.where(id: scoped.collect(&:id))
+          scoped = templates.select do |t| 
+            c = customizations[t.dmptemplate_id]
+            (params[:scope] == 'unpublished' && (!c.present? || !c.published?)) || (params[:scope] == 'published' && c.present? && c.published?)
           end
+          templates = Template.where(id: scoped.collect(&:id))
         end
 
       else
@@ -541,7 +536,7 @@ module OrgAdmin
       scopes = { all: templates.length, published: 0, unpublished: 0, dmptemplate_ids: templates.collect(&:dmptemplate_id).uniq }
       templates.each do |t|
         # If we have customizations use their status
-        if customizations.respond_to?(:keys)
+        if customizations.keys.length > 0
           c = customizations[t.dmptemplate_id]
           # If the template was not customized then its unpublished
           if c.nil?

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -104,6 +104,9 @@ class Org < ActiveRecord::Base
       return "None"
   end
 
+  def funder_only?
+    self.org_type == Org.org_type_values_for(:funder).min
+  end
 
   ##
   # returns the name of the organisation

--- a/app/views/org_admin/templates/_edit_template.html.erb
+++ b/app/views/org_admin/templates/_edit_template.html.erb
@@ -29,7 +29,7 @@
         <% if template_hash[:live].nil? %>
           <%= _('Unpublished') %>
         <% elsif template_hash[:current].dirty? %>
-          <%= _('You have un-published changes') %>
+          <%= _('You have unpublished changes') %>
         <% else %>
           <%= _('Published') %>
         <% end %>

--- a/app/views/org_admin/templates/_funder_templates_list.html.erb
+++ b/app/views/org_admin/templates/_funder_templates_list.html.erb
@@ -45,9 +45,9 @@
                 <%= _('Original funder template has changed!')%>
               <% elsif !template.published? %>
                 <!-- The template does not have a live version -->
-                <%= b_label = _('Funder version is un-published') %>
+                <%= b_label = _('Funder version is unpublished') %>
               <% elsif customization.dirty? %>
-                <%= _('You have un-published changes') %>
+                <%= _('You have unpublished changes') %>
               <% elsif customization.published? %>
                 <%= _('Published') %>
               <% else %>

--- a/app/views/org_admin/templates/_show_template.html.erb
+++ b/app/views/org_admin/templates/_show_template.html.erb
@@ -12,7 +12,7 @@
       <%= _('Unpublished') %>
     
     <% elsif template_hash[:current].dirty? %>
-      <%= _('You have un-published changes') %>
+      <%= _('You have unpublished changes') %>
     
     <% else %>
       <%= _('Published') %>

--- a/app/views/org_admin/templates/index.html.erb
+++ b/app/views/org_admin/templates/index.html.erb
@@ -25,60 +25,53 @@
     <ul class="nav nav-tabs" role="tablist">
       <% if current_user.can_super_admin? %>
         <li role="all-templates" class="active">
-          <a href="#all-templates" role="tab" aria-controls="all-templates" data-toggle="tab"><%= _('All Templates') %></a>
+          <a data-target="#all-templates" role="tab" aria-controls="all-templates" data-toggle="tab"><%= _('All Templates') %></a>
         </li>
       <% end %>
       <li role="organisation-templates" class="<%= !current_user.can_super_admin? ? 'active' : '' %>">
-        <a href="#organisation-templates" role="tab" aria-controls="organisation-templates" data-toggle="tab"><%= current_user.can_super_admin? ? _('%{org_name} Templates') % { org_name: current_user.org.name } : _('Own Templates') %></a>
+        <a data-target="#organisation-templates" role="tab" aria-controls="organisation-templates" data-toggle="tab"><%= current_user.can_super_admin? ? _('%{org_name} Templates') % { org_name: current_user.org.name } : _('Own Templates') %></a>
       </li>
-      <li role="funder-templates">
-        <a href="#funder-templates" role="tab" aria-controls="funder-templates" data-toggle="tab"><%= _('Customizable Templates') %></a>
-      </li>
+      <!-- If the Org is not just a funder then show the customizations table -->
+      <% if !current_org.funder_only? %>
+        <li role="funder-templates">
+          <a data-target="#funder-templates" role="tab" aria-controls="funder-templates" data-toggle="tab"><%= _('Customizable Templates') %></a>
+        </li>
+      <% end %>
     </ul>
   
     <div class="tab-content">
       <% if current_user.can_super_admin? %>
         <div id="all-templates" role="tabpanel" class="tab-pane active">
           <h2><%= _('All Templates') %></h2>
-          <% if all_templates.length > 0 %>
-            <%= paginable_renderise(
-              partial: 'templates_list',
-              controller: 'org_admin/templates',
-              action: 'all', 
-              scope: all_templates,
-              locals: {current_org: current_org.id, published: published, scopes: scopes[:all], hide_actions: true}) %>
-          <% else %>
-            <p><%= _('There are currently no templates.') %></p>
-          <% end %>
+          <%= paginable_renderise(
+            partial: 'templates_list',
+            controller: 'org_admin/templates',
+            action: 'all', 
+            scope: all_templates,
+            locals: {current_org: current_org.id, published: published, scopes: scopes[:all], hide_actions: true}) %>
         </div>
       <% end %>
       <div id="organisation-templates" role="tabpanel" class="tab-pane<%= !current_user.can_super_admin? ? ' active' : '' %>">
         <h2><%= current_user.can_super_admin? ? _('%{org_name} Templates') % { org_name: current_user.org.name } : _('Own Templates') %></h2>
-        <% if own_templates.length > 0 %>
-          <%= paginable_renderise(
-            partial: 'templates_list',
-            controller: 'org_admin/templates',
-            action: 'orgs', 
-            scope: own_templates,
-            locals: {current_org: current_org.id, published: published, scopes: scopes[:orgs], hide_actions: false}) %>
-        <% else %>
-          <p><%= _('There are currently no templates defined for your organisation.') %></p>
-        <% end %>
+        <%= paginable_renderise(
+          partial: 'templates_list',
+          controller: 'org_admin/templates',
+          action: 'orgs', 
+          scope: own_templates,
+          locals: {current_org: current_org.id, published: published, scopes: scopes[:orgs], hide_actions: false}) %>
       </div>
       <!-- If the Org is not just a funder then show the customizations table -->
-      <div id="funder-templates" role="tabpanel" class="tab-pane">
-        <h2><%= _('Customizable Templates') %></h2>
-        <% if customizable_templates.length > 0 %>
+      <% if !current_org.funder_only? %>
+        <div id="funder-templates" role="tabpanel" class="tab-pane">
+          <h2><%= _('Customizable Templates') %></h2>
           <%= paginable_renderise(
             partial: 'funder_templates_list',
             controller: 'org_admin/templates',
             action: 'funders', 
             scope: customizable_templates,
             locals: {current_org: current_org.id, customizations: customized_templates, published: published, scopes: scopes[:funders]}) %>
-        <% else %>
-          <p><%= _('There are currently no customisable templates.') %></p>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
 
     <a href="<%= new_org_admin_template_path %>" class="btn btn-primary" role="button">

--- a/test/functional/org_admin/templates_controller_test.rb
+++ b/test/functional/org_admin/templates_controller_test.rb
@@ -513,28 +513,32 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
   end
   
   def verify_funder_templates_table(user)
-    assert_select "#funder-templates table tbody" do |el|
-      # An Org Admin should see all of the funder/default templates (except ones that belong to their org)
-      templates = Template.where("(org_id IN (?) OR is_default = ?) AND org_id != ?", Org.where(org_type: [2,3]).collect(&:id), true, user.org.id)
-      if user.can_org_admin?
-        templates.each do |template|
-          # Expect to only see published public templates
-          if template.publicly_visible? && template.published?
-            assert el.to_s.include?(template.title), "expected #{user.email}'s customizable table to have the funder (or default) template: '#{template.title}'" 
-          else
-            assert_not el.to_s.include?(template.title), "expected #{user.email}'s customizable table to NOT have the unpublished/non-public funder template: '#{template.title}' (from org: #{template.org.abbreviation})"
-          end
-        end
-
-        # Expect to see only the current org's customizations
-        Template.where.not(id: templates.collect(&:id)).each do |template|
-          if template.customization_of.nil?
-            assert_not el.to_s.include?(template.title), "expected #{user.email}'s customizable table to NOT have the template from a non-funder org: '#{template.title}'"
-          else
-            if template.org == user.org
-              assert el.to_s.include?(template.title), "expected #{user.email}'s customizable table to have their own customization: '#{template.title}'" 
+    if user.org.funder_only?
+      assert_select "#funder-templates table tbody", 0, "expected a funder only Org to NOT see the customizable table"
+    else
+      assert_select "#funder-templates table tbody" do |el|
+        # An Org Admin should see all of the funder/default templates (except ones that belong to their org)
+        templates = Template.where("(org_id IN (?) OR is_default = ?) AND org_id != ?", Org.where(org_type: [2,3]).collect(&:id), true, user.org.id)
+        if user.can_org_admin?
+          templates.each do |template|
+            # Expect to only see published public templates
+            if template.publicly_visible? && template.published?
+              assert el.to_s.include?(template.title), "expected #{user.email}'s customizable table to have the funder (or default) template: '#{template.title}'" 
             else
-              assert_not el.to_s.include?(template.title), "expected #{user.email}'s customizable table to NOT have a customization from another organisation: '#{template.title}'"
+              assert_not el.to_s.include?(template.title), "expected #{user.email}'s customizable table to NOT have the unpublished/non-public funder template: '#{template.title}' (from org: #{template.org.abbreviation})"
+            end
+          end
+
+          # Expect to see only the current org's customizations
+          Template.where.not(id: templates.collect(&:id)).each do |template|
+            if template.customization_of.nil?
+              assert_not el.to_s.include?(template.title), "expected #{user.email}'s customizable table to NOT have the template from a non-funder org: '#{template.title}'"
+            else
+              if template.org == user.org
+                assert el.to_s.include?(template.title), "expected #{user.email}'s customizable table to have their own customization: '#{template.title}'" 
+              else
+                assert_not el.to_s.include?(template.title), "expected #{user.email}'s customizable table to NOT have a customization from another organisation: '#{template.title}'"
+              end
             end
           end
         end


### PR DESCRIPTION
Based on feedback in #955 
- changed all 'un-published' text to 'unpublished'
- Fixed issues with 'Published' and 'Unpublished' filter counts
- Hide Customizable templates table if the user's Org is a funder only
- Updated test