### PR TITLE
Fix Shibboleth logins

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,21 +49,19 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    return request.referer || root_path unless request.referer.eql?(new_user_session_path)
-    root_path
+    (from_external_domain? ? root_path : (!request.referer.eql?(new_user_session_path) ? request.referer || root_path : root_path))
   end
 
   def after_sign_up_path_for(resource)
-    return request.referer || root_path unless request.referer.eql?(new_user_registration_path)
-    root_path
+    (from_external_domain? ? root_path : (!request.referer.eql?(new_user_session_path) ? request.referer || root_path : root_path))
   end
 
   def after_sign_in_error_path_for(resource)
-    request.referer || root_path
+    (from_external_domain? ? root_path : request.referer || root_path)
   end
 
   def after_sign_up_error_path_for(resource)
-    request.referer || root_path
+    (from_external_domain? ? root_path : request.referer || root_path)
   end
 
   def authenticate_admin!
@@ -138,4 +136,13 @@ class ApplicationController < ActionController::Base
     end
     # -------------------------------------------------------------
 
+    def from_external_domain?
+      if request.referer.present?
+        referer = URI.parse(request.referer)
+        home = URI.parse(root_url)
+        referer.host != home.host
+      else
+        false
+      end
+    end
 end


### PR DESCRIPTION
The application_controller.rb was redirecting the user to `request.referer` after login. This creates issues when the user is authenticating via Shibboleth. The user logs in and this code sends them back to the IdP resulting in a stale SAML request.

Updated the application_controller.rb to only use `request.referer` if the referer matches the domain of the site