### PR TITLE
Bugfix for Org details page

### DIFF
--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -18,7 +18,7 @@
 
       <% if org.logo.present? %>
         <div class="clearfix"></div>
-        <%= image_tag org.logo.url, alt: "#{@org.name} #{_('logo')}" %>
+        <%= image_tag org.logo.url, alt: "#{org.name} #{_('logo')}" %>
         <div class="org-logo-controls checkbox">
           <%= f.label :remove_logo, raw("#{f.check_box :remove_logo, title: _("This will remove your organisation's logo")} #{_('Remove logo')}") %>
           <strong> - <%= _('or') %> - </strong>

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -2,10 +2,10 @@
   <table class="table table-hover" id="guidance-groups">
     <thead>
       <tr>
-        <th><%= _('Organisation') %>&nbsp;<%= paginable_sort_link('name') %></th>
-        <th><%= _('Administrator Email') %>&nbsp;<%= paginable_sort_link('contact_email') %></th>
-        <th><%= _('Organisation Type(s)') %>&nbsp;<%= paginable_sort_link('optional_subset') %></th>
-        <th><%= _('Templates') %>&nbsp;<%= paginable_sort_link('updated_at') %></th>
+        <th><%= _('Organisation') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
+        <th><%= _('Administrator Email') %>&nbsp;<%= paginable_sort_link('orgs.contact_email') %></th>
+        <th><%= _('Organisation Type(s)') %>&nbsp;<%= paginable_sort_link('orgs.org_type') %></th>
+        <th><%= _('Templates') %>&nbsp;<%= paginable_sort_link('orgs.updated_at') %></th>
         <th class="sorter-false"><span aria-hidden="false" class="sr-only"><%= _('Actions') %></span></th>
       </tr>
     </thead>


### PR DESCRIPTION
Fixes issues in #1056 
- lingering reference to `@org.name` caused the issue when saving a logo. switched it to `org.name` 
- added table name to column sorts