### PR TITLE
Update to template visibility functionality

### DIFF
--- a/app/controllers/paginable/templates_controller.rb
+++ b/app/controllers/paginable/templates_controller.rb
@@ -68,12 +68,12 @@ class Paginable::TemplatesController < ApplicationController
   # GET /paginable/templates/publicly_visible/:page  (AJAX)
   # -----------------------------------------------------
   def publicly_visible
-    template_ids = Template.families(Org.funder.pluck(:id)).publicly_visible.pluck(:dmptemplate_id) <<
-    Template.where(is_default: true).valid.published.pluck(:dmptemplate_id)
-
+    templates = Template.live(Template.families(Org.funder.pluck(:id)).pluck(:dmptemplate_id)).publicly_visible.pluck(:id) <<
+    Template.where(is_default: true).valid.published.pluck(:id)
+    
     paginable_renderise(
       partial: 'publicly_visible',
-      scope: Template.includes(:org).where(dmptemplate_id: template_ids.uniq.flatten).valid.published)
+      scope: Template.includes(:org).where(id: templates.uniq.flatten).valid.published)
   end
 
   # GET /paginable/templates/:id/history/:page  (AJAX)

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -4,9 +4,9 @@ class PublicPagesController < ApplicationController
   # GET template_index
   # -----------------------------------------------------
   def template_index
-    template_ids = Template.families(Org.funder.pluck(:id)).publicly_visible.pluck(:dmptemplate_id) <<
-    Template.where(is_default: true).valid.published.pluck(:dmptemplate_id)
-    @templates = Template.includes(:org).where(dmptemplate_id: template_ids.uniq.flatten).valid.published.order(title: :asc).page(1)
+    templates = Template.live(Template.families(Org.funder.pluck(:id)).pluck(:dmptemplate_id)).publicly_visible.pluck(:id) <<
+    Template.where(is_default: true).valid.published.pluck(:id)
+    @templates = Template.includes(:org).where(id: templates.uniq.flatten).valid.published.order(title: :asc).page(1)
   end
 
   # GET template_export/:id

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -36,8 +36,8 @@ class Phase < ActiveRecord::Base
   # EVALUATE CLASS AND INSTANCE METHODS BELOW
   #
   # What do they do? do they do it efficiently, and do we need them?
-
-
+  
+  
   # Callbacks
   after_save do |phase|
     # Updates the template.updated_at attribute whenever a phase has been created/updated 

--- a/app/views/org_admin/templates/_edit_template.html.erb
+++ b/app/views/org_admin/templates/_edit_template.html.erb
@@ -1,5 +1,5 @@
 <!-- edit template details A template is passed as an argument-->
-<%= form_for(template, url: org_admin_template_path(template), html: { method: :put, remote: true }) do |f| %>
+<%= form_for(template, url: org_admin_template_path(template), html: { 'data-method': :put, remote: true }) do |f| %>
   <div class="form-group col-xs-8">
     <%= f.label(:title, _('Title'), class: "control-label") %>
     <%= f.text_field(:title, class: "form-control", "aria-required": false, 'data-toggle': 'tooltip', title: _('Please enter a title for your template.')) %>

--- a/test/integration/template_selection_test.rb
+++ b/test/integration/template_selection_test.rb
@@ -14,12 +14,14 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     @funder_template = @funder.templates.where(published: true).first #Template.create(title: 'Funder template', org: @funder, migrated: false)
     # Template can't be published on creation so do it afterward
     @funder_template.published = true
+    @funder_template.visibility = Template.visibilities[:publicly_visible]
     @funder_template.save
 
     @org = @researcher.org
     @org_template = Template.create(title: 'Org template', org: @org, migrated: false)
     # Template can't be published on creation so do it afterward
     @org_template.published = true
+    @org_template.visibility = Template.visibilities[:organisationally_visible]
     @org_template.save
   end
 
@@ -116,7 +118,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = JSON.parse(@response.body)
 
-    assert_equal 1, json['templates'].size
+    assert_equal 2, json['templates'].size
     assert_equal @funder_template.id, json['templates'][0]['id']
   end
 
@@ -125,6 +127,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     customization = Template.create(title: 'Customization', org: @org)
     # Template can't be published on creation so do it afterward
     customization.published = true
+    customization.visibility = Template.visibilities[:organisationally_visible]
     customization.customization_of = @funder_template.dmptemplate_id
     customization.save
 
@@ -134,7 +137,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = JSON.parse(@response.body)
 
-    assert_equal 1, json['templates'].size
+    assert_equal 2, json['templates'].size
     assert_equal customization.id, json['templates'][0]['id']
   end
 
@@ -143,6 +146,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     funder_template2 = Template.create(title: 'Funder template 2', org: @funder)
     # Template can't be published on creation so do it afterward
     funder_template2.published = true
+    funder_template2.visibility = Template.visibilities[:publicly_visible]
     funder_template2.save
 
     sign_in @researcher
@@ -151,7 +155,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     assert_response :success
     json = JSON.parse(@response.body)
 
-    assert_equal 2, json['templates'].size
+    assert_equal 3, json['templates'].size
     assert_equal @funder_template.id, json['templates'][0]['id']
     assert_equal funder_template2.id, json['templates'][1]['id']
   end

--- a/test/integration/template_versioning_test.rb
+++ b/test/integration/template_versioning_test.rb
@@ -20,32 +20,6 @@ class TemplateVersioningTest < ActionDispatch::IntegrationTest
   end
 
   # ----------------------------------------------------------
-  test 'template gets versioned when its details are updated but it is already published' do
-    # Publish the template
-    get publish_org_admin_template_path(@template)
-    @template = Template.current(@dmptemplate_id)
-    get edit_org_admin_template_path(@template)   # Click on 'edit'
-    @template = Template.current(@dmptemplate_id) # Edit new version
-
-    # Change the title after its been published
-    put org_admin_template_path(@template), {template: {title: "Blah blah blah"}}
-    @template = Template.current(@dmptemplate_id)
-
-    # Make sure that the template was versioned
-    assert_equal (@initial_version + 1), @template.version, "expected the version to have incremented"
-    assert_not_equal @initial_id, @template.id, "expected the id to have changed"
-    assert_equal @dmptemplate_id, @template.dmptemplate_id, "expected the dmptemplate_id to match"
-    assert_equal false, @template.published?, "expected the new version to be unpublished"
-    assert_not_equal @initial_title, @template.title, "expected the title to have been updated"
-
-    # Now retrieve the published version and verify that it is unchanged
-    old = Template.live(@dmptemplate_id)
-    assert_equal @initial_version, old.version, "expected the version number of the published version to be the same"
-    assert_equal @initial_id, old.id, "expected the id of the published version to be the same"
-    assert_equal @initial_title, old.title, "expected the title of the published version to be the same"
-  end
-
-  # ----------------------------------------------------------
   test 'template gets versioned when its phases are modified and it is already published' do
     @template.dirty = false
     @template.save!
@@ -99,69 +73,5 @@ class TemplateVersioningTest < ActionDispatch::IntegrationTest
     get publish_org_admin_template_path(@template)
     get unpublish_org_admin_template_path(@template)
     assert Template.live(@dmptemplate_id).nil?
-  end
-
-  # ----------------------------------------------------------
-  test 'plans get attached to the appropriate template version' do
-=begin
-    if Org.funders.include?(@template.org)
-      put admin_publish_template_path(@template)
-      @template = Template.current(@dmptemplate_id)
-      liveA = Template.live(@dmptemplate_id)
-
-    else
-      funder_template = Template.create(org: Org.funders.first, title: 'Testing integration')
-
-      # Sign in as the funder so that we cna publish the template
-      sign_in User.find_by(org: funder_template.org)
-
-      # Publish the funder template
-      put admin_publish_template_path(funder_template)
-      assert_response :redirect
-      assert_redirected_to admin_index_template_path(funder_template.org)
-
-      @template = Template.current(funder_template.dmptemplate_id)
-      liveA = Template.live(funder_template.dmptemplate_id)
-      @dmptemplate_id = @template.dmptemplate_id
-    end
-
-    sign_in @user
-
-    # Plan A gets attached to the template v1
-    post plans_path, {plan: {funder_id: @template.org.id}}
-    planA = Plan.last
-    assert_equal liveA, planA.template, "expected the latest published version to have been assigned to PlanA"
-
-    # Template v2 is updated
-    put admin_update_template_path(@template), {template: {title: "Blah blah blah"}}
-    @template = Template.current(@dmptemplate_id)
-
-    # Plan B gets attached to the template v1 because v2 is not yet published
-    post plans_path, {plan: {funder_id: @template.org.id}}
-    planB = Plan.last
-    assert_equal liveA, planB.template, "expected the latest published version to have been assigned to PlanB"
-
-    # Plan A should still be attached to v1
-    assert_equal liveA, planA.template, "expected PlanA to still be attached to the original published version"
-
-    # Sign back in as the funder
-    sign_in User.find_by(org: funder_template.org)
-
-    # Template v2 is published
-    put admin_publish_template_path(@template)
-    @template = Template.current(@dmptemplate_id)
-    liveB = Template.live(@dmptemplate_id)
-
-    sign_in @user
-
-    # Plan C gets attached to template v2
-    post plans_path, {plan: {funder_id: @template.org.id}}
-    planC = Plan.last
-    assert_equal liveB, planC.template, "expected the latest published version to have been assigned to PlanA"
-
-    # Plan A and B are still attached to v1
-    assert_equal liveA, planA.template, "expected PlanA to still be attached to the original published version"
-    assert_equal liveA, planB.template, "expected PlanB to still be attached to the original published version"
-=end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,10 +87,7 @@ class ActiveSupport::TestCase
   # Version the template
   # ----------------------------------------------------------------------
   def version_the_template
-    get publish_org_admin_template_path(@template)
-    get edit_org_admin_template_path(@template)            # Click on 'edit'
-    @template = Template.current(@template.dmptemplate_id) # Edit working copy
-    put org_admin_template_path(@template), {template: {title: "#{@template.title} - VERSIONED"}}
+    @template = @template.get_new_version
   end
 
   # Scaffold a new Plan based on the scaffolded Template


### PR DESCRIPTION
Changes to template visibility functionality per #1083
- Changes on template details no longer forces a new version to be created. Versions are now created only when a phase is accessed 
- Moved version code from controller to template model
- Updated code behind template selection during plan creation. Is now properly working for cases where Org is both a funder and something else like organisation/institution
- Fixed tests