### PR TITLE
fixes issue wih published status on templates page

### DIFF
--- a/app/views/paginable/templates/_all.html.erb
+++ b/app/views/paginable/templates/_all.html.erb
@@ -31,12 +31,12 @@
             <%= template.org.name %>
           </td>
           <td>
-            <% if !published[template.dmptemplate_id].present? %>
-              <%= _('Unpublished') %>
-            <% elsif template.dirty? %>
+            <% if template.dirty? %>
               <%= _('Unpublished changes') %>
-            <% else %>
+            <% elsif template.published? %>
               <%= _('Published') %>
+            <% else %>
+              <%= _('Unpublished') %>
             <% end %>
           </td>
           <td>

--- a/app/views/paginable/templates/_orgs.html.erb
+++ b/app/views/paginable/templates/_orgs.html.erb
@@ -30,12 +30,12 @@
             <%= raw(template.description) %>
           </td>
           <td>
-            <% if !published[template.dmptemplate_id].present? %>
-              <%= _('Unpublished') %>
-            <% elsif template.dirty? %>
+            <% if template.dirty? %>
               <%= _('Unpublished changes') %>
-            <% else %>
+            <% elsif template.published? %>
               <%= _('Published') %>
+            <% else %>
+              <%= _('Unpublished') %>
             <% end %>
           </td>
           <td>


### PR DESCRIPTION
The Published/Unpublished status was not displaying properly on the All templates and Org templates tabs. It was basing  'Published' on whether or not there was a published version of the template available ... we want to show the status of the current version though. #955
