### PR TITLE
updated iterator on admin_template page to remove nil access errors

### DIFF
--- a/app/views/templates/admin_template.html.erb
+++ b/app/views/templates/admin_template.html.erb
@@ -36,7 +36,7 @@
         <%= render partial: 'templates/show_phases_sections', locals: {phase: phase[:data], phase_hash: phase, template: @template, current: @current} %>
       <% end %>
     <% else %>
-      <% (1..@hash[:template][:phases].length).each do |phase_no| %>
+      <% @hash[:template][:phases].keys.sort.each do |phase_no| %>
         <% phase = @hash[:template][:phases][phase_no] %>
         <div class="accordion" id="project-accordion">
           <div class="accordion-group">


### PR DESCRIPTION
Fixes a bug where a template would not display.

The user had deleted phase 1 but kept 2,3 this caused a nil error with the old iterator.  Fixed by iterating over the sorted list of keys from the hash

NOTE:
This is a bugfix to be applied to Master & any live services.

