### PR TITLE
Fixes lingering issue with Guidance div ids on Edit Plan page

### DIFF
--- a/app/views/guidance_groups/_show.html.erb
+++ b/app/views/guidance_groups/_show.html.erb
@@ -9,14 +9,14 @@
       </div>
     </div>
   <% end %>
-  <% group.keys.each do |theme| %>
+  <% group.keys.each_with_index do |theme, i| %>
     <div class="panel panel-default">
       <div class="panel-heading" role="tab" id="headingA">
         <h2 class="panel-title">
           <a role="button" data-toggle="collapse" 
              data-parent="<%= question.id %>-guidance" 
-             href="#collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>" 
-             aria-controls="collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>"
+             href="#collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>" 
+             aria-controls="collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>"
              class="reverse">
             <span class="fa fa-plus" aria-hidden="true"></span>
             <%= theme %>
@@ -25,8 +25,8 @@
       </div>
     </div>
 
-    <div id="collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>" class="panel-collapse collapse" role="tabpanel"
-         aria-labelledby="heading-guidance-<%= question.id %>-<%= guidance_accordion_id %>">
+    <div id="collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>" class="panel-collapse collapse" role="tabpanel"
+         aria-labelledby="heading-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>">
       <div class="panel-body">
         <% group[theme].each do |guidance| %>
           <%= raw guidance %>

--- a/app/views/phases/_guidances_notes.html.erb
+++ b/app/views/phases/_guidances_notes.html.erb
@@ -71,10 +71,10 @@
         <% guidance_set.keys.each_with_index do |group, i| %>
           <% obj = guidance_groups.select{ |gg| gg.name == group }.first %>
           <% if obj.present? %>
-            <div id="guidance-<%= question.id %>-<%= obj.id %>" role="tabpanel" class="tab-pane<%= annotations.present? ? '' : ' active' %>">
-              <% accordion_id = "#{obj.id}-#{i}" %>
+            <% accordion_id = "#{question.id}-#{obj.id}" %>
+            <div id="guidance-<%= accordion_id %>" role="tabpanel" class="tab-pane<%= annotations.present? ? '' : ' active' %>">
               <%= render partial: 'guidance_groups/show', 
-                         locals: { group: guidance_set[group], question: question, guidance_accordion_id: accordion_id } %>
+                         locals: { group: guidance_set[group], question: question, guidance_accordion_id: "#{accordion_id}-#{i}" } %>
             </div>
           <% end %>
         <% end %>


### PR DESCRIPTION
Fixes issue with Guidance div ids that was causing the expand/collapse of themed guidance to open/close the wrong div #996