### PR TITLE
Fixed issue with organisationally_publicly_visible scope

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -61,10 +61,11 @@ class Plan < ActiveRecord::Base
 
   # Retrieves any plan organisationally or publicly visible for a given org id
   scope :organisationally_or_publicly_visible, -> (user) {
-    includes([:template, :roles])
+    includes(:template, {roles: :user})
       .where({
         visibility: [visibilities[:organisationally_visible], visibilities[:publicly_visible]],
-        "templates.org_id": user.org_id})
+        "roles.access": Role.access_values_for(:creator, :administrator, :editor, :commenter).min,
+        "users.org_id": user.org_id})
       .where(['NOT EXISTS (SELECT 1 FROM roles WHERE plan_id = plans.id AND user_id = ?)', user.id])
   }
 


### PR DESCRIPTION
Fixes issue discovered in #1012 

The old query that retrieved the list of organisationally and publicly visible plans on the user's dashboard was incorrectly using `templates.org_id` when it should have been using the creator's `users.org_id`.