### PR TITLE
Issue 867

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -58,7 +58,7 @@ class AnswersController < ApplicationController
           "locking" => @stale_answer ?
             render_to_string(partial: 'answers/locking', locals: { question: @question, answer: @stale_answer, user: @answer.user }, formats: [:html]) :
             nil,
-          "form" => render_to_string(partial: 'answers/new_edit', locals: { question: @question, answer: @answer, readonly: false }, formats: [:html]),
+          "form" => render_to_string(partial: 'answers/new_edit', locals: { question: @question, answer: @answer, readonly: false, locking: false }, formats: [:html]),
           "answer_status" => render_to_string(partial: 'answers/status', locals: { answer: @answer}, formats: [:html])
         },
         "section" => {

--- a/app/views/answers/_locking.html.erb
+++ b/app/views/answers/_locking.html.erb
@@ -1,5 +1,5 @@
 <div class="answer_notice">
     <p><%= _('The following answer cannot be saved') %></p>
-        <%= render partial: '/answers/new_edit', locals: { question: question, answer: answer, readonly: true } %>
+        <%= render partial: '/answers/new_edit', locals: { question: question, answer: answer, readonly: true, locking: true } %>
     <p><%= _('since %{name} saved the answer below while you were editing. Please, combine your changes and then save the answer again.') % { name: user.name} %></p>
 </div>

--- a/app/views/answers/_new_edit.html.erb
+++ b/app/views/answers/_new_edit.html.erb
@@ -1,4 +1,4 @@
-<%# locals: { question, answer, readonly } %>
+<%# locals: { question, answer, readonly, locking } %>
 <!--
   This partial creates a form for each type of question. The local variables are: plan, answer, question, readonly
 -->
@@ -8,6 +8,16 @@
     <%= f.hidden_field :question_id %>
     <%= f.hidden_field :lock_version %>
   <% end %>
+  <fieldset <%= 'disabled' if readonly %>>
+    <% if question.option_based? %>
+        <%= render(partial: 'questions/new_edit_question_option_based', locals: { f: f, question: question, answer: answer }) %>
+    <% elsif question.question_format.textfield?%>
+        <%= render(partial: 'questions/new_edit_question_textfield', locals: { f: f, question: question, answer: answer }) %>
+    <% elsif question.question_format.textarea? %>
+        <%= render(partial: 'questions/new_edit_question_textarea', locals: { f: f, question: question, answer: answer, locking: locking }) %>
+    <% end %>
+    <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
+  </fieldset>
   <!--Example Answer area -->
   <% annotation = question.first_example_answer %>
   <% if annotation.present? && annotation.text.present? %>
@@ -20,14 +30,4 @@
       </div>
     </div>
   <% end %>
-  <fieldset <%= 'disabled' if readonly %>>
-    <% if question.option_based? %>
-        <%= render(partial: 'questions/new_edit_question_option_based', locals: { f: f, question: question, answer: answer }) %>
-    <% elsif question.question_format.textfield?%>
-        <%= render(partial: 'questions/new_edit_question_textfield', locals: { f: f, question: question, answer: answer }) %>
-    <% elsif question.question_format.textarea? %>
-        <%= render(partial: 'questions/new_edit_question_textarea', locals: { f: f, question: question, answer: answer }) %>
-    <% end %>
-    <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
-  </fieldset>
 <% end %>

--- a/app/views/answers/_status.html.erb
+++ b/app/views/answers/_status.html.erb
@@ -1,12 +1,10 @@
 <%# locals: { answer } %>
-<!-- Partial for handling the answer status (e.g. Saving, Unsaved, Not Answered, Answered) -->
-<p class="bg-primary saving-message" style="display:none;">
-    <%= _('Saving...')%>
-</p>
-<p class="bg-warning unsaved-message" style="display: none;"></p>
+<!-- Partial for handling the answer status (e.g. saving, error-saving, data-status) -->
+<span class="label label-info status" style="display:none;" data-status="saving"><%= _('Saving...') %></span>
+<span class="label label-warning status" style="display: none;" data-status="error-saving"></span>
 <% if answer.is_valid? %>
-    <p class="bg-info">
+    <span class="label label-info status" data-status="saved-at">
       <%= _('Answered')%> <time class="timeago" datetime="<%= answer.updated_at.iso8601 %>"></time>
       <%= _(' by %{user_name}') %{ :user_name => answer.user.name } if answer.user.present? %>
-    </p>
+    </span>
 <% end %>

--- a/app/views/guidance_groups/_show.html.erb
+++ b/app/views/guidance_groups/_show.html.erb
@@ -11,26 +11,25 @@
   <% end %>
   <% group.keys.each_with_index do |theme, i| %>
     <div class="panel panel-default">
-      <div class="panel-heading" role="tab" id="headingA">
+      <div class="panel-heading" role="tab" id="heading-<%= i %>">
         <h2 class="panel-title">
           <a role="button" data-toggle="collapse" 
              data-parent="<%= question.id %>-guidance" 
              href="#collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>" 
              aria-controls="collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>"
              class="reverse">
-            <span class="fa fa-plus" aria-hidden="true"></span>
+            <i class="fa fa-plus" aria-hidden="true"></i>
             <%= theme %>
           </a>
         </h2>
       </div>
-    </div>
-
-    <div id="collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>" class="panel-collapse collapse" role="tabpanel"
+      <div id="collapse-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>" class="panel-collapse collapse" role="tabpanel"
          aria-labelledby="heading-guidance-<%= question.id %>-<%= guidance_accordion_id %>-<%= i %>">
-      <div class="panel-body">
-        <% group[theme].each do |guidance| %>
-          <%= raw guidance %>
-        <% end %>
+        <div class="panel-body">
+          <% group[theme].each do |guidance| %>
+            <%= raw guidance %>
+          <% end %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/notes/_layout.html.erb
+++ b/app/views/notes/_layout.html.erb
@@ -1,23 +1,27 @@
 <%# locals: { plan, question, answer } %>
 <% notes = answer.non_archived_notes %>
-<div class="row">
-  <div class="col-md-12">
-    <%= render partial: "/notes/list", locals: { question_id: question.id, notes: notes, plan: plan }, formats: [:html] %>  
+<div class="panel panel-default">
+  <div class="panel-body">
+    <div class="row">
+      <div class="col-md-12">
+        <%= render partial: "/notes/list", locals: { question_id: question.id, notes: notes, plan: plan }, formats: [:html] %>  
+      </div>
+    </div>
+    <% if plan.commentable_by?(current_user) %>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="note_new" id="<%= "note_new#{question.id}" %>" data-question-id="<%= question.id %>">
+              <%= render partial: "/notes/new", locals: { question: question, answer: answer, plan: plan }, formats: [:html] %>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-12">
+          <div class="pull-right">
+            <%= link_to(_('Add Comment'), "#note_new#{question.id}", class: "btn btn-default note_new_link", role: "button", style: "visibility: hidden") %>
+          </div>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>
-<% if plan.commentable_by?(current_user) %>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="note_new" id="<%= "note_new#{question.id}" %>" data-question-id="<%= question.id %>">
-          <%= render partial: "/notes/new", locals: { question: question, answer: answer, plan: plan }, formats: [:html] %>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="pull-right">
-        <%= link_to(_('Add Comment'), "#note_new#{question.id}", class: "btn btn-default note_new_link", role: "button", style: "visibility: hidden") %>
-      </div>
-    </div>
-  </div>
-<% end %>

--- a/app/views/notes/_show.html.erb
+++ b/app/views/notes/_show.html.erb
@@ -4,7 +4,7 @@
     <ul class="list-unstyled">
         <li><%= raw note.text %></li>
         <li>
-            <span class="label label-default">
+            <span class="label label-info">
                 <%= "#{user.name} at #{l(note.updated_at, format: :custom)}" %>
             </span>
         </li>

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -49,47 +49,42 @@
           </div>
           <div class="clearfix"></div>
         </div>
-      </div>
-      <div id="collapse-<%= sectionid %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-<%= sectionid %>">
-        <div class="panel-body"><!-- accordion body -->
-          <div class="section-description"><%= raw section.description %></div>
-            <div class="saving" style="display: none">
-              <p><%= _('Saving ...') %></p>
-            </div>
-            <div class="removing" style="display: none">
-              <p><%= _('Removing ...') %></p>
-            </div>
-            <!-- the section body -->
-            <% section.questions.each do |question| %>
-              <% # Load the answer or create a new one
-                answers = question.plan_answers(plan.id)  if plan.present?
-                if answers.present?
-                  answer = answers.first
-                else
-                  answer = Answer.new({ plan: plan, question: question })
-                end
-              %>
-              <div class="row">
-                <div class="col-md-8">
-                  <!-- Answer Section -->
-                  <div class="question-form">
-                    <div id="<%= "answer-locking-#{question.id}" %>" class="answer-locking"></div>
-                    <div id="<%= "answer-form-#{question.id}" %>" class="answer-form"> 
-                      <%= render(partial: '/answers/new_edit', locals: { question: question, answer: answer, readonly: readonly }) %>
-                    </div>
-                    <div id="<%= "answer-status-#{question.id}" %>">
-                      <%= render(partial: '/answers/status', locals: { answer: answer }) %>
+        <div id="collapse-<%= sectionid %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-<%= sectionid %>">
+          <div class="panel-body"><!-- accordion body -->
+            <div class="section-description"><%= raw section.description %></div>
+              <!-- the section body -->
+              <% section.questions.each_with_index do |question, i| %>
+                <% # Load the answer or create a new one
+                  answers = question.plan_answers(plan.id)  if plan.present?
+                  if answers.present?
+                    answer = answers.first
+                  else
+                    answer = Answer.new({ plan: plan, question: question })
+                  end
+                %>
+                <div class="row">
+                  <div class="col-md-8">
+                    <!-- Answer Section -->
+                    <div class="question-form">
+                      <div id="<%= "answer-locking-#{question.id}" %>" class="answer-locking"></div>
+                      <div id="<%= "answer-form-#{question.id}" %>" class="answer-form"> 
+                        <%= render(partial: '/answers/new_edit', locals: { question: question, answer: answer, readonly: readonly, locking: false }) %>
+                      </div>
+                      <div id="<%= "answer-status-#{question.id}" %>" class="mt-10">
+                        <%= render(partial: '/answers/status', locals: { answer: answer }) %>
+                      </div>
                     </div>
                   </div>
+                  <div class="col-md-4">
+                    <!-- Guidances and notes partial view -->
+                    <%= render partial: '/phases/guidances_notes', locals: { plan: plan, template: phase.template, question: question, answer: answer, question_guidance: question_guidance, guidance_groups: guidance_groups } %>
+                  </div>
                 </div>
-                <div class="col-md-4">
-                  <!-- Guidances and notes partial view -->
-                  <%= render partial: '/phases/guidances_notes', locals: { plan: plan, template: phase.template, question: question, answer: answer, question_guidance: question_guidance, guidance_groups: guidance_groups } %>
-                </div>
-              </div>
-            <% end %> <!-- section.questions.each do -->
-          </div> <!-- panel-body -->
-        </div> <!-- panel-collapse -->
+                <%= raw('<hr />') if i != section.questions.length - 1 %>
+              <% end %> <!-- section.questions.each do -->
+            </div> <!-- panel-body -->
+          </div> <!-- panel-collapse -->
+        </div> <!-- panel panel-default -->
       <% end %>   <!-- phase.sections.order(:number).each do -->
     </div>   <!-- panel-group -->
   </div> <!-- tab panel -->

--- a/app/views/phases/_guidances_notes.html.erb
+++ b/app/views/phases/_guidances_notes.html.erb
@@ -4,7 +4,7 @@
 <% guidances_active = (annotations.present? || guidance_set.length > 0) %>
 <div id="plan-guidance-tab">
   <!-- Nav tabs -->
-  <ul class="nav nav-pills nav-justified" role="tablist">
+  <ul class="nav nav-pills nav-justified mb-10" role="tablist">
       <% if guidances_active %>
           <li role="presentation" class="active">
               <a href="#guidances-<%= question.id %>" aria-controls="guidances-<%= question.id %>" role="tab" data-toggle="pill">
@@ -45,39 +45,40 @@
           <% end %>
         <% end %>
       </ul>
-
       <div class="tab-content">
-        <% if annotations.present? %>
-          <div id="annotations-<%= question.id %>" role="tabpanel" class="tab-pane active">
-            <!-- annotations with type guidance -->
-            <% num_annotations = 0 %>
-            <% i = 0 %>
-
-            <% annotations.each do |annotation| %>
-              <%= render partial: 'annotations/show', 
-                         locals: {
-                           template: template,
-                           example_answer: (annotation.example_answer? ? annotation : nil),
-                           guidance: (annotation.guidance? ? annotation : nil),
-                           for_plan: true 
-                         } %>
-              <% num_annotations += 1%>
-              <% i += 1 %>
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <% if annotations.present? %>
+              <div id="annotations-<%= question.id %>" role="tabpanel" class="tab-pane active">
+                <!-- annotations with type guidance -->
+                <% num_annotations = 0 %>
+                <% i = 0 %>
+                <% annotations.each do |annotation| %>
+                  <%= render partial: 'annotations/show', 
+                    locals: {
+                      template: template,
+                      example_answer: (annotation.example_answer? ? annotation : nil),
+                      guidance: (annotation.guidance? ? annotation : nil),
+                      for_plan: true 
+                  } %>
+                  <% num_annotations += 1%>
+                  <% i += 1 %>
+                <% end %>
+              </div>
+            <% end %>
+            <% guidance_accordion_id = 0 %>
+            <% guidance_set.keys.each_with_index do |group, i| %>
+              <% obj = guidance_groups.select{ |gg| gg.name == group }.first %>
+              <% if obj.present? %>
+                <% accordion_id = "#{question.id}-#{obj.id}" %>
+                <div id="guidance-<%= accordion_id %>" role="tabpanel" class="tab-pane<%= annotations.present? ? '' : ' active' %>">
+                  <%= render partial: 'guidance_groups/show', 
+                             locals: { group: guidance_set[group], question: question, guidance_accordion_id: "#{accordion_id}-#{i}" } %>
+                </div>
+              <% end %>
             <% end %>
           </div>
-        <% end %>
-
-        <% guidance_accordion_id = 0 %>
-        <% guidance_set.keys.each_with_index do |group, i| %>
-          <% obj = guidance_groups.select{ |gg| gg.name == group }.first %>
-          <% if obj.present? %>
-            <% accordion_id = "#{question.id}-#{obj.id}" %>
-            <div id="guidance-<%= accordion_id %>" role="tabpanel" class="tab-pane<%= annotations.present? ? '' : ' active' %>">
-              <%= render partial: 'guidance_groups/show', 
-                         locals: { group: guidance_set[group], question: question, guidance_accordion_id: "#{accordion_id}-#{i}" } %>
-            </div>
-          <% end %>
-        <% end %>
+        </div>
       </div>
     </div>
 

--- a/app/views/plans/_navigation.html.erb
+++ b/app/views/plans/_navigation.html.erb
@@ -24,6 +24,10 @@
 </ul>
 <div class="tab-content">
   <div id="content" role="tabpanel" class="tab-pane active">
-    <%= yield %>
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <%= yield %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/questions/_new_edit_question_textarea.html.erb
+++ b/app/views/questions/_new_edit_question_textarea.html.erb
@@ -1,5 +1,17 @@
-<%# locals: { f, question, answer } %>
+<%# locals: { f, question, answer, locking } %>
+<%# 
+  When locking variable is true, this partial renders a plain paragraph with the question answer or default value instead.
+  Since the partial answers/_locking reuses the partial answers/_new_edit which reuses this partial within, when a stale answer is found
+  the browser renders two forms (first the stale answer form followed by the latest answer saved). This reusability comes with a side-effect,
+  i.e. the browser might end up with duplicate ids for the form controls and therefore re-loading tinymce for the locking form becomes
+  rather cumbersome. As such, this workaround, simplifies the logic when a stale answer is found by rendering the html of the answer directly
+  within a paragraph.
+%>
 <div class="form-group">
     <%= f.label(:text, raw(question.text), class: 'control-label') %>
-    <%= text_area_tag('answer[text]', answer.text || question.default_value, id: "answer-text-#{question.id}", class: "form-control tinymce_answer") %>
+    <% if locking %>
+      <%= raw("<p>#{answer.text || question.default_value}</p>") %> 
+    <% else %>
+      <%= text_area_tag('answer[text]', answer.text || question.default_value, id: "answer-text-#{question.id}", class: "form-control tinymce_answer") %>
+    <% end %>
 </div>

--- a/app/views/sections/_progress.html.erb
+++ b/app/views/sections/_progress.html.erb
@@ -4,5 +4,4 @@
 <% num_section_answers = section.num_answered_questions(plan.id) %>
 <span class="right section-status">
   (<%= num_section_answers %> / <%= num_section_questions %>)
-  <span class="fa <%= num_section_answers > 0 ? 'fa-check-circle' : 'fa-circle-o' %>"></span>
 </span>

--- a/app/views/shared/_access_controls.html.erb
+++ b/app/views/shared/_access_controls.html.erb
@@ -14,10 +14,18 @@
 
   <div class="tab-content">
     <div id="sign-in-form" role="tabpanel" class="tab-pane active">
-      <%= render :partial => 'shared/sign_in_form' %>      
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <%= render :partial => 'shared/sign_in_form' %>
+        </div>
+      </div>      
     </div>
-    <div id="create-account-form" role="tabpanel" class="tab-pane"> 
-      <%= render :partial => 'shared/create_account_form', locals: {extended: false} %>
+    <div id="create-account-form" role="tabpanel" class="tab-pane">
+      <div class="panel panel-default">
+        <div class="panel-body"> 
+          <%= render :partial => 'shared/create_account_form', locals: {extended: false} %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/assets/javascripts/utils/expandCollapseAll.js
+++ b/lib/assets/javascripts/utils/expandCollapseAll.js
@@ -23,25 +23,33 @@ import 'bootstrap-sass/assets/javascripts/bootstrap.min';
  *            </a>
  *          </h2>
  *        </div>
- *      </div>
- *      <div id="collapseA" class="panel-collapse collapse" role="tabpanel"
- *                  aria-labelledby="headingA">
- *        <div class="panel-body">
- *          This is test section A.
+ *        <div id="collapseA" class="panel-collapse collapse" role="tabpanel"
+ *          aria-labelledby="headingA">
+ *          <div class="panel-body">
+ *            This is test section A.
+ *          </div>
  *        </div>
  *      </div>
  *    </div>
- *  </div>
  */
 export default () => {
-  $.each($('.accordion-controls'), (idx, el) => {
-    const accordion = $(el).attr('data-parent');
-
-    $.each($(el).children('a[data-toggle-direction]'), (i, a) => {
-      $(a).click((event) => {
-        event.preventDefault();
-        $(`#${accordion}`).children('div.panel-collapse').collapse(`${$(a).attr('data-toggle-direction')}`);
+  $('.accordion-controls').on('click', (e) => {
+    e.preventDefault();
+    const currentTarget = $(e.currentTarget);
+    const target = $(e.target);
+    const direction = target.attr('data-toggle-direction');
+    if (direction) {
+      // Selects all .panel elements where the parent is currentTarget.attr('data-parent') and
+      // after gets the immediately children whose class selector is panel-collapse
+      $(`#${currentTarget.attr('data-parent')} > .panel`).children('.panel-collapse').each((i, el) => {
+        const panelCollapse = $(el);
+        // Expands or collapses the panel according to the
+        // direction passed (e.g. show --> expands, hide --> collapses)
+        $(el).collapse(direction);
+        // Sets icon at panel-title accordingly
+        panelCollapse.prev().find('i.fa')
+          .removeClass('fa-plus fa-minus').addClass(direction === 'show' ? 'fa-minus' : 'fa-plus');
       });
-    });
+    }
   });
 };

--- a/lib/assets/javascripts/views/answers/edit.js
+++ b/lib/assets/javascripts/views/answers/edit.js
@@ -8,9 +8,9 @@ import TimeagoFactory from '../../utils/timeagoFactory';
 
 $(() => {
   const editorClass = 'tinymce_answer';
-  const showSavingMessage = jQuery => jQuery.closest('.question-form').find('.saving-message').show();
-  const hideSavingMessage = jQuery => jQuery.closest('.question-form').find('.saving-message').hide();
-  const closestUnsavedMessage = jQuery => jQuery.closest('.question-form').find('.unsaved-message');
+  const showSavingMessage = jQuery => jQuery.closest('.question-form').find('[data-status="saving"]').show();
+  const hideSavingMessage = jQuery => jQuery.closest('.question-form').find('[data-status="saving"]').hide();
+  const closestErrorSavingMessage = jQuery => jQuery.closest('.question-form').find('[data-status="error-saving"]');
   const questionId = jQuery => jQuery.closest('.form-answer').attr('data-autosave');
   const isStale = jQuery => jQuery.closest('.question-form').find('.answer-locking').html().length !== 0;
   const isReadOnly = () => $('.form-answer fieldset:disabled').length > 0;
@@ -39,12 +39,16 @@ $(() => {
             TimeagoFactory.render($('time.timeago'));
           }
           if (isString(data.question.locking)) { // When an answer is stale...
+            // Removes event handlers for the saved form
             detachEventHandlers(form); // eslint-disable-line no-use-before-define
-            // Reflesh views for this context
-            $(`#answer-locking-${data.question.id}`).html(data.question.locking);
+            // Reflesh form view with the new partial form received
             $(`#answer-form-${data.question.id}`).html(data.question.form);
+            // Retrieves the newly form added to the DOM
             const newForm = $(`#answer-form-${data.question.id}`).find('form');
+            // Attaches event handlers for the new form
             attachEventHandlers(newForm); // eslint-disable-line no-use-before-define
+            // Refresh optimistic locking view with the form that caused the locking
+            $(`#answer-locking-${data.question.id}`).html(data.question.locking);
           } else { // When answer is NOT stale...
             $(`#answer-locking-${data.question.id}`).html('');
             if (isNumber(data.question.answer_lock_version)) {
@@ -68,7 +72,7 @@ $(() => {
     }
   };
   const failCallback = (error, jQuery) => {
-    closestUnsavedMessage(jQuery).html(
+    closestErrorSavingMessage(jQuery).html(
       (isObject(error.responseJSON) && isString(error.responseJSON.detail)) ?
         error.responseJSON.detail : error.statusText).show();
   };
@@ -157,6 +161,7 @@ $(() => {
     Tinymce.init({ selector: `#${tinymceId}` });
     editorHandlers(Tinymce.findEditorById(tinymceId));
   };
+  // Initial load
   TimeagoFactory.render($('time.timeago'));
   Tinymce.init({ selector: `.${editorClass}` });
   if (!isReadOnly()) {

--- a/lib/assets/stylesheets/application.scss
+++ b/lib/assets/stylesheets/application.scss
@@ -4,12 +4,6 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
 $fa-font-path: "~font-awesome/fonts/";
 @import "~font-awesome/scss/font-awesome";
 
-/* CSSs files for jquery-ui. TODO, remove when bootstrap is re-introduced
-*= require jquery-ui-dist/jquery-ui.min
-*= require jquery-ui-dist/jquery-ui.structure.min
-*= require jquery-ui-dist/jquery-ui.theme.min
-*/
-
 @import "/overrides.scss";
 
 [class^="bg-"] {
@@ -17,4 +11,16 @@ $fa-font-path: "~font-awesome/fonts/";
 }
 .mb-5 {
   margin-bottom: 5px;
+}
+.mb-10 {
+  margin-bottom: 10px;
+}
+.mt-10 {
+  margin-top: 10px;
+}
+.status {
+  display:block;
+  float: left;
+  clear: left;
+  margin-bottom: 10px;
 }

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -84,44 +84,51 @@ thead th.table-scope {
   }
 }
 
-/* TABS STYLING */
-
+/* nav-tabs and nav-pills styling */
 .nav-tabs, .nav-pills {
   background-color: $grey;
   color: $white;
-  border: none;
-  margin-right:2px;
-  margin-bottom: 10px;
+  border-bottom: 0px;
 }
 .nav-tabs > li > a, .nav-pills > li > a {
-  border-radius: 2px;
   color: $white;
 }
-.nav-tabs > li > a:hover, .nav-pills > li > a:hover {
+.nav-tabs > li > a:hover,
+.nav-tabs > li > a:focus,
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:focus,
+.nav-tabs > li.active > a:hover {
   background-color: $white;
   color: $grey;
-  border:1px solid $grey;
-  border-bottom: 1px solid $white; /* white border prevents tabs from shifting on mouseover/mouseout */
-}
-.nav-tabs > li.active > a, .nav-pills >li.active > a,
-.nav-tabs > li.active > a:focus, .nav-pills > li.active > a:focus,
-.nav-tabs > li.active > a:hover, .nav-pills > li.active > a:hover {
-  background-color: $white !important;
-  color:$grey;
-  border:1px solid $grey;
-  border-bottom: 1px solid $white; /* white border prevents tabs from shifting on mouseover/mouseout */
+  border: 1px solid $grey;
+  border-bottom-color: transparent; /* Only nav-tabs have a transparent border-bottom */
 }
 .nav-pills > li > a:hover,
+.nav-pills > li > a:focus,
 .nav-pills > li.active > a,
 .nav-pills > li.active > a:focus,
-.nav-pills > li.active > a:hover, {
-  border-bottom: 1px solid $grey;
+.nav-pills > li.active > a:hover {
+  background-color: $white;
+  color: $grey;
+  border: 1px solid $grey;
 }
+.nav-pills > li:last-child > a:hover,
+.nav-pills > li:last-child > a:focus,
+.nav-pills > li.active:last-child > a,
+.nav-pills > li.active:last-child > a:focus,
+.nav-pills > li.active:last-child > a:hover {
+  border-right: 0px;
+}
+/* panel styling */
 
-/* PANEL STYLING */
+.panel-default {
+  border-color: $grey;
+}
 .panel-default > .panel-heading {
   background-color: $grey;
   color: $white;
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
 }
 
 .panel-title a {
@@ -134,6 +141,21 @@ thead th.table-scope {
 .panel-title > a.reverse {
   background-color: $white;
   color: $grey;
+}
+
+/* list-group styling */
+.list-group-item:last-child {
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+}
+.list-group-item:first-child {
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
+}
+
+/* label stylying */
+.label {
+  font-size: 85%;
 }
 
 /* LIST STYLING */
@@ -287,13 +309,8 @@ $header-text-color: $black;
 $header-background: linear-gradient(#ED6406, #F59503);
 */
 
-#app-navbar {
-  border-radius: 0px;
-}
-
 /* For org navbar custom height */
 #org-navbar {
-  border-radius: 0px;
   margin-top: -20px;
 
   #banner-org-name {
@@ -456,4 +473,19 @@ $tooltip-background: $grey;
 }
 .create-plan-mock {
   margin-left: -40px;
+}
+
+/* Sharp edges */
+#app-navbar,
+#org-navbar,
+.nav-tabs > li > a,
+.nav-pills > li > a,
+.panel, .panel-group .panel,
+.progress,
+.btn,
+.form-control,
+.label,
+.alert,
+.input-group-addon {
+  border-radius: 0px;
 }


### PR DESCRIPTION
- Removed circular tick icon progress indicators from each section in write plan. DMPRoadmap/roadmap#867
- Ensure the question text comes before an example answer. DMPRoadmap/roadmap#867
- Made the "Answered X mins ago" alert smaller. DMPRoadmap/roadmap#867
- drew a line between questions to visually demarcate one from another. DMPRoadmap/roadmap#867
- Fixed accordion HTML elements hierarchy and optimised expandCollapseAll. DMPRoadmap/roadmap#867
- Reinstate borders around active areas. DMPRoadmap/roadmap#867
- Ensure edges are consistent throughout UI - sharp not curved. DMPRoadmap/roadmap#867
- Ensure edges are consistent throughout UI - sharp not curved. DMPRoadmap/roadmap#867
- example answer for plans tweaked. Answer status html refactored. DMPRoadmap/roadmap#867
- fixes problem rendering tinymce when a stale answer is found. DMPRoadmap/roadmap#867
- refactored styles into classes. DMPRoadmap/roadmap#867