### PR TITLE
Updated Plans table to use plans.updated_at for edited dates

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,5 +1,11 @@
 class Answer < ActiveRecord::Base
 
+  after_save do |answer|
+    # Updates the plan.updated_at attribute whenever an answer has been created/updated 
+    # check first for a nil plan so that the controller can properly handle the ActiveRecord::NotFound exception
+    answer.plan.touch unless answer.plan.nil? 
+  end
+  
   ##
   # Associations
 	belongs_to :question

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -19,7 +19,7 @@
           <td><%= plan.template.title %></td>
           <td><%= plan.users.first.org.name %></td>
           <td><%= plan.users.first.name(false) %></td>
-          <td><%= l(plan.latest_update.to_date, formats: :short) %></td>
+          <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
           <td class="plan-visibility">
             <%= plan.visibility === 'is_test' ? _('Test') : raw(display_visibility(plan.visibility)) %>
           </td>

--- a/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
@@ -23,7 +23,7 @@
                                     <td><%= link_to "#{plan.title.length > 40 ? "#{plan.title[0..39]} ..." : plan.title}", plan_path(plan) %></td>
                                     <td><%= plan.template.title %></td>
                                     <td><%= plan.owner.present? ? plan.owner.name : _('Unknown') %></td>
-                                    <td><%= l(plan.latest_update.to_date, formats: :short) %></td>
+                                    <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
                                     <td class="text-center">
                                         <%= link_to _('PDF'), plan_export_path(plan, format: :pdf), target: '_blank' %>
                                     </td>

--- a/app/views/paginable/plans/_privately_visible.html.erb
+++ b/app/views/paginable/plans/_privately_visible.html.erb
@@ -22,7 +22,7 @@
                       plan_path(plan) %>
                 </td>
                 <td><%= plan.template.title %></td>
-                <td><%= l(plan.latest_update.to_date, formats: :short) %></td>
+                <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
                 <td><%= display_role(plan.roles.find_by(user: current_user)) %></td>
                 <td class="text-center">
                   <% if plan.administerable_by?(current_user.id) then %>


### PR DESCRIPTION
Was using `plans.last_updated` which reflects the time the template's phase was updated. Switched to use `plans.updated_at` and verified that localization is working (e.g. 12/15/2017 - US, 15/12/2017 - UK) #817