### PR TITLE
Issue 1055

### DIFF
--- a/app/controllers/guidances_controller.rb
+++ b/app/controllers/guidances_controller.rb
@@ -6,8 +6,8 @@ class GuidancesController < ApplicationController
   # GET /guidances
   def admin_index
     authorize Guidance
-    @guidances = policy_scope(Guidance)
-    @guidance_groups = GuidanceGroup.where(org_id: current_user.org_id)
+    @guidances = Guidance.by_org(current_user.org).includes(:guidance_group, :themes).page(1)
+    @guidance_groups = GuidanceGroup.by_org(current_user.org).page(1)
   end
 
   def admin_new

--- a/app/controllers/paginable/guidance_groups_controller.rb
+++ b/app/controllers/paginable/guidance_groups_controller.rb
@@ -1,0 +1,11 @@
+module Paginable 
+  class GuidanceGroupsController < ApplicationController
+    include Paginable
+    # /paginable/guidance_groups/index/:page
+    def index
+      authorize(Guidance)
+      paginable_renderise(partial: 'index',
+        scope: GuidanceGroup.by_org(current_user.org))
+    end
+  end
+end

--- a/app/controllers/paginable/guidances_controller.rb
+++ b/app/controllers/paginable/guidances_controller.rb
@@ -1,0 +1,11 @@
+module Paginable 
+  class GuidancesController < ApplicationController
+    include Paginable
+    # /paginable/guidances/index/:page
+    def index
+      authorize(Guidance)
+      paginable_renderise(partial: 'index',
+        scope: Guidance.by_org(current_user.org).includes(:guidance_group, :themes))
+    end
+  end
+end

--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -11,4 +11,15 @@ class Paginable::PlansController < ApplicationController
     paginable_renderise(partial: 'organisationally_or_publicly_visible',
       scope: Plan.organisationally_or_publicly_visible(current_user))
   end
+  # GET /paginable/plans/publicly_visible/:page
+  def publicly_visible
+    paginable_renderise(partial: 'publicly_visible',
+      scope: Plan.publicly_visible)
+  end
+  # GET /paginable/plans/org_admin/:page
+  def org_admin
+    raise Pundit::NotAuthorizedError unless current_user.present? && current_user.can_org_admin?
+    paginable_renderise(partial: 'org_admin',
+      scope: current_user.org.plans)
+  end
 end

--- a/app/controllers/paginable/templates_controller.rb
+++ b/app/controllers/paginable/templates_controller.rb
@@ -2,7 +2,7 @@ class Paginable::TemplatesController < ApplicationController
   include Paginable
   include TemplateFilter
       
-  # GET /org_admin/templates/all/:page  (AJAX)
+  # GET /paginable/templates/all/:page  (AJAX)
   # -----------------------------------------------------
   def all
     raise Pundit::NotAuthorizedError unless Paginable::TemplatePolicy.new(current_user).all?
@@ -23,7 +23,7 @@ class Paginable::TemplatesController < ApplicationController
                                   scopes: hash[:scopes]}
   end
   
-  # GET /org_admin/templates/funders/:page  (AJAX)
+  # GET /paginable/templates/funders/:page  (AJAX)
   # -----------------------------------------------------
   def funders
     raise Pundit::NotAuthorizedError unless Paginable::TemplatePolicy.new(current_user).funders?
@@ -44,7 +44,7 @@ class Paginable::TemplatesController < ApplicationController
                                   scopes: hash[:scopes] }
   end
   
-  # GET /org_admin/templates/orgs/:page  (AJAX)
+  # GET /paginable/templates/orgs/:page  (AJAX)
   # -----------------------------------------------------
   def orgs
     raise Pundit::NotAuthorizedError unless Paginable::TemplatePolicy.new(current_user).orgs?
@@ -63,5 +63,16 @@ class Paginable::TemplatesController < ApplicationController
                                   customizations: hash[:customizations],
                                   published: published,
                                   scopes: hash[:scopes]}
+  end
+
+  # GET /paginable/templates/publicly_visible/:page  (AJAX)
+  # -----------------------------------------------------
+  def publicly_visible
+    template_ids = Template.families(Org.funder.pluck(:id)).publicly_visible.pluck(:dmptemplate_id) <<
+    Template.where(is_default: true).valid.published.pluck(:dmptemplate_id)
+
+    paginable_renderise(
+      partial: 'publicly_visible',
+      scope: Template.includes(:org).where(dmptemplate_id: template_ids.uniq.flatten).valid.published)
   end
 end

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -4,13 +4,9 @@ class PublicPagesController < ApplicationController
   # GET template_index
   # -----------------------------------------------------
   def template_index
-    template_ids = Template.where(org_id: Org.funder.pluck(:id), visibility: Template.visibilities[:publicly_visible]).valid.pluck(:dmptemplate_id).uniq << Template.where(is_default: true, published: true).pluck(:dmptemplate_id)
-    @templates = []
-    template_ids.flatten.each do |tid|
-      t = Template.live(tid)
-      @templates << t unless t.nil?
-    end
-    @templates = @templates.sort{|x,y| x.title <=> y.title } if @templates.count > 1
+    template_ids = Template.families(Org.funder.pluck(:id)).publicly_visible.pluck(:dmptemplate_id) <<
+    Template.where(is_default: true).valid.published.pluck(:dmptemplate_id)
+    @templates = Template.includes(:org).where(dmptemplate_id: template_ids.uniq.flatten).valid.published.order(title: :asc).page(1)
   end
 
   # GET template_export/:id
@@ -119,7 +115,6 @@ class PublicPagesController < ApplicationController
   # GET /plans_index
   # ------------------------------------------------------------------------------------
   def plan_index
-    @plans = Plan.publicly_visible
-    @plans = @plans.sort{|x,y| x.title <=> y.title } if @plans.count > 1
+    @plans = Plan.publicly_visible.order(:title => :asc).page(1)
   end
 end

--- a/app/models/guidance.rb
+++ b/app/models/guidance.rb
@@ -27,7 +27,15 @@ class Guidance < ActiveRecord::Base
 
   validates :text, presence: {message: _("can't be blank")}
 
+  # Retrieves every guidance associated to an org
+  scope :by_org, -> (org) {
+    joins(:guidance_group).merge(GuidanceGroup.by_org(org))
+  }
 
+  scope :search, -> (term) {
+    search_pattern = "%#{term}%"
+    joins(:guidance_group).where("guidances.text LIKE ? OR guidance_groups.name LIKE ?", search_pattern, search_pattern)
+  }
   ##
   # Determine if a guidance is in a group which belongs to a specified organisation
   #
@@ -40,20 +48,6 @@ class Guidance < ActiveRecord::Base
   		end
     end
 		return false
-	end
-
-  ##
-  # returns all guidance that belongs to a specified organisation
-  #
-  # @param org_id [Integer] the integer id for an organisation
-  # @return [Array<Guidance>] list of guidance
-	def self.by_org(org_id)
-    org_guidance = []
-    # TODO: re-write below querry when guidance_in_group removed from model
-    Org.find_by(id: org_id).guidance_groups.each do |group|
-      org_guidance += Guidance.where(guidance_group_id: group.id)
-    end
-		return org_guidance
 	end
 
   ##

--- a/app/models/guidance_group.rb
+++ b/app/models/guidance_group.rb
@@ -22,10 +22,14 @@ class GuidanceGroup < ActiveRecord::Base
   #
   # What do they do? do they do it efficiently, and do we need them?
 
-
-
-
-
+  # Retrieves every guidance group associated to an org
+  scope :by_org, -> (org) {
+    where(org_id: org.id)
+  }
+  scope :search, -> (term) {
+    search_pattern = "%#{term}%"
+    where("name LIKE ?", search_pattern)
+  }
 
   ##
   # Converts the current guidance group to a string containing the display name.

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -52,7 +52,7 @@ class Plan < ActiveRecord::Base
 
   # Scope queries
   # Note that in ActiveRecord::Enum the mappings are exposed through a class method with the pluralized attribute name (e.g visibilities rather than visibility)
-  scope :publicly_visible, -> { where(:visibility => visibilities[:publicly_visible]).order(:title => :asc) }
+  scope :publicly_visible, -> { includes(:template).where(:visibility => visibilities[:publicly_visible]) }
 
   # Retrieves any plan in which the user has an active role and it is not a reviewer
   scope :active, -> (user) {

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -47,7 +47,7 @@ class Template < ActiveRecord::Base
     Template.where(templates: { is_default: is_default }).valid().published()
   }
 
-  scope :publicly_visible, -> { where(:visibility => Template.visibilities[:publicly_visible]).order(:title => :asc) }
+  scope :publicly_visible, -> { where(:visibility => Template.visibilities[:publicly_visible]) }
 
   # Retrieves template with distinct dmptemplate_id that are valid (e.g. migrated false) and customization_of is nil. Note,
   # if organisation ids are passed, the query will filter only those distinct dmptemplate_ids for those organisations

--- a/app/policies/guidance_policy.rb
+++ b/app/policies/guidance_policy.rb
@@ -19,6 +19,10 @@ class GuidancePolicy < ApplicationPolicy
     user.can_modify_guidance? && guidance.in_group_belonging_to?(user.org_id)
   end
 
+  def index?
+    admin_index?
+  end
+
   def admin_index?
     user.can_modify_guidance?
   end
@@ -57,11 +61,5 @@ class GuidancePolicy < ApplicationPolicy
 
   def update_questions?
     user.can_modify_guidance?
-  end
-
-  class Scope < Scope
-    def resolve
-      scope = Guidance.includes(:guidance_group, :themes).by_org(user.org_id)
-    end
   end
 end

--- a/app/views/guidances/admin_index.html.erb
+++ b/app/views/guidances/admin_index.html.erb
@@ -13,75 +13,11 @@
     <h2><%= _('Guidance group list') %></h2>
   
     <!-- List of guidance groups -->
-    <% if @guidance_groups.length > 0 then%>
-    <div class="table-responsive">
-      <table class="table table-hover tablesorter" id="guidance-groups">
-        <thead>
-          <% if @guidance_groups.length > TABLE_FILTER_MIN_ROWS %>
-            <tr>
-              <th colspan="5" class="sorter-false">
-                <%= render(partial: "shared/table_filter",
-                            locals: {path: admin_index_guidance_path(current_user.org_id), placeholder: _('Filter guidance groups')}) %>
-              </th>
-            </tr>
-          <% end %>
-          <tr>
-            <th><%= _('Name') %></th>
-            <th class="text-center"><%= _('Status') %></th>
-            <th class="text-center"><%= _('Optional subset') %></th>
-            <th class="text-center"><%= _('Last updated') %></th>
-            <th class="sorter-false"><span aria-hidden="false" class="sr-only"><%= _('Actions') %></span></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% !@guidance_groups.each do |guidance_gr| %>
-            <tr>
-              <td>
-                <%= guidance_gr.name %>
-              </td>
-              <td class="text-center">
-                <% if guidance_gr.published.nil? || guidance_gr.published == false then%>
-                  <%= _('Unpublished')%>
-                <% else %>
-                  <%= _('Published')%>
-                <% end %>
-              </td>
-              <td class="text-center">
-                <% if guidance_gr.optional_subset.nil? || guidance_gr.optional_subset == false then%>
-                  <%= _('No')%>
-                <% else %>
-                  <%= _('Yes')%>
-                <% end %>
-              </td>
-              <td class="text-center">
-                <%= l guidance_gr.updated_at.to_date, formats: :short %>
-              </td>
-              <td>
-                <div class="dropdown">
-                  <button class="btn btn-link dropdown-toggle" type="button"
-                          id="guidance_group-<%= guidance_gr.id %>-actions" data-toggle="dropdown"
-                          aria-haspopup="true" aria-expanded="true">
-                    <%= _('Actions') %><span class="caret"></span>
-                  </button>
-
-                  <ul class="dropdown-menu" aria-labelledby="guidance_group-<%= guidance_gr.id %>-actions">
-                    <li><%= link_to _('Edit'), admin_edit_guidance_group_path(guidance_gr) %></li>
-                  <% if guidance_gr.published? %>
-                    <li><%= link_to _('Unpublish'),  admin_update_unpublish_guidance_group_path(guidance_gr), method: :put %></li>
-                  <% else %>
-                    <li><%= link_to _('Publish'),  admin_update_publish_guidance_group_path(guidance_gr), method: :put %></li>
-                  <% end %>
-                    <li><%= link_to _('Remove'), admin_destroy_guidance_group_path(guidance_gr), data: {confirm: _("You are about to delete '%{guidance_group_name}'. This will affect guidance. Are you sure?") % { :guidance_group_name => guidance_gr.name }}, method: :delete %></li>
-                  </ul>
-                </div>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-    <%end%>
-  
+    <%= paginable_renderise(
+      partial: '/paginable/guidance_groups/index',
+      controller: 'paginable/guidance_groups',
+      action: 'index',
+      scope: @guidance_groups) %>
     <div>
       <a href="<%= admin_new_guidance_group_path %>" class="btn btn-primary"><%= _('Create a guidance group') %></a>
     </div>
@@ -96,91 +32,11 @@
     </p>
 
     <!-- List of guidance -->
-    <% if @guidances.length > 0 then%>
-    <div class="table-responsive">
-      <table class="table table-hover tablesorter" id="guidances">
-        <thead>
-          <% if @guidances.length > TABLE_FILTER_MIN_ROWS %>
-            <tr>
-              <%= render(partial: "shared/table_filter", 
-                         locals: {path: admin_index_guidance_path(current_user.org_id), placeholder: _('Filter guidance')}) %>
-            </tr>
-          <% end %>
-          <tr>
-            <th><%= _('Text') %></th>
-            <th><%= _('Themes') %></th>
-            <th><%= _('Guidance group') %></th>
-            <th><%= _('Status') %></th>
-            <th><%= _('Last updated') %></th>
-            <th class="sorter-false"><span aria-hidden="false" class="sr-only"><%= _('Actions') %></span></th></td>
-          </tr>
-        </thead>
-        <tbody>
-          <% @guidances.each do |guidance| %>
-            <% if guidance.in_group_belonging_to?(current_user.org_id) then %>
-              <tr>
-                <td>
-                  <%= guidance.text.html_safe%>
-                </td>
-                <% if guidance.themes.present? then %>
-                  <td>
-                    <% guidance.themes.each do |th| %>
-                      <%= th.title %>
-                    <% end %>
-                  </td>
-                <% else %>
-                  <td>
-                      -
-                  </td>
-                <% end %>
-                <% if guidance.guidance_group.present? then %>
-                  <td>
-                    <%= guidance.guidance_group.name %>
-                  </td>
-                <% else %>
-                  <td>
-                    -
-                   </td>
-                <% end %>
-                <td class="text-center">
-                  <% if guidance.published.nil? || guidance.published == false then%>
-                    <%= _('Unpublished')%>
-                  <% else %>
-                    <%= _('Published')%>
-                  <% end %>
-                </td>
-                <td>
-                  <%= l guidance.updated_at.to_date, formats: :short %>
-                </td>
-                <td>
-                  <div class="dropdown">
-                    <button class="btn btn-link dropdown-toggle" type="button"
-                            id="guidance-<%= guidance.id %>-actions" data-toggle="dropdown"
-                            aria-haspopup="true" aria-expanded="true">
-                      <%= _('Actions') %><span class="caret"></span>
-                    </button>
-
-                    <ul class="dropdown-menu" aria-labelledby="guidance-<%= guidance.id %>-actions">
-                      <li><%= link_to _('Edit'), admin_edit_guidance_path(guidance) %></li>
-                    <!-- If the guidance has never been published or it has changed -->
-                    <% if guidance.published? %>
-                      <li><%= link_to _('Unpublish'), admin_unpublish_guidance_path(guidance), method: :put %></li>
-                    <% else %>
-                      <li><%= link_to _('Publish'), admin_publish_guidance_path(guidance), method: :put %></li>
-                    <% end %>
-                      <li><%= link_to _('Remove'), admin_destroy_guidance_path(guidance),
-                              data: {confirm: _("You are about to delete '%{guidance_summary}'. Are you sure?") % { :guidance_summary => truncate(sanitize(guidance.text,tags: %w(br a)), length: 20 , omission: _('... (continued)'))} }, 
-                              method: :delete %></li>
-                    </ul>
-                  </div>
-                </td>
-              </tr>
-            <% end %>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-    <% end %>
+    <%= paginable_renderise(
+        partial: '/paginable/guidances/index',
+        controller: 'paginable/guidances',
+        action: 'index',
+        scope: @guidances) %>
   
     <div>
       <a href="<%= admin_new_guidance_path %>" class="btn btn-primary"><%= _('Create guidance') %></a>

--- a/app/views/layouts/_paginable.html.erb
+++ b/app/views/layouts/_paginable.html.erb
@@ -28,14 +28,14 @@
         <div class="pull-left">
           <% if total > Kaminari.config.default_per_page %>
             <% if searchable? %>
-              <% if paginable %>
                 <ul class="list-inline">
+                <% if paginable %>
                   <li><%= paginable_search_link(_('View all search results'), 'ALL') %></li>
+                <% else %>
+                  <%= paginable_search_link(_('View less search results'), 1) %>
+                <% end %>
                   <li><%= link_to(_('Clear search results'), url_for(controller: controller, action: action, page: 1), { 'data-remote': true, class: 'clear' }) %></li>
                 </ul>
-              <% else %>
-                <%= paginable_search_link(_('View less search results'), 1) %>
-              <% end %>
             <% else %>
               <% if paginable %>
                 <%= link_to(_('View all'), url_for(controller: controller, action: action, page: 'ALL'), { 'data-remote': true }) %>

--- a/app/views/org_admin/plans/index.html.erb
+++ b/app/views/org_admin/plans/index.html.erb
@@ -33,47 +33,13 @@
         </div>
       </div>
     <% end %>
-
     <% if @plans.length > 0 %>
       <%= link_to _('Download plans'), org_admin_download_plans_path(format: :csv), target: '_blank', class: 'btn btn-default pull-right' %>
-      <div class="table-responsive">
-        <table class="table table-hover tablesorter" id="my-plans">
-          <thead>
-            <% if @plans.length > TABLE_FILTER_MIN_ROWS %>
-              <tr>
-                <th colspan="6" class="sorter-false">
-                  <%= render(partial: "shared/table_filter",
-                             locals: { placeholder: _('Filter plans')}) %>
-                </th>
-              </tr>
-            <% end %>
-            <tr>
-              <th><%= _('Project Title') %></th>
-              <th><%= _('Template') %></th>
-              <th><%= _('Organisation') %></th>
-              <th><%= _('Owner') %></th>
-              <th><%= _('Updated') %></th>
-              <th><%= _('Visibility') %></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @plans.each do |plan| %>
-              <tr>
-                <td>
-                  <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
-                </td>
-                <td><%= plan.template.title %></td>
-                <td><%= plan.users.first.org.name %></td>
-                <td><%= plan.users.first.name(false) %></td>
-                <td><%= l(plan.latest_update.to_date, formats: :short) %></td>
-                <td class="plan-visibility">
-                  <%= plan.visibility === 'is_test' ? _('Test') : raw(display_visibility(plan.visibility)) %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
+      <%= paginable_renderise(
+        partial: '/paginable/plans/org_admin',
+        controller: 'paginable/plans',
+        action: 'org_admin',
+        scope: @plans) %>
     <% end %>
   </div>
 </div>

--- a/app/views/paginable/guidance_groups/_index.html.erb
+++ b/app/views/paginable/guidance_groups/_index.html.erb
@@ -1,0 +1,57 @@
+<div class="table-responsive">
+  <table class="table table-hover" id="guidance-groups">
+    <thead>
+      <tr>
+        <th><%= _('Name') %></th>
+        <th class="text-center"><%= _('Status') %>&nbsp;<%= paginable_sort_link('published') %></th>
+        <th class="text-center"><%= _('Optional subset') %>&nbsp;<%= paginable_sort_link('optional_subset') %></th>
+        <th class="text-center"><%= _('Last updated') %>&nbsp;<%= paginable_sort_link('updated_at') %></th>
+        <th class="sorter-false"><span aria-hidden="false" class="sr-only"><%= _('Actions') %></span></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% scope.each do |guidance_gr| %>
+        <tr>
+          <td><%= guidance_gr.name %></td>
+          <td class="text-center">
+            <% if guidance_gr.published.nil? || guidance_gr.published == false %>
+                <%= _('Unpublished')%>
+            <% else %>
+                <%= _('Published')%>
+            <% end %>
+          </td>
+          <td class="text-center">
+            <% if guidance_gr.optional_subset.nil? || guidance_gr.optional_subset == false %>
+                <%= _('No')%>
+            <% else %>
+                <%= _('Yes')%>
+            <% end %>
+          </td>
+          <td class="text-center"><%= l guidance_gr.updated_at.to_date, formats: :short %></td>
+          <td>
+            <div class="dropdown">
+              <button
+                class="btn btn-link dropdown-toggle"
+                type="button"
+                id="guidance_group-<%= guidance_gr.id %>-actions"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="true">
+                <%= _('Actions') %><span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" aria-labelledby="guidance_group-<%= guidance_gr.id %>-actions">
+                <li><%= link_to _('Edit'), admin_edit_guidance_group_path(guidance_gr) %></li>
+                <% if guidance_gr.published? %>
+                    <li><%= link_to _('Unpublish'),  admin_update_unpublish_guidance_group_path(guidance_gr), method: :put %></li>
+                <% else %>
+                    <li><%= link_to _('Publish'),  admin_update_publish_guidance_group_path(guidance_gr), method: :put %></li>
+                <% end %>
+                <li><%= link_to _('Remove'), admin_destroy_guidance_group_path(guidance_gr), data: {confirm: _("You are about to delete '%{guidance_group_name}'. This will affect guidance. Are you sure?") % { :guidance_group_name => guidance_gr.name }}, method: :delete %></li>
+              </ul>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/paginable/guidances/_index.html.erb
+++ b/app/views/paginable/guidances/_index.html.erb
@@ -1,0 +1,71 @@
+<div class="table-responsive">
+  <table class="table table-hover" id="guidances">
+    <thead>
+      <tr>
+        <th><%= _('Text') %>&nbsp;<%= paginable_sort_link('guidances.text') %></th>
+        <th><%= _('Themes') %></th>
+        <th><%= _('Guidance group') %>&nbsp;<%= paginable_sort_link('guidance_groups.name') %></th>
+        <th><%= _('Status') %>&nbsp;<%= paginable_sort_link('guidances.published') %></th>
+        <th><%= _('Last updated') %>&nbsp;<%= paginable_sort_link('guidances.updated_at') %></th>
+        <th class="sorter-false"><span aria-hidden="false" class="sr-only"><%= _('Actions') %></span></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% scope.each do |guidance| %>
+        <% if guidance.in_group_belonging_to?(current_user.org_id) %>
+          <tr>
+            <td><%= guidance.text.html_safe %></td>
+            <% if guidance.themes.present? %>
+              <td>
+                <% guidance.themes.each do |th| %>
+                  <%= th.title %>
+                <% end %>
+              </td>
+            <% else %>
+              <td>-</td>
+            <% end %>
+            <% if guidance.guidance_group.present? %>
+              <td><%= guidance.guidance_group.name %></td>
+            <% else %>
+              <td>-</td>
+            <% end %>
+            <td class="text-center">
+              <% if guidance.published.nil? || guidance.published == false %>
+                <%= _('Unpublished')%>
+              <% else %>
+                <%= _('Published')%>
+              <% end %>
+            </td>
+            <td>
+              <%= l guidance.updated_at.to_date, formats: :short %>
+            </td>
+            <td>
+              <div class="dropdown">
+                <button
+                  class="btn btn-link dropdown-toggle"
+                  type="button"
+                  id="guidance-<%= guidance.id %>-actions"
+                  data-toggle="dropdown"
+                  aria-haspopup="true" aria-expanded="true">
+                  <%= _('Actions') %><span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="guidance-<%= guidance.id %>-actions">
+                  <li><%= link_to _('Edit'), admin_edit_guidance_path(guidance) %></li>
+                  <!-- If the guidance has never been published or it has changed -->
+                  <% if guidance.published? %>
+                    <li><%= link_to _('Unpublish'), admin_unpublish_guidance_path(guidance), method: :put %></li>
+                  <% else %>
+                    <li><%= link_to _('Publish'), admin_publish_guidance_path(guidance), method: :put %></li>
+                  <% end %>
+                  <li><%= link_to _('Remove'), admin_destroy_guidance_path(guidance),
+                  data: {confirm: _("You are about to delete '%{guidance_summary}'. Are you sure?") % { :guidance_summary => truncate(sanitize(guidance.text,tags: %w(br a)), length: 20 , omission: _('... (continued)'))} }, method: :delete %>
+                  </li>
+                </ul>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -1,0 +1,30 @@
+<div class="table-responsive">
+  <table class="table table-hover" id="my-plans">
+    <thead>
+      <tr>
+        <th><%= _('Project Title') %>&nbsp;<%= paginable_sort_link('plans.title') %></th>
+        <th><%= _('Template') %>&nbsp;<%= paginable_sort_link('templates.title') %></th>
+        <th><%= _('Organisation') %></th>
+        <th><%= _('Owner') %></th>
+        <th><%= _('Updated') %>&nbsp;<%= paginable_sort_link('plans.updated_at') %></th>
+        <th><%= _('Visibility') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% scope.each do |plan| %>
+        <tr>
+          <td>
+            <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
+          </td>
+          <td><%= plan.template.title %></td>
+          <td><%= plan.users.first.org.name %></td>
+          <td><%= plan.users.first.name(false) %></td>
+          <td><%= l(plan.latest_update.to_date, formats: :short) %></td>
+          <td class="plan-visibility">
+            <%= plan.visibility === 'is_test' ? _('Test') : raw(display_visibility(plan.visibility)) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
@@ -7,7 +7,7 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="table-responsive">
-                    <table class="table table-hover tablesorter">
+                    <table class="table table-hover">
                         <thead>
                             <tr>
                                 <th><%= _('Project Title') %>&nbsp;<%= paginable_sort_link('plans.title') %></th>

--- a/app/views/paginable/plans/_privately_visible.html.erb
+++ b/app/views/paginable/plans/_privately_visible.html.erb
@@ -1,5 +1,5 @@
       <div class="table-responsive">
-        <table class="table table-hover tablesorter" id="my-plans">
+        <table class="table table-hover" id="my-plans">
           <thead>
             <tr>
               <th><%= _('Project Title') %>&nbsp;<%= paginable_sort_link('plans.title') %></th>

--- a/app/views/paginable/plans/_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_publicly_visible.html.erb
@@ -1,0 +1,26 @@
+<div class="table-responsive">
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th><%= _('Project Title') %>&nbsp;<%= paginable_sort_link('plans.title') %></th>
+        <th><%= _('Template') %>&nbsp;<%= paginable_sort_link('templates.title') %></th>
+        <th><%= _('Institution') %></th>
+        <th><%= _('Owner') %></th>
+        <th class="sorter-false text-center"><%= _('Download') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% scope.each do |plan| %>
+        <tr class="table-data">
+          <td><%= plan.title %></td>
+          <td><%= plan.template.title %></td>
+          <td><%= (plan.owner.nil? || plan.owner.org.nil? ? _('Not Applicable') : plan.owner.org.name) %></td>
+          <td><%= (plan.owner.nil? ? _('Unknown') : plan.owner.name(false)) %></td>
+          <td class="text-center">
+            <%= link_to _('PDF'), plan_export_path(plan, format: :pdf), class: "dmp_table_link", target: '_blank' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/paginable/templates/_all.html.erb
+++ b/app/views/paginable/templates/_all.html.erb
@@ -1,7 +1,7 @@
 <% # locals: templates, current_org %>
 
 <div class="table-responsive">
-  <table class="table table-hover table-bordered tablesorter">
+  <table class="table table-hover table-bordered">
     <thead>
       <% if scopes.present? %>
         <tr><th colspan="4" class="sorter-false table-scope"><ul class="nav navbar-nav">

--- a/app/views/paginable/templates/_funders.html.erb
+++ b/app/views/paginable/templates/_funders.html.erb
@@ -1,7 +1,7 @@
 <% # locals: templates, current_org %>
 
 <div class="table-responsive">
-  <table class="table table-hover table-bordered tablesorter">
+  <table class="table table-hover table-bordered">
     <thead>
       <% if scopes.present? %>
         <tr><th colspan="5" class="sorter-false table-scope"><ul class="nav navbar-nav">

--- a/app/views/paginable/templates/_orgs.html.erb
+++ b/app/views/paginable/templates/_orgs.html.erb
@@ -1,7 +1,7 @@
 <% # locals: templates, current_org %>
 
 <div class="table-responsive">
-  <table class="table table-hover table-bordered tablesorter">
+  <table class="table table-hover table-bordered">
     <thead>
       <% if scopes.present? %>
         <tr><th colspan="5" class="sorter-false table-scope"><ul class="nav navbar-nav">

--- a/app/views/paginable/templates/_publicly_visible.html.erb
+++ b/app/views/paginable/templates/_publicly_visible.html.erb
@@ -1,0 +1,33 @@
+<div class="table-responsive">
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th><%= _('Template Name') %>&nbsp;<%= paginable_sort_link('templates.title') %></th>
+        <th class="sorter-false text-center"><%= _('Download') %></th>
+        <th><%= _('Organisation Name') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
+        <th><%= _('Last Updated') %>&nbsp;<%= paginable_sort_link('templates.updated_at') %></th>
+        <th class="sorter-false"><%= _('Funder Links') %></th>
+        <th class="sorter-false" data-toggle="tooltip" title="<%= _('Sample plans are provided by a funder, an institution or a trusted party.') %>"><%= _('Sample Plans') %><br><small><%= _('(if available)') %></small></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% scope.each do |template| %>
+        <tr>
+          <td><%= template.title %></td>
+          <td class="text-center">
+            <%= link_to _('DOCX'), template_export_path(template.dmptemplate_id, format: :docx), target: '_blank' %><br>
+            <%= link_to _('PDF'), template_export_path(template.dmptemplate_id, format: :pdf), target: '_blank' %>
+          </td>
+          <td><%= template.org.name %></td>
+          <td><%= l(template.updated_at.to_date, formats: :short) %></td>
+          <td>
+            <%= raw links_to_a_elements(template.links['funder'], '<br>') %>
+          </td>
+          <td>
+            <%= raw links_to_a_elements(template.links['sample_plan'], '<br>') %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/paginable/themes/_index.html.erb
+++ b/app/views/paginable/themes/_index.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-hover tablesorter">
+<table class="table table-hover">
   <thead>
     <tr>
       <th><%= _('Name') %>&nbsp;<%= paginable_sort_link('title') %></th>

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-12">
     <div class="table-responsive">
-      <table class="table tablesorter table-hover table-bordered user_accounts">
+      <table class="table table-hover table-bordered user_accounts">
         <thead>
           <tr>
               <th><%= _('Name') %>&nbsp;<%= paginable_sort_link('firstname') %></th>

--- a/app/views/public_pages/plan_index.html.erb
+++ b/app/views/public_pages/plan_index.html.erb
@@ -17,40 +17,11 @@
 <div class="row">
   <div class="col-md-12">
     <% if @plans.count > 0 %>
-      <div class="table-responsive">
-        <table class="table table-hover tablesorter">
-          <thead>
-            <% if @plans.count > TABLE_FILTER_MIN_ROWS %>
-              <tr>
-                <th colspan="5" class="sorter-false">
-                  <%= render(partial: "shared/table_filter",
-                             locals: {path: public_plans_path, placeholder: _('Filter plans')}) %>
-                </th>
-              </tr>
-            <% end %>
-            <tr>
-              <th><%= _('Project Title') %></th>
-              <th><%= _('Template') %></th>
-              <th><%= _('Institution') %></th>
-              <th><%= _('Owner') %></th>
-              <th class="sorter-false text-center"><%= _('Download') %></th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @plans.each do |plan| %>
-              <tr class="table-data">
-                <td><%= plan.title %></td>
-                <td><%= plan.template.title %></td>
-                <td><%= (plan.owner.nil? || plan.owner.org.nil? ? _('Not Applicable') : plan.owner.org.name) %></td>
-                <td><%= (plan.owner.nil? ? _('Unknown') : plan.owner.name(false)) %></td>
-                <td class="text-center">
-                  <%= link_to _('PDF'), plan_export_path(plan, format: :pdf), class: "dmp_table_link", target: '_blank' %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
+      <%= paginable_renderise(
+        partial: '/paginable/plans/publicly_visible',
+        controller: 'paginable/plans',
+        action: 'publicly_visible', 
+        scope: @plans) %>
     <% end %>
   </div>
 </div>

--- a/app/views/public_pages/template_index.html.erb
+++ b/app/views/public_pages/template_index.html.erb
@@ -1,7 +1,6 @@
 <div class="row">
   <div class="col-md-12">
     <h1><%= raw _('DMP Templates') %></h1>
-
     <% if @templates.count > 0 %>
       <p class="left-indent"><%= _('Templates are provided by a funder, an institution, or a trusted party.') %></p>
     <% else %>
@@ -9,51 +8,14 @@
     <% end %>
   </div>
 </div>
-
 <div class="row">
   <div class="col-md-12">
     <% if @templates.count > 0 %>
-      <div class="table-responsive">
-      <table class="table table-hover tablesorter">
-        <thead>
-         <% if @templates.count > TABLE_FILTER_MIN_ROWS %>
-            <tr>
-              <th colspan="6" class="sorter-false">
-                <%= render(partial: "shared/table_filter",
-                           locals: {path: public_templates_path, placeholder: _('Filter templates')}) %>
-              </th>
-            </tr>
-          <% end %>
-          <tr>
-            <th><%= _('Template Name') %></th>
-            <th class="sorter-false text-center"><%= _('Download') %></th>
-            <th><%= _('Organisation Name') %></th>
-            <th><%= _('Last Updated') %></th>
-            <th class="sorter-false"><%= _('Funder Links') %></th>
-            <th class="sorter-false" data-toggle="tooltip" title="<%= _('Sample plans are provided by a funder, an institution or a trusted party.') %>"><%= _('Sample Plans') %><br><small><%= _('(if available)') %></small></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @templates.each do |template| %>
-            <tr>
-              <td><%= template.title %></td>
-              <td class="text-center">
-                <%= link_to _('DOCX'), template_export_path(template.dmptemplate_id, format: :docx), target: '_blank' %>
-                <br>
-                <%= link_to _('PDF'), template_export_path(template.dmptemplate_id, format: :pdf), target: '_blank' %>
-              </td>
-              <td><%= template.org.name %></td>
-              <td><%= l(template.updated_at.to_date, formats: :short) %></td>
-              <td>
-                <%= raw links_to_a_elements(template.links['funder'], '<br>') %>
-              </td>
-              <td>
-                <%= raw links_to_a_elements(template.links['sample_plan'], '<br>') %>
-              </td>
-            </tr>
-          <% end %>
-      </table>
-      </div>
+      <%= paginable_renderise(
+        partial: '/paginable/templates/publicly_visible',
+        controller: 'paginable/templates',
+        action: 'publicly_visible', 
+        scope: @templates) %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/admin_grant_permissions.html.erb
+++ b/app/views/users/admin_grant_permissions.html.erb
@@ -1,0 +1,57 @@
+<% namesHash = name_and_text %>
+<div class="row">
+  <div class="col-md-12">
+    <h1><%= _('Edit User Privileges') %></h1>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= form_tag( admin_update_permissions_user_path(@user), method: :put) do %>
+    <div class='table-responsive'>
+      <table class="table table-hover table-bordered">
+        <thead>
+          <tr>
+            <th><%= _('Name') %></th>
+          
+            <% @perms.each do |perm| %>
+              <% case perm.name when 'grant_permissions' %>
+                <th class="text-center" data-toggle="tooltip" title="<%= _('Allows the user to assign permissions to other users within the same organisation. Users can only assign permissions they own themselves') %>">
+                  <%= namesHash[perm.name.to_sym] %>
+                </th>
+              <% when 'modify_templates' %>
+                <th class="text-center" data-toggle="tooltip" title="<%= _('Allows the user to create new institutional templates, edit existing ones and customise funder templates') %>">
+                  <%= namesHash[perm.name.to_sym] %>
+                </th>
+              <% when 'modify_guidance' %>
+                <th class="text-center" data-toggle="tooltip" title="<%= _('Allows the user to create and edit guidance') %>">
+                  <%= namesHash[perm.name.to_sym] %>
+                </th>
+              <% when 'use_api' %>
+                <th class="text-center" data-toggle="tooltip" title="<%= _('Provides the user with an API token and grants rights to harvest information from the tool') %>">
+                  <%= namesHash[perm.name.to_sym] %>
+                </th>
+              <% when 'change_org_details' %>
+                <th class="text-center" data-toggle="tooltip" title="<%= _('Allows the user to amend the organisation details (name, URL etc) and add basic branding such as the logo') %>">
+                  <%= namesHash[perm.name.to_sym] %>
+                </th>
+              <% end %>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><%= @user.name(false) %></td>
+            <% @perms.each do |perm| %>
+              <td class="text-center"><%= check_box_tag "perm_ids[]", perm.id, @user.perms.include?(perm) %></td>
+            <% end %>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="form-group">
+      <%= submit_tag _('Save'), class: "btn btn-primary" %>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,6 +249,8 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
       resources :plans, only: [] do
         get 'privately_visible/:page', action: :privately_visible, on: :collection, as: :privately_visible
         get 'organisationally_or_publicly_visible/:page', action: :organisationally_or_publicly_visible, on: :collection, as: :organisationally_or_publicly_visible
+        get 'publicly_visible/:page', action: :publicly_visible, on: :collection, as: :publicly_visible
+        get 'org_admin/:page', action: :org_admin, on: :collection, as: :org_admin
       end
       # Paginable actions for users
       resources :users, only: [] do
@@ -258,12 +260,20 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
       resources :themes, only: [] do
         get 'index/:page', action: :index, on: :collection, as: :index
       end
-      
       # Paginable actions for templates
       resources :templates, only: [] do
         get 'all/:page', action: :all, on: :collection, as: :all
         get 'funders/:page', action: :funders, on: :collection, as: :funders
         get 'orgs/:page', action: :orgs, on: :collection, as: :orgs
+        get 'publicly_visible/:page', action: :publicly_visible, on: :collection, as: :publicly_visible
+      end
+      # Paginable actions for guidances
+      resources :guidances, only: [] do
+        get 'index/:page', action: :index, on: :collection, as: :index
+      end
+      # Paginable actions for guidance_groups
+      resources :guidance_groups, only: [] do
+        get 'index/:page', action: :index, on: :collection, as: :index
       end
     end
 

--- a/test/integration/paginable_flows_test.rb
+++ b/test/integration/paginable_flows_test.rb
@@ -44,6 +44,10 @@ class PaginableFlowsTest < ActionDispatch::IntegrationTest
     refute_nil(link_view_less_search_results)
     assert_equal(link_view_less_search_results.content, _('View less search results'))
 
+    link_clear_search_results = css_select('a[href$="/1"]').first
+    refute_nil(link_clear_search_results)
+    assert_equal(link_clear_search_results.content, _('Clear search results'))
+
     # Fails if pagination nav is found
     assert_empty(css_select('nav.pagination'))
   end

--- a/test/unit/guidance_test.rb
+++ b/test/unit/guidance_test.rb
@@ -37,9 +37,9 @@ class GuidanceTest < ActiveSupport::TestCase
   # ---------------------------------------------------
   test "retrieves guidance by org" do
     org = Org.create!(name: 'Tester 123', abbreviation: 'TEST', org_type: 1, links: {"org":[]})
-    assert Guidance.by_org(org.id).empty?, "expected the newly created org to have no guidance"
+    assert Guidance.by_org(org).empty?, "expected the newly created org to have no guidance"
 
-    assert_not Guidance.by_org(@user.org.id).empty?, "expected the org to have guidance"
+    assert_not Guidance.by_org(@user.org).empty?, "expected the org to have guidance"
   end
 
   # ---------------------------------------------------


### PR DESCRIPTION
- public DMPs paginablerised. DMPRoadmap/roadmap#1055
- public DMPs templates paginablerised. DMPRoadmap/roadmap#1055
- plans visible to org admin paginablerised. DMPRoadmap/roadmap#1055
- guidances paginablerised. DMPRoadmap/roadmap#1055
- guidance_groups paginablerised. DMPRoadmap/roadmap#1055
- remove tablesorter class from paginable views. Introduce Clear search results when ALL search results are active. DMPRoadmap/roadmap#1055
- guidance policy for paginable/guidance/index/:page. DMPRoadmap/roadmap#1055
