### PR TITLE
Change long strings to text in DB

### DIFF
--- a/db/migrate/20180123161959_change_long_strings_to_text.rb
+++ b/db/migrate/20180123161959_change_long_strings_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeLongStringsToText < ActiveRecord::Migration
+  def change
+    change_column :orgs, :links, :text
+    change_column :templates, :links, :text
+    change_column :identifier_schemes, :logo_url, :text
+    change_column :identifier_schemes, :user_landing_url, :text
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171124133802) do
+ActiveRecord::Schema.define(version: 20180123161959) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "annotations", force: :cascade do |t|
-    t.integer  "question_id", limit: 4
-    t.integer  "org_id",      limit: 4
-    t.text     "text",        limit: 65535
-    t.integer  "type",        limit: 4,     default: 0, null: false
+    t.integer  "question_id"
+    t.integer  "org_id"
+    t.text     "text"
+    t.integer  "type",        default: 0, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -27,13 +30,13 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   add_index "annotations", ["question_id"], name: "index_annotations_on_question_id", using: :btree
 
   create_table "answers", force: :cascade do |t|
-    t.text     "text",         limit: 65535
-    t.integer  "plan_id",      limit: 4
-    t.integer  "user_id",      limit: 4
-    t.integer  "question_id",  limit: 4
+    t.text     "text"
+    t.integer  "plan_id"
+    t.integer  "user_id"
+    t.integer  "question_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "lock_version", limit: 4,     default: 0
+    t.integer  "lock_version",             default: 0
     t.string   "label_id",     limit: 255
   end
 
@@ -42,25 +45,25 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   add_index "answers", ["user_id"], name: "fk_rails_584be190c2", using: :btree
 
   create_table "answers_question_options", id: false, force: :cascade do |t|
-    t.integer "answer_id",          limit: 4, null: false
-    t.integer "question_option_id", limit: 4, null: false
+    t.integer "answer_id",          null: false
+    t.integer "question_option_id", null: false
   end
 
   add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id", using: :btree
 
   create_table "exported_plans", force: :cascade do |t|
-    t.integer  "plan_id",    limit: 4
-    t.integer  "user_id",    limit: 4
+    t.integer  "plan_id"
+    t.integer  "user_id"
     t.string   "format",     limit: 255
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
-    t.integer  "phase_id",   limit: 4
+    t.integer  "phase_id"
   end
 
   create_table "file_types", force: :cascade do |t|
     t.string   "name",          limit: 255
     t.string   "icon_name",     limit: 255
-    t.integer  "icon_size",     limit: 4
+    t.integer  "icon_size"
     t.string   "icon_location", limit: 255
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
@@ -69,18 +72,18 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   create_table "file_uploads", force: :cascade do |t|
     t.string   "name",         limit: 255
     t.string   "title",        limit: 255
-    t.text     "description",  limit: 65535
-    t.integer  "size",         limit: 4
+    t.text     "description"
+    t.integer  "size"
     t.boolean  "published"
     t.string   "location",     limit: 255
-    t.integer  "file_type_id", limit: 4
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.integer  "file_type_id"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string   "slug",           limit: 255, null: false
-    t.integer  "sluggable_id",   limit: 4,   null: false
+    t.integer  "sluggable_id",               null: false
     t.string   "sluggable_type", limit: 40
     t.datetime "created_at"
   end
@@ -91,7 +94,7 @@ ActiveRecord::Schema.define(version: 20171124133802) do
 
   create_table "guidance_groups", force: :cascade do |t|
     t.string   "name",            limit: 255
-    t.integer  "org_id",          limit: 4
+    t.integer  "org_id"
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.boolean  "optional_subset"
@@ -102,11 +105,11 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   add_index "guidance_groups", ["org_id"], name: "index_guidance_groups_on_org_id", using: :btree
 
   create_table "guidances", force: :cascade do |t|
-    t.text     "text",              limit: 65535
-    t.integer  "guidance_group_id", limit: 4
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.integer  "question_id",       limit: 4
+    t.text     "text"
+    t.integer  "guidance_group_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.integer  "question_id"
     t.boolean  "published"
   end
 
@@ -119,8 +122,8 @@ ActiveRecord::Schema.define(version: 20171124133802) do
     t.boolean  "active"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "logo_url",         limit: 255
-    t.string   "user_landing_url", limit: 255
+    t.text     "logo_url"
+    t.text     "user_landing_url"
   end
 
   create_table "languages", force: :cascade do |t|
@@ -131,11 +134,11 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   end
 
   create_table "notes", force: :cascade do |t|
-    t.integer  "user_id",     limit: 4
-    t.text     "text",        limit: 65535
+    t.integer  "user_id"
+    t.text     "text"
     t.boolean  "archived"
-    t.integer  "answer_id",   limit: 4
-    t.integer  "archived_by", limit: 4
+    t.integer  "answer_id"
+    t.integer  "archived_by"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -149,16 +152,16 @@ ActiveRecord::Schema.define(version: 20171124133802) do
     t.string   "attrs",                limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "org_id",               limit: 4
-    t.integer  "identifier_scheme_id", limit: 4
+    t.integer  "org_id"
+    t.integer  "identifier_scheme_id"
   end
 
   add_index "org_identifiers", ["identifier_scheme_id"], name: "fk_rails_189ad2e573", using: :btree
   add_index "org_identifiers", ["org_id"], name: "fk_rails_36323c0674", using: :btree
 
   create_table "org_token_permissions", force: :cascade do |t|
-    t.integer  "org_id",                   limit: 4
-    t.integer  "token_permission_type_id", limit: 4
+    t.integer  "org_id"
+    t.integer  "token_permission_type_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -172,24 +175,24 @@ ActiveRecord::Schema.define(version: 20171124133802) do
     t.string   "abbreviation",           limit: 255
     t.string   "target_url",             limit: 255
     t.string   "wayfless_entity",        limit: 255
-    t.datetime "created_at",                                           null: false
-    t.datetime "updated_at",                                           null: false
-    t.integer  "parent_id",              limit: 4
+    t.datetime "created_at",                                         null: false
+    t.datetime "updated_at",                                         null: false
+    t.integer  "parent_id"
     t.boolean  "is_other"
     t.string   "sort_name",              limit: 255
-    t.text     "banner_text",            limit: 65535
+    t.text     "banner_text"
     t.string   "logo_file_name",         limit: 255
-    t.integer  "region_id",              limit: 4
-    t.integer  "language_id",            limit: 4
+    t.integer  "region_id"
+    t.integer  "language_id"
     t.string   "logo_uid",               limit: 255
     t.string   "logo_name",              limit: 255
     t.string   "contact_email",          limit: 255
-    t.integer  "org_type",               limit: 4,     default: 0,     null: false
+    t.integer  "org_type",                           default: 0,     null: false
     t.string   "contact_name",           limit: 255
-    t.string   "links",                  limit: 255,   default: "[]"
-    t.boolean  "feedback_enabled",                     default: false
+    t.text     "links",                              default: "[]"
+    t.boolean  "feedback_enabled",                   default: false
     t.string   "feedback_email_subject", limit: 255
-    t.text     "feedback_email_msg",     limit: 65535
+    t.text     "feedback_email_msg"
   end
 
   add_index "orgs", ["language_id"], name: "fk_rails_5640112cab", using: :btree
@@ -206,9 +209,9 @@ ActiveRecord::Schema.define(version: 20171124133802) do
 
   create_table "phases", force: :cascade do |t|
     t.string   "title",       limit: 255
-    t.text     "description", limit: 65535
-    t.integer  "number",      limit: 4
-    t.integer  "template_id", limit: 4
+    t.text     "description"
+    t.integer  "number"
+    t.integer  "template_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "slug",        limit: 255
@@ -219,62 +222,62 @@ ActiveRecord::Schema.define(version: 20171124133802) do
 
   create_table "plans", force: :cascade do |t|
     t.string   "title",                             limit: 255
-    t.integer  "template_id",                       limit: 4
+    t.integer  "template_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "slug",                              limit: 255
     t.string   "data_contact_phone",                limit: 255
     t.string   "grant_number",                      limit: 255
     t.string   "identifier",                        limit: 255
-    t.text     "description",                       limit: 65535
+    t.text     "description"
     t.string   "principal_investigator",            limit: 255
     t.string   "principal_investigator_identifier", limit: 255
     t.string   "data_contact",                      limit: 255
     t.string   "funder_name",                       limit: 255
-    t.integer  "visibility",                        limit: 4,                     null: false
+    t.integer  "visibility",                                                    null: false
     t.string   "data_contact_email",                limit: 255
     t.string   "principal_investigator_email",      limit: 255
     t.string   "principal_investigator_phone",      limit: 255
-    t.boolean  "feedback_requested",                              default: false
+    t.boolean  "feedback_requested",                            default: false
   end
 
   add_index "plans", ["template_id"], name: "index_plans_on_template_id", using: :btree
 
   create_table "plans_guidance_groups", force: :cascade do |t|
-    t.integer "guidance_group_id", limit: 4
-    t.integer "plan_id",           limit: 4
+    t.integer "guidance_group_id"
+    t.integer "plan_id"
   end
 
   add_index "plans_guidance_groups", ["guidance_group_id"], name: "fk_rails_ec1c5524d7", using: :btree
   add_index "plans_guidance_groups", ["plan_id"], name: "fk_rails_13d0671430", using: :btree
 
   create_table "prefs", force: :cascade do |t|
-    t.text    "settings", limit: 65535
-    t.integer "user_id",  limit: 4
+    t.text    "settings"
+    t.integer "user_id"
   end
 
   create_table "question_format_labels", id: false, force: :cascade do |t|
-    t.integer  "id",          limit: 4
+    t.integer  "id"
     t.string   "description", limit: 255
-    t.integer  "question_id", limit: 4
-    t.integer  "number",      limit: 4
+    t.integer  "question_id"
+    t.integer  "number"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "question_formats", force: :cascade do |t|
     t.string   "title",        limit: 255
-    t.text     "description",  limit: 65535
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
-    t.boolean  "option_based",               default: false
-    t.integer  "formattype",   limit: 4,     default: 0
+    t.text     "description"
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.boolean  "option_based",             default: false
+    t.integer  "formattype",               default: 0
   end
 
   create_table "question_options", force: :cascade do |t|
-    t.integer  "question_id", limit: 4
+    t.integer  "question_id"
     t.string   "text",        limit: 255
-    t.integer  "number",      limit: 4
+    t.integer  "number"
     t.boolean  "is_default"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -284,14 +287,14 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   add_index "question_options", ["question_id"], name: "index_question_options_on_question_id", using: :btree
 
   create_table "questions", force: :cascade do |t|
-    t.text     "text",                   limit: 65535
-    t.text     "default_value",          limit: 65535
-    t.integer  "number",                 limit: 4
-    t.integer  "section_id",             limit: 4
+    t.text     "text"
+    t.text     "default_value"
+    t.integer  "number"
+    t.integer  "section_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "question_format_id",     limit: 4
-    t.boolean  "option_comment_display",               default: true
+    t.integer  "question_format_id"
+    t.boolean  "option_comment_display", default: true
     t.boolean  "modifiable"
   end
 
@@ -299,8 +302,8 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   add_index "questions", ["section_id"], name: "index_questions_on_section_id", using: :btree
 
   create_table "questions_themes", id: false, force: :cascade do |t|
-    t.integer "question_id", limit: 4, null: false
-    t.integer "theme_id",    limit: 4, null: false
+    t.integer "question_id", null: false
+    t.integer "theme_id",    null: false
   end
 
   add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id", using: :btree
@@ -309,16 +312,16 @@ ActiveRecord::Schema.define(version: 20171124133802) do
     t.string  "abbreviation",    limit: 255
     t.string  "description",     limit: 255
     t.string  "name",            limit: 255
-    t.integer "super_region_id", limit: 4
+    t.integer "super_region_id"
   end
 
   create_table "roles", force: :cascade do |t|
-    t.integer  "user_id",    limit: 4
-    t.integer  "plan_id",    limit: 4
+    t.integer  "user_id"
+    t.integer  "plan_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "access",     limit: 4, default: 0,    null: false
-    t.boolean  "active",               default: true
+    t.integer  "access",     default: 0,    null: false
+    t.boolean  "active",     default: true
   end
 
   add_index "roles", ["plan_id"], name: "fk_rails_a1ce6c2772", using: :btree
@@ -327,34 +330,34 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   add_index "roles", ["user_id"], name: "index_roles_on_user_id", using: :btree
 
   create_table "sample_plans", id: false, force: :cascade do |t|
-    t.integer  "id",          limit: 4
+    t.integer  "id"
     t.string   "url",         limit: 255
     t.string   "label",       limit: 255
-    t.integer  "template_id", limit: 4
+    t.integer  "template_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "sections", force: :cascade do |t|
     t.string   "title",       limit: 255
-    t.text     "description", limit: 65535
-    t.integer  "number",      limit: 4
+    t.text     "description"
+    t.integer  "number"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "published"
-    t.integer  "phase_id",    limit: 4
+    t.integer  "phase_id"
     t.boolean  "modifiable"
   end
 
   add_index "sections", ["phase_id"], name: "index_sections_on_phase_id", using: :btree
 
   create_table "settings", force: :cascade do |t|
-    t.string   "var",         limit: 255,   null: false
-    t.text     "value",       limit: 65535
-    t.integer  "target_id",   limit: 4,     null: false
-    t.string   "target_type", limit: 255,   null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.string   "var",         limit: 255, null: false
+    t.text     "value"
+    t.integer  "target_id",               null: false
+    t.string   "target_type", limit: 255, null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
   add_index "settings", ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true, using: :btree
@@ -367,20 +370,20 @@ ActiveRecord::Schema.define(version: 20171124133802) do
 
   create_table "templates", force: :cascade do |t|
     t.string   "title",            limit: 255
-    t.text     "description",      limit: 65535
+    t.text     "description"
     t.boolean  "published"
-    t.integer  "org_id",           limit: 4
+    t.integer  "org_id"
     t.string   "locale",           limit: 255
     t.boolean  "is_default"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "version",          limit: 4
-    t.integer  "visibility",       limit: 4
-    t.integer  "customization_of", limit: 4
-    t.integer  "dmptemplate_id",   limit: 4
+    t.integer  "version"
+    t.integer  "visibility"
+    t.integer  "customization_of"
+    t.integer  "dmptemplate_id"
     t.boolean  "migrated"
-    t.boolean  "dirty",                          default: false
-    t.string   "links",            limit: 255,   default: "{\"funder\":[], \"sample_plan\":[]}"
+    t.boolean  "dirty",                        default: false
+    t.text     "links",                        default: "{\"funder\":[], \"sample_plan\":[]}"
   end
 
   add_index "templates", ["org_id", "dmptemplate_id"], name: "template_organisation_dmptemplate_index", using: :btree
@@ -388,15 +391,15 @@ ActiveRecord::Schema.define(version: 20171124133802) do
 
   create_table "themes", force: :cascade do |t|
     t.string   "title",       limit: 255
-    t.text     "description", limit: 65535
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.text     "description"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.string   "locale",      limit: 255
   end
 
   create_table "themes_in_guidance", id: false, force: :cascade do |t|
-    t.integer "theme_id",    limit: 4
-    t.integer "guidance_id", limit: 4
+    t.integer "theme_id"
+    t.integer "guidance_id"
   end
 
   add_index "themes_in_guidance", ["guidance_id"], name: "fk_rails_a5ab9402df", using: :btree
@@ -406,7 +409,7 @@ ActiveRecord::Schema.define(version: 20171124133802) do
 
   create_table "token_permission_types", force: :cascade do |t|
     t.string   "token_type",       limit: 255
-    t.text     "text_description", limit: 65535
+    t.text     "text_description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -415,8 +418,8 @@ ActiveRecord::Schema.define(version: 20171124133802) do
     t.string   "identifier",           limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",              limit: 4
-    t.integer  "identifier_scheme_id", limit: 4
+    t.integer  "user_id"
+    t.integer  "identifier_scheme_id"
   end
 
   add_index "user_identifiers", ["identifier_scheme_id"], name: "fk_rails_fe95df7db0", using: :btree
@@ -435,7 +438,7 @@ ActiveRecord::Schema.define(version: 20171124133802) do
     t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          limit: 4,   default: 0
+    t.integer  "sign_in_count",                      default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip",     limit: 255
@@ -449,11 +452,11 @@ ActiveRecord::Schema.define(version: 20171124133802) do
     t.datetime "invitation_accepted_at"
     t.string   "other_organisation",     limit: 255
     t.boolean  "accept_terms"
-    t.integer  "org_id",                 limit: 4
+    t.integer  "org_id"
     t.string   "api_token",              limit: 255
-    t.integer  "invited_by_id",          limit: 4
+    t.integer  "invited_by_id"
     t.string   "invited_by_type",        limit: 255
-    t.integer  "language_id",            limit: 4
+    t.integer  "language_id"
     t.string   "recovery_email",         limit: 255
   end
 
@@ -463,8 +466,8 @@ ActiveRecord::Schema.define(version: 20171124133802) do
   add_index "users", ["org_id"], name: "index_users_on_org_id", using: :btree
 
   create_table "users_perms", id: false, force: :cascade do |t|
-    t.integer "user_id", limit: 4
-    t.integer "perm_id", limit: 4
+    t.integer "user_id"
+    t.integer "perm_id"
   end
 
   add_index "users_perms", ["perm_id"], name: "fk_rails_457217c31c", using: :btree


### PR DESCRIPTION
**DB Migration** for #729 .

Changes proposed in this PR:
- As discussed, switch strings that we know are long (JSON, URLs) to TEXT type in DB
