### PR TITLE
Guidance section in Plan edit page(#943)

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -108,8 +108,35 @@ class PlansController < ApplicationController
       end
     end
   end
+  
+  ## Using GET request to display all gudiance groups
+  def select_guidances_list
+    @plan = Plan.find(params[:id])
+    authorize @plan
+    @all_guidance_groups = @plan.get_guidance_group_options
+    @selected_guidance_groups = @plan.guidance_groups
 
+    render json: {
+      "plan" => {
+        "id" => @plan.id,
+        "html" => render_to_string(partial: 'plans/all_guidances', 
+                                   locals: { guidance_groups: @all_guidance_groups,
+                                             selected_guidance_groups: @selected_guidance_groups }, 
+                                   formats: [:html])
+      }
+    }.to_json
+  end
 
+  ## Using PUT request to update the plan with the guidance group selections
+  def update_guidances_list
+    @plan = Plan.find(params[:id])
+    authorize @plan
+
+    guidance_group_ids = params[:guidance_group_ids].blank? ? [] : params[:guidance_group_ids].map(&:to_i)
+    save_guidance_selections(guidance_group_ids)
+    @plan.save!
+    redirect_to(request.env["HTTP_REFERER"] || plan_path(@plan), notice: success_message(_('plan'), _('saved')) )
+  end
 
   # GET /plans/show
   def show

--- a/app/policies/plan_policy.rb
+++ b/app/policies/plan_policy.rb
@@ -65,4 +65,11 @@ class PlanPolicy < ApplicationPolicy
     @plan.readable_by?(@user.id)
   end
 
+  def select_guidances_list?
+    @plan.readable_by?(@user.id)
+  end
+
+  def update_guidances_list?
+    @plan.editable_by?(@user.id)
+  end
 end

--- a/app/views/plans/_all_guidances.html.erb
+++ b/app/views/plans/_all_guidances.html.erb
@@ -1,0 +1,36 @@
+<div class="modal-dialog" role="document">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button type="button" class="close" 
+            data-dismiss="modal" 
+            aria-label="Close">
+            <span aria-hidden="true">&times;</span></button>
+      <p><strong><%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations. Select from the list below.') %
+        {application_name: Rails.configuration.branding[:application][:name]} %>
+      </p></strong>
+    </div>
+    <%#= form_tag(plan_path(plan), method: :put) do %>
+      <%= form_tag( update_guidances_list_plan_path(@plan), method: :put) do %>
+        <div class="modal-body">
+          <ul class="list-group" style="list-style: none;" aria-hidden="true">
+            <% cur_letter = nil %>
+            <% @all_guidance_groups = @all_guidance_groups.sort_by(&:name) %>
+            <% @all_guidance_groups.each do |group| %>
+              <% title_letter = group.name[0].capitalize.match(/[A-Z]/) ? group.name[0].capitalize : "#" %> 
+              <% if title_letter != cur_letter %>
+                <% cur_letter = title_letter %>
+                <li class="bg-primary"><%= cur_letter %></li>
+              <% end %>
+              <li>
+                <%= check_box_tag "guidance_group_ids[]", group.id, @selected_guidance_groups.include?(group) %>
+                <%= group.name %></li>
+            <% end %> 
+          </ul>
+      </div>
+      <div class="modal-footer">
+        <%= submit_tag _('Save selections'), class: "btn btn-primary" %>
+        <%= link_to 'Cancel', plan_path(@plan), class: "btn btn-default" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -163,5 +163,8 @@
                             current_selections: @selected_guidance_groups} %>
       </ul>
     </div>
+    <p><%= _('Find guidance from additional organisations below') %></p>
+    <%= link_to 'see the full list', select_guidances_list_plan_path(@plan), 'data-toggle' =>  'modal', 'data-target' => '#modal-full-guidances', class: 'modal-guidances-window' %>
+    <div id="modal-full-guidances" class="modal" tabindex="-1" role="dialog"></div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,6 +208,8 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
         post 'set_test', constraints: {format: [:json]}
         get 'request_feedback'
         get 'overview'
+        get 'select_guidances_list'
+        put 'update_guidances_list'
       end
 
       collection do

--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -31,6 +31,7 @@ import './views/plans/edit_details';
 import './views/plans/index';
 import './views/plans/new';
 import './views/plans/share';
+import './views/plans/all_guidances';
 import './views/roles/edit';
 import './views/sections/edit';
 import './views/sections/index';

--- a/lib/assets/javascripts/views/plans/all_guidances.js
+++ b/lib/assets/javascripts/views/plans/all_guidances.js
@@ -1,0 +1,23 @@
+$(() => {
+  const success = (data) => {
+    // Render the html in the modal-permissions modal
+    $('#modal-full-guidances').html(data.plan.html);
+  };
+
+  const error = () => {
+    // There was an ajax error so just route the user to the sign-in modal
+    // and let them sign in as a Non-Partner Institution
+    $('a[data-target="#modal-full-guidances"]').tab('show');
+  };
+  // Loading the list of guidance groups options when user clicks the 'see the full list' link
+  $('.modal-guidances-window').on('click', (e) => {
+    const target = $(e.target);
+    $('#modal-full-guidances').html('');
+    $.ajax({
+      method: 'GET',
+      url: target.attr('href'),
+    }).done((data) => {
+      success(data);
+    }, error);
+  });
+});

--- a/test/functional/plans_controller_test.rb
+++ b/test/functional/plans_controller_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'byebug'
+
 class PlansControllerTest < ActionDispatch::IntegrationTest
 
   include Devise::Test::IntegrationHelpers
@@ -73,6 +73,36 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   
     # assert that the default visibility is used when none is specified
     assert_equal Rails.application.config.default_plan_visibility, new_plan.visibility, "Expected the plan to have been assigned the default visibility"
+  end
+
+  # GET /plan/:id (plan_path)
+  # ----------------------------------------------------------
+  test "select_guidances_list for a plan" do
+    # Should redirect user to the root path if they are not logged in!
+    get select_guidances_list_plan_path(@plan)
+    assert_unauthorized_redirect_to_root_path
+
+    sign_in @user
+    # GET /plan/:id (plan_path) 
+    get select_guidances_list_plan_path(@plan)
+    assert_response :success
+    assert assigns(:plan)
+    assert_not assigns(:editing)
+    assert assigns(:all_guidance_groups)
+  end
+
+  # PUT /plan/:id (plan_path)
+  # ----------------------------------------------------------
+  test "update_guidances_list for a plan" do
+    ids = [GuidanceGroup.first.id, GuidanceGroup.last.id]
+    # Should redirect user to the root path if they are not logged in!
+    put update_guidances_list_plan_path(@plan), { "HTTP_REFERER": plan_path(@plan) }
+    assert_unauthorized_redirect_to_root_path
+
+    sign_in @user
+    # GET /plan/:id (plan_path) 
+    put update_guidances_list_plan_path(@plan), {plan: {id: @plan.id}, guidance_group_ids: ids}
+    assert_response :redirect
   end
 
   # GET /plan/:id (plan_path)


### PR DESCRIPTION
- reimplement the guidance selection functionality on the project details page #943
- all possible guidance selections are now only loaded on-demand when the user opens the modal
- add functional test for the select guidance list modal
