### PR TITLE
fixes for super admin orgs

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -27,11 +27,7 @@ class OrgsController < ApplicationController
     
     begin
       # Only allow super admins to change the org types and shib info
-      if current_user.can_super_admin?
-        @org.funder = params[:funder].present?
-        @org.institution = params[:institution].present?
-        @org.organisation = params[:organisation].present?      
-    
+      if current_user.can_super_admin?    
         # Handle Shibboleth identifiers if that is enabled
         if Rails.application.config.shibboleth_use_filtered_discovery_service 
           shib = IdentifierScheme.find_by(name: 'shibboleth')
@@ -107,7 +103,7 @@ class OrgsController < ApplicationController
 
   private
     def org_params
-      params.require(:org).permit(:name, :abbreviation, :logo, :contact_email, :contact_name, :remove_logo,
+      params.require(:org).permit(:name, :abbreviation, :logo, :contact_email, :contact_name, :remove_logo, :org_type,
                                   :feedback_enabled, :feedback_email_subject, :feedback_email_msg)
     end
 end

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="form-group col-xs-8">
       <%= f.label :abbreviation, _('Organisation abbreviated name'), class: "control-label" %>
-      <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control" %>
+      <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control", "aria-required": true %>
     </div>
   </div>
 
@@ -83,14 +83,15 @@
         <div class="form-group col-xs-8">
           <%= f.label _('Organisation Types'), for: :funder, class: 'control-label' %>
           <div class="checkbox">
-            <%= f.label :funder, raw("#{check_box_tag :org_types, 2, org.funder?} #{_('Funder')}") %>
+            <%= f.label :funder, raw("#{check_box_tag :funder, 2, org.funder?, class: 'org_types'} #{_('Funder')}") %>
           </div>
           <div class="checkbox">
-            <%= f.label :institution, raw("#{check_box_tag :institution, 1, org.institution?} #{_('Institution')}") %>
+            <%= f.label :institution, raw("#{check_box_tag :institution, 1, org.institution?, class: 'org_types'} #{_('Institution')}") %>
           </div>
           <div class="checkbox">
-            <%= f.label :organisation, raw("#{check_box_tag :organisation, 4, org.organisation?} #{_('Organisation')}") %>
+            <%= f.label :organisation, raw("#{check_box_tag :organisation, 4, org.organisation?, class: 'org_types'} #{_('Organisation')}") %>
           </div>
+          <%= f.hidden_field :org_type, 'data-validation': 'text', 'data-validation-error': _('You must select at least one organisation type') %>
         </div>
       </div>
     <% else %>

--- a/app/views/orgs/admin_edit.html.erb
+++ b/app/views/orgs/admin_edit.html.erb
@@ -1,8 +1,9 @@
 <div class="row">
   <div class="col-md-12">
-    <h1>
-      <%= org.id.present? ? _('Organisation details') : _('New organisation') %>
-    </h1>
+    <h1><%= org.id.present? ? _('Organisation details') : _('New organisation') %></h1>
+    <% if current_user.can_super_admin? %>
+      <%= link_to _('View all organisations'), super_admin_orgs_path, class: 'btn btn-default pull-right' %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -2,7 +2,7 @@
   <table class="table table-hover" id="guidance-groups">
     <thead>
       <tr>
-        <th><%= _('Organisation') %></th>&nbsp;<%= paginable_sort_link('name') %>
+        <th><%= _('Organisation') %>&nbsp;<%= paginable_sort_link('name') %></th>
         <th><%= _('Administrator Email') %>&nbsp;<%= paginable_sort_link('contact_email') %></th>
         <th><%= _('Organisation Type(s)') %>&nbsp;<%= paginable_sort_link('optional_subset') %></th>
         <th><%= _('Templates') %>&nbsp;<%= paginable_sort_link('updated_at') %></th>

--- a/lib/assets/javascripts/views/orgs/admin_edit.js
+++ b/lib/assets/javascripts/views/orgs/admin_edit.js
@@ -22,13 +22,26 @@ $(() => {
   toggleFeedback();
 
   enableValidations($('#edit_org_profile_form'));
+
+  // update the hidden org_type field based on the checkboxes selected
+  const calculateOrgType = () => {
+    let orgType = 0;
+    $('input.org_types:checked').each((i, el) => {
+      orgType += parseInt($(el).val(), 10);
+    });
+    $('#org_org_type').val((orgType === 0 ? '' : orgType.toString()));
+  };
+  $('input.org_types').on('click', calculateOrgType);
+
   $('#edit_org_profile_form').on('submit', (e) => {
+    // Collect links
     const links = {};
     eachLinks((ctx, value) => {
       links[ctx] = value;
     }).done(() => {
       $('#org_links').val(JSON.stringify(links));
     });
+
     if (!validate(e.target)) {
       e.preventDefault();
     }


### PR DESCRIPTION
updates for #1056
- add 'view all orgs' button to edit/new page if user is super admin
- add validation to require abbreviation and org_type
- fix issues with org type save