### PR TITLE
updates to pdf and docx formatting for public templates and plans

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -18,14 +18,14 @@ class PublicPagesController < ApplicationController
     raise Pundit::NotAuthorizedError unless PublicPagePolicy.new( @template).template_export?
     skip_authorization
     # now with prefetching (if guidance is added, prefetch annottaions/guidance)
-    @template = Template.includes(:org, phases: {sections:{questions:[:question_options, :question_format]}}).find(@template.id)
+    @template = Template.includes(:org, phases: {sections:{questions:[:question_options, :question_format, :annotations]}}).find(@template.id)
+    @formatting = Settings::Template::DEFAULT_SETTINGS[:formatting]
 
     begin
-      file_name = @template.title.gsub(/ /, "_")
+      file_name = @template.title.gsub(/[^a-zA-Z\d\s]/, '').gsub(/ /, "_")
       respond_to do |format|
         format.docx { render docx: 'template_export', filename: "#{file_name}.docx" }
         format.pdf do
-          @formatting = Settings::Template::DEFAULT_SETTINGS[:formatting]
           render pdf: file_name,
           margin: @formatting[:margin],
           footer: {

--- a/app/models/settings/template.rb
+++ b/app/models/settings/template.rb
@@ -16,14 +16,14 @@ module Settings
 
     DEFAULT_SETTINGS = {
       formatting: {
-        margin: { # in millimeters
-          top:    10,
-          bottom: 10,
-          left:   10,
-          right:  10
+        margin: {
+          top:    25,
+          bottom: 20,
+          left:   20,
+          right:  20
         },
-        font_face: VALID_FONT_FACES.first,
-        font_size: 10 # pt
+        font_face: 'Arial, Helvetica, Sans-Serif',
+        font_size: 11 # pt
       },
       max_pages: 3,
       fields: {

--- a/app/views/public_pages/plan_export.pdf.erb
+++ b/app/views/public_pages/plan_export.pdf.erb
@@ -1,26 +1,66 @@
 <!DOCTYPE html>
 <html>
   <head>
-      <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-      <title>
-          <%= @plan.title %>
-      </title>
-      <style>
-          html { font-family: <%= @formatting[:font_face].tr('"', '') -%>; font-size: <%= @formatting[:font_size] -%>pt; }
-          h1 { font-size: <%= @formatting[:font_size] + 2 -%>pt; font-face:bold; padding: 0;}
-          h2 { font-size: <%= @formatting[:font_size] + 1 -%>pt; font-face:bold; padding: 0; margin: 1em 0 0 0;}
-          h3 { font-size: <%= @formatting[:font_size] + 0 -%>pt; font-face:bold; padding: 0; margin: 1em 0 0 0;}
-          h2 + div.question > h3 { margin: 0; }
-          table, tr, td, th, tbody, thead, tfoot { page-break-inside: avoid !important; }
-          table { border-collapse: collapse; }
-          th, td { border: 1px solid black !important; padding: 2px; }
-          p { margin: 0.25em 0; }
-      </style>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>
+        <%= @plan.title %>
+    </title>
+    <style>
+      html {
+        font-family: <%= @formatting[:font_face].tr('"', '') -%>; 
+        font-size: <%= @formatting[:font_size] -%>pt; 
+        margin: <%= @formatting[:margin][:top] %>px <%= @formatting[:margin][:right] %>px <%= @formatting[:margin][:bottom] %>px <%= @formatting[:margin][:left] %>px; */
+      }
+      h1 {
+        font-size: <%= @formatting[:font_size] + 3 -%>pt; 
+        font-face:bold; 
+        padding: 0;
+      }
+      h2 {
+        font-size: <%= @formatting[:font_size] + 2 -%>pt; 
+        font-face:bold; 
+        padding: 0; 
+        margin: 1em 0 0 0;
+      }
+      h3 {
+        font-size: <%= @formatting[:font_size] + 1 -%>pt; 
+        font-face:bold; 
+        padding: 0; 
+        margin: 1em 0 0 0;
+      }
+      h2 + div.question > h3 {
+        margin: 0; 
+      }
+      table, tr, td, th, tbody, thead, tfoot {
+        page-break-inside: avoid !important; 
+      }
+      table { 
+        border-collapse: collapse; 
+      }
+      th, td { 
+        border: 1px solid black !important; 
+        padding: 2px;
+      }
+      p { 
+        margin: 0.25em 0;
+      }
+      .question {
+        margin-top: 15px;
+        margin-bottom: 10px;
+      }
+      .question:first-child {
+        margin-top: 0;
+      }
+      .annotations {
+        margin-left: 15px;
+        margin-bottom: 10px;
+      }
+    </style>
   </head>
   <body>
     <div style="text-align:center;">
       <h1><%= @plan.title %></h1>
-      <p><em><%= _("A Data Management Plan created using ") + Rails.configuration.branding[:application][:name] + "." %></em></p>
+      <p><em><%= _("A Data Management Plan created using ") + Rails.configuration.branding[:application][:name] %></em></p>
     </div>
     </br>
     <p><%= _("Creator(s): ") + @creator_text %></p>    <br>

--- a/app/views/public_pages/template_export.docx.erb
+++ b/app/views/public_pages/template_export.docx.erb
@@ -5,29 +5,43 @@
     <title>
       <%= @template.title %>
     </title>
+    <style>
+      .guidance {
+        margin: 10px 0 10px 15px;
+      }
+    </style>
   </head>
-  <body>
+  <body style="font-family: Arial; font-size: 11pt;">
     <% @template.phases.each do |phase| %>
       <!-- page break before each phase -->
       <br style="page-break-before: always">
       <h2><%= "#{@template.org.name}: #{@template.title}" %><%= @template.phases.length > 1 ? " - #{phase.title}" : "" %></h2>
+
       <% phase.sections.each do |section| %>
         <h3><%= section.title %></h3>
         <% section.questions.each do |question|%>
-          <p><%= raw question.text %></p>
-          <% q_format = question.question_format %>
-          <% if q_format.option_based? %>
-            <ul>
-              <% question.question_options.each do |option| %>
-                <li><%= option.text %></li>
+          <div>
+            <p><%= raw question.text %></p>
+            <% q_format = question.question_format %>
+            <% if q_format.option_based? %>
+              <ul>
+                <% question.question_options.each do |option| %>
+                  <li><%= option.text %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+        
+          <div class="guidance">
+            <% question.annotations.each do |annotation| %>
+              <% unless annotation.text.chomp.strip.gsub(/<\/?p>/, '').gsub(/<br\s?\/>/, '').blank? %>
+                <br>
+                <p><i><%= annotation.type == 0 ? _('Example Answer') : _('Guidance') %></i>:</p>
+                <%= raw annotation.text %>
               <% end %>
-            </ul>
-          <% end %>
-          <% question.annotations.each do |annotation| %>
-            <br>
-            <p><i><%= annotation.type == 0 ? _('Example Answer') : _('Guidance') %></i>:</p>
-            <%= raw annotation.text %>
-          <% end %>
+            <% end %>
+          </div>
+
           <br>
         <% end %>
       <% end %>

--- a/app/views/public_pages/template_export.pdf.erb
+++ b/app/views/public_pages/template_export.pdf.erb
@@ -6,15 +6,55 @@
       <%= @template.title %>
     </title>
     <style>
-      html { font-family: <%= @formatting[:font_face].tr('"', '') -%>; font-size: <%= @formatting[:font_size] -%>pt; }
-        h1 { font-size: <%= @formatting[:font_size] + 2 -%>pt; font-face:bold; padding: 0;}
-        h2 { font-size: <%= @formatting[:font_size] + 1 -%>pt; font-face:bold; padding: 0; margin: 1em 0 0 0;}
-        h3 { font-size: <%= @formatting[:font_size] + 0 -%>pt; font-face:bold; padding: 0; margin: 1em 0 0 0;}
-        h2 + div.question > h3 { margin: 0; }
-        table, tr, td, th, tbody, thead, tfoot { page-break-inside: avoid !important; }
-        table { border-collapse: collapse; }
-        th, td { border: 1px solid black !important; padding: 2px; }
-        p { margin: 0.25em 0; }
+      html {
+        font-family: <%= @formatting[:font_face].tr('"', '') -%>; 
+        font-size: <%= @formatting[:font_size] -%>pt; 
+        margin: <%= @formatting[:margin][:top] %>px <%= @formatting[:margin][:right] %>px <%= @formatting[:margin][:bottom] %>px <%= @formatting[:margin][:left] %>px; */
+      }
+      h1 {
+        font-size: <%= @formatting[:font_size] + 3 -%>pt; 
+        font-face:bold; 
+        padding: 0;
+      }
+      h2 {
+        font-size: <%= @formatting[:font_size] + 2 -%>pt; 
+        font-face:bold; 
+        padding: 0; 
+        margin: 1em 0 0 0;
+      }
+      h3 {
+        font-size: <%= @formatting[:font_size] + 1 -%>pt; 
+        font-face:bold; 
+        padding: 0; 
+        margin: 1em 0 0 0;
+      }
+      h2 + div.question > h3 {
+        margin: 0; 
+      }
+      table, tr, td, th, tbody, thead, tfoot {
+        page-break-inside: avoid !important; 
+      }
+      table { 
+        border-collapse: collapse; 
+      }
+      th, td { 
+        border: 1px solid black !important; 
+        padding: 2px;
+      }
+      p { 
+        margin: 0.25em 0;
+      }
+      .question {
+        margin-top: 15px;
+        margin-bottom: 10px;
+      }
+      .question:first-child {
+        margin-top: 0;
+      }
+      .annotations {
+        margin-left: 15px;
+        margin-bottom: 10px;
+      }
     </style>
   </head>
   <body>
@@ -37,9 +77,10 @@
         </div>
         <div class="annotations">
           <% question.annotations.each do |annotation| %>
-            <br>
-            <p><i><%= annotation.type == 0 ? _('Example Answer') : _('Guidance') %></i>:</p>
-            <div style="margin-left: 15px;"><%= raw annotation.text %></div>
+            <% unless annotation.text.chomp.strip.gsub(/<\/?p>/, '').gsub(/<br\s?\/>/, '').blank? %>
+              <p><i><%= annotation.type == 0 ? _('Example Answer') : _('Guidance') %></i>:</p>
+              <div style="margin-left: 15px;"><%= raw annotation.text.chomp.strip %></div>
+            <% end %>
           <% end %>
         </div>
         <% end %>


### PR DESCRIPTION
Addresses comments on #1003 and #712 
- Update default template formatting settings so that 'Arial' is the default and each PDF doc has 1 inch margins
- Updated formatting of public templates/plans
