### PR TITLE
Fix bugs on template pages

### DIFF
--- a/app/views/org_admin/templates/_edit_template.html.erb
+++ b/app/views/org_admin/templates/_edit_template.html.erb
@@ -12,16 +12,19 @@
     </div>
   </div>
 
-  <div class="form-group col-xs-8">
-    <%= f.label _('Visibility'), class: 'control-label' %>
-    <%= render partial: 'shared/popover', 
-               locals: { message: _('Checking this box prevents the template from appearing in the public list of templates.'),
-                         placement: 'right' }%>
-    <div class="checkbox">
-      <%= f.label(:visibility,
-          raw("#{check_box_tag('template_visibility', '0', (template.visibility == 'organisationally_visible'))} #{_('for internal %{org_name} use only') % {org_name: @template.org.name}}")) %>
+  <% if current_user.org.funder? && !current_user.org.funder_only? %>
+    <!-- If the Org is a funder and another org type then allow then to set the visibility -->
+    <div class="form-group col-xs-8">
+      <%= f.label _('Visibility'), class: 'control-label' %>
+      <%= render partial: 'shared/popover', 
+                 locals: { message: _('Checking this box prevents the template from appearing in the public list of templates.'),
+                           placement: 'right' }%>
+      <div class="checkbox">
+        <%= f.label(:visibility,
+            raw("#{check_box_tag('template_visibility', '0', (template.visibility == 'organisationally_visible'))} #{_('for internal %{org_name} use only') % {org_name: @template.org.name}}")) %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
   <div class="form-group col-xs-8">
     <%= label_tag(:status, _('Status'), class: "control-label") %>

--- a/app/views/org_admin/templates/_show_template.html.erb
+++ b/app/views/org_admin/templates/_show_template.html.erb
@@ -18,7 +18,8 @@
       <%= _('Published') %>
     <% end %>
   </dd>
-  <% if template.org.funder? %>
+  <% if current_user.org.funder? && !current_user.org.funder_only? %>
+    <!-- If the Org is a funder and another org type then allow then to set the visibility -->
     <dt><%= _('Visibility') %></dt>
     <dd><%= (template.visibility == 'organisationally_visible' ? _('for internal %{org_name} use only') % {org_name: @template.org.name} : _('available to the public') + (template_hash[:live].nil? ? ' (once published)' : '')) %></dd>
   <% end %>

--- a/app/views/org_admin/templates/container.html.erb
+++ b/app/views/org_admin/templates/container.html.erb
@@ -1,7 +1,8 @@
+<%= current_tab = '' unless current_tab.present? %>
 <div class="row">
   <div class="col-md-12">
     <h1><%= template.title %></h1>
-    <%= link_to _('View all templates'), org_admin_templates_path, class: 'btn btn-default pull-right' %>
+    <%= link_to _('View all templates'), org_admin_templates_path(r: current_tab), class: 'btn btn-default pull-right' %>
   </div>
 </div>
 <div class="row">

--- a/app/views/org_admin/templates/history.html.erb
+++ b/app/views/org_admin/templates/history.html.erb
@@ -1,6 +1,11 @@
 <div class="row">
   <div class="col-md-12">
-    <h1><%= _('Template History') %></h1>
+    <h1>
+      <%= _('Template History') %>
+      <div class="pull-right">
+        <%= link_to _('View all templates'), "#{org_admin_templates_path}##{@current_tab}", class: "btn btn-primary" %>
+      </div>
+    </h1>
     <p><%= _('Here you can view previously published versions of your template.  These can no longer be modified.')%></p>
   </div>
 </div>
@@ -19,8 +24,5 @@
     <% else %>
       <p><%= _('This template is new and does not yet have any publication history.') %></p>
     <% end %>
-    <div>
-      <%= link_to _('View all templates'), org_admin_templates_path, class: "btn btn-default" %>
-    </div>
   </div>
 </div>

--- a/app/views/org_admin/templates/new.html.erb
+++ b/app/views/org_admin/templates/new.html.erb
@@ -4,7 +4,7 @@
       <%= _('New template') %>
     </h1>
     <div class="pull-right">
-      <%= link_to _('View all templates'), org_admin_templates_path, class: "btn btn-primary" %>
+      <%= link_to _('View all templates'), "#{org_admin_templates_path}#organisation-templates", class: "btn btn-primary" %>
     </div>
   </div>
 </div>

--- a/app/views/paginable/templates/_funders.html.erb
+++ b/app/views/paginable/templates/_funders.html.erb
@@ -68,16 +68,17 @@
                   <% if customization.updated_at < template.updated_at %>
                     <li><%= link_to _('Transfer customisation'), transfer_customization_org_admin_template_path(template) %></li>
                   <% else %>
-                    <li><%= link_to _('Edit customisation'), edit_org_admin_template_path(id: customization.id, edit: "true") %></li>
+                    <li><%= link_to _('Edit customisation'), edit_org_admin_template_path(id: customization.id, edit: "true", r: 'funder-templates') %></li>
                     <% if !customization.published? %>
-                      <li><%= link_to _('Publish'), publish_org_admin_template_path(customization) %></li>
+                      <li><%= link_to _('Publish'), publish_org_admin_template_path(customization, r: 'funder-templates') %></li>
                     <% else %>
-                      <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(customization) %></li>
+                      <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(customization, r: 'funder-templates') %></li>
                     <% end %>
                     <% if customization.plans.length <= 0 %>
                       <li>
-                        <%= link_to _('Remove'), org_admin_template_path(id: customization.id), 'data-method': 'delete', rel: 'nofollow',
-                            'data-confirm': _('Are you sure you want to remove your customization of "%{template_title}"?') % { template_title: customization.title} %>
+                        <%= link_to _('Remove'), org_admin_template_path(id: customization.id, r: 'funder-templates'), 
+                                    'data-method': 'delete', rel: 'nofollow',
+                                    'data-confirm': _('Are you sure you want to remove your customization of "%{template_title}"?') % { template_title: customization.title} %>
                       </li>
                     <% end %>
                   <% end %>

--- a/app/views/paginable/templates/_orgs.html.erb
+++ b/app/views/paginable/templates/_orgs.html.erb
@@ -30,7 +30,7 @@
             <%= raw(template.description) %>
           </td>
           <td>
-            <% if template.dirty? %>
+            <% if published[template.dmptemplate_id].present? && !template.published? %>
               <%= _('Unpublished changes') %>
             <% elsif template.published? %>
               <%= _('Published') %>
@@ -53,19 +53,20 @@
                 <%= _('Actions') %><span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
-                <li><%= link_to _('Edit'), edit_org_admin_template_path(id: template.id, edit: "true") %></li>
-                <li><%= link_to _('History'), history_org_admin_template_path(id: template.id) %></li>
+                <li><%= link_to _('Edit'), edit_org_admin_template_path(id: template.id, edit: "true", r: 'organisation-templates') %></li>
+                <li><%= link_to _('History'), history_org_admin_template_path(id: template.id, r: 'organisation-templates') %></li>
                 <% if !published[template.dmptemplate_id].present? %>
-                  <li><%= link_to _('Publish'), publish_org_admin_template_path(template) %></li>
-                <% elsif template.dirty? %>
-                  <li><%= link_to _('Publish changes'), publish_org_admin_template_path(template) %></li>
+                  <li><%= link_to _('Publish'), publish_org_admin_template_path(template, r: 'organisation-templates') %></li>
+                <% elsif !template.published? %>
+                  <li><%= link_to _('Publish changes'), publish_org_admin_template_path(template, r: 'organisation-templates') %></li>
                 <% else %>
-                  <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template) %></li>
+                  <li><%= link_to _('Unpublish'), unpublish_org_admin_template_path(template, r: 'organisation-templates') %></li>
                 <% end %>
                 <li><%= link_to _('Copy'), copy_org_admin_template_path(template) %></li>
                 <% if template.plans.length <= 0 %>
                   <li>
-                    <%= link_to _('Remove'), org_admin_template_path(id: template.id), 'data-method': 'delete', rel: 'nofollow',
+                    <%= link_to _('Remove'), org_admin_template_path(id: template.id, r: 'organisation-templates'), 
+                                'data-method': 'delete', rel: 'nofollow',
                                 'data-confirm': _('Are you sure you want to remove "%{template_title}"?') % { template_title: template.title} %>
                   </li>
                 <% end %>

--- a/test/functional/org_admin/templates_controller_test.rb
+++ b/test/functional/org_admin/templates_controller_test.rb
@@ -188,13 +188,13 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     delete org_admin_template_path(prior)
     assert_equal _('You cannot delete historical versions of this template.'), flash[:alert]
     assert_response :redirect
-    assert_redirected_to org_admin_templates_path
+    assert_redirected_to org_admin_templates_path(r: 'all-templates')
     assert_not Template.find(prior.id).nil?
 
     # Try to delete the current version should work
     delete org_admin_template_path(current)
     assert_response :redirect
-    assert_redirected_to org_admin_templates_path
+    assert_redirected_to org_admin_templates_path(r: 'all-templates')
     assert_raise ActiveRecord::RecordNotFound do
       Template.find(current.id).nil?
     end
@@ -304,7 +304,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     customization = Template.where(customization_of: template.dmptemplate_id).last
 
     assert_response :redirect
-    assert_redirected_to edit_org_admin_template_url(Template.last)
+    assert_redirected_to edit_org_admin_template_url(Template.last, r: 'funder-templates')
     assert assigns(:template)
 
     assert_equal 0, customization.version
@@ -419,7 +419,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     get copy_org_admin_template_path(@template)
     assert_response :redirect
-    assert_redirected_to "#{edit_org_admin_template_url(Template.last)}?edit=true"
+    assert_redirected_to edit_org_admin_template_url(Template.last, edit: true, r: 'organisation-templates')
   end
   
   test "unauthorized user cannot transfer a template customization" do


### PR DESCRIPTION
- Updated template show/edit so that 'visibility' is only available to Orgs that are a funder AND some other org type (e.g. USGS is funder+organisation) #1042 
- Update 'View all templates' buttons so that they return to the correct template tab #1042 
- Discovered an issue with the way Published/Unpublished was displaying on org templates tab