### PR TITLE
New login workflow changes (post-shibboleth authentication) [UPDATE: now tested on DMPonline-test]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,11 +49,20 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(resource)
-    (from_external_domain? ? root_path : (!request.referer.eql?(new_user_session_path) ? request.referer || root_path : root_path))
+    if from_external_domain? || request.referer.eql?(new_user_session_url(:protocol => 'https')) || request.referer.eql?(new_user_registration_url(:protocol => 'https'))
+      root_path
+    else
+      return request.referer unless request.referer.nil?
+      root_path
+    end
   end
 
   def after_sign_up_path_for(resource)
-    (from_external_domain? ? root_path : (!request.referer.eql?(new_user_session_path) ? request.referer || root_path : root_path))
+    if from_external_domain? or request.referer.eql?(new_user_session_url(:protocol => 'https'))
+      root_path
+    else
+      request.referer
+    end
   end
 
   def after_sign_in_error_path_for(resource)

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -26,14 +26,13 @@ class RegistrationsController < Devise::RegistrationsController
 
     unless oauth.nil?
       # The OAuth provider could not be determined or there was no unique UID!
-      if oauth[:provider].nil? || oauth[:uid].nil?
-        flash[:alert] = _('We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward.')
-
+      if oauth['provider'].nil? || oauth['uid'].nil?
+        # flash[:alert] = _('We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward.')
       else
         # Connect the new user with the identifier sent back by the OAuth provider
-        flash[:notice] = _('It does not look like you have setup an account with us yet. Please fill in the following information to complete your registration.')
-        UserIdentifier.create(identifier_scheme: oauth[:provider].upcase,
-                              identifier: oauth[:uid],
+        flash[:notice] = _('Please make a choice below. After linking your details to a %{application_name} account, you will be able to sign in directly with your institutional credentials.') % {application_name: Rails.configuration.branding[:application][:name]}
+        UserIdentifier.create(identifier_scheme: IdentifierScheme.find_by(name: oauth['provider'].downcase),
+                              identifier: oauth['uid'],
                               user: @user)
       end
     end
@@ -41,7 +40,11 @@ class RegistrationsController < Devise::RegistrationsController
 
   # POST /resource
   def create
-    if !sign_up_params[:accept_terms] then
+    oauth = {provider: nil, uid: nil}
+    IdentifierScheme.all.each do |scheme|
+      oauth = session["devise.#{scheme.name.downcase}_data"] unless session["devise.#{scheme.name.downcase}_data"].nil?
+    end
+    if !sign_up_params[:accept_terms]
       redirect_to after_sign_up_error_path_for(resource), alert: _('You must accept the terms and conditions to register.')
     else
       existing_user = User.where_case_insensitive('email', sign_up_params[:email]).first
@@ -61,6 +64,19 @@ class RegistrationsController < Devise::RegistrationsController
             set_flash_message :notice, :signed_up if is_navigational_format?
             sign_up(resource_name, resource)
             UserMailer.welcome_notification(current_user).deliver
+            unless oauth.nil?
+              # The OAuth provider could not be determined or there was no unique UID!
+              unless oauth['provider'].nil? || oauth['uid'].nil?
+                prov = IdentifierScheme.find_by(name: oauth['provider'].downcase)
+                # Until we enable ORCID signups
+                if prov.name == 'shibboleth'
+                  UserIdentifier.create(identifier_scheme: prov,
+                                        identifier: oauth['uid'],
+                                        user: @user)
+                  flash[:notice] = _('Welcome! You have signed up successfully with your institutional credentials. You will now be able to access your account with them.')
+                end
+              end
+            end
             respond_with resource, location: after_sign_up_path_for(resource)
           else
             set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_navigational_format?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,22 +3,29 @@ class SessionsController < Devise::SessionsController
   def new
     redirect_to(root_path)
   end
+
   # Capture the user's shibboleth id if they're coming in from an IDP
   # ---------------------------------------------------------------------
   def create
     existing_user = User.find_by(email: params[:user][:email])
     if !existing_user.nil?
       
-# TODO: Not sure why we check for shib data in params and then use session value below. We should move this to the 
-#       new user_identifiers table
-      if !params[:shibboleth_data].nil? 
-        #after authentication verify if session[:shibboleth] exists
-        existing_user.update_attributes(shibboleth_id: session[:shibboleth_data][:uid])
+      # Until ORCID login is supported
+      if !session['devise.shibboleth_data'].nil?
+        if u = UserIdentifier.create(identifier_scheme: IdentifierScheme.find_by(name: 'shibboleth'),
+                                 identifier: session['devise.shibboleth_data']['uid'],
+                                 user: existing_user)
+          success = _('Your account has been successfully linked to your institutional credentials. You will now be able to sign in with them.')
+        end
+        existing_user.update_attributes(shibboleth_id: session['devise.shibboleth_data'][:uid])
       end
       session[:locale] = existing_user.get_locale unless existing_user.get_locale.nil?
       set_gettext_locale  #Method defined at controllers/application_controller.rb
     end
     super
+    if success
+      flash[:notice] = success
+    end
   end
 
   def destroy

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -27,7 +27,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # If the uid didn't have a match in the system send them to register
       if user.nil?
         session["devise.#{scheme.name.downcase}_data"] = request.env["omniauth.auth"]
-        flash[:notice] = _('It does not look like you have setup an account with us yet. Please fill in the following information to complete your registration.')
         redirect_to new_user_registration_url
         
       # Otherwise sign them in

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -20,7 +20,7 @@
       </div>
       <div class="checkbox">
         <label for="passwords_toggle">
-          <input type="checkbox" id="passwords_toggle" /><%= _('Show passwords') %>
+          <input type="checkbox" id="passwords_toggle" class="passwords_toggle"/><%= _('Show passwords') %>
         </label>
       </div>
 

--- a/app/views/devise/registrations/_password_details.html.erb
+++ b/app/views/devise/registrations/_password_details.html.erb
@@ -22,7 +22,7 @@
   <div class="form-group col-xs-8">
     <div class="checkbox">
       <label>
-         <input type="checkbox" id="passwords_toggle" /><%= _('Show passwords') %>
+         <input type="checkbox" id="passwords_toggle" class="passwords_toggle" /><%= _('Show passwords') %>
       </label>
     </div>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,31 @@
+<div class="row">
+  <div id="dual_columns" class="container" style="display:table">
+    <% unless session["devise.shibboleth_data"].nil? %>
+        <% cookies[:show_shib_link] = { value: 'show_shib_link', expires: 3.hours.from_now } %>
+        <div class="col-md-6" style="border-top:1px solid black; border-bottom:1px solid black; border-left:1px solid black; display:table-cell; float:none">
+            <h3 class="text-center"><%= _("Do you have a %{application_name} account?") % {application_name: Rails.configuration.branding[:application][:name]} %></h3>
+            <big><p class="text-center"><i class="fa fa-arrow-circle-down" aria-hidden="true"></i></p></big>
+            <h2 class="text-center">
+                <%= _("Sign in") %></i>
+            </h2>
+            <p class="text-center"><%= _("This will link your existing account to your credentials.") %></p>
+            <p><%= render :partial => 'shared/sign_in_form' %><br></p>
+        </div>
+        <div class="col-md-6" style="border:1px solid black; display:table-cell; float:none">
+            <h3 class="text-center"><%= _("No %{application_name} account?") % {application_name: Rails.configuration.branding[:application][:name]} %></h3>
+            <big><p class="text-center"><i class="fa fa-arrow-circle-down" aria-hidden="true"></i></p></big>
+            <h2 class="text-center">
+                <%= _("Create account") %></i>
+            </h2>
+            <p class="text-center"><%= _("This will create an account and link it to your credentials.") %></p>
+            <p><%= render :partial => 'shared/create_account_form', locals: {extended: false} %><br></p>
+        </div>
+    <% else %>
+        <div>
+            <h2><%= _("Create account") %>&nbsp;&nbsp;<i class="fa fa-user-plus" aria-hidden="true">&nbsp;&nbsp;</i></h2>
+            <%= render :partial => 'shared/create_account_form', locals: {extended: true} %>  
+        </div>
+    <% end %>
+  </div>
+</div>
+    

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -24,8 +24,8 @@
     <%= f.password_field(:password, class: "form-control", "aria-required": true) %>
   </div>
   <div class="checkbox">
-    <label for="passwords_toggle">
-      <input type="checkbox" id="passwords_toggle" /><%= _('Show password') %>
+    <label for="passwords_toggle_sign_up">
+      <input type="checkbox" id="passwords_toggle_sign_up" class="passwords_toggle" /><%= _('Show password') %>
     </label>
   </div>
   <div class="checkbox">

--- a/app/views/shared/_sign_in_form.html.erb
+++ b/app/views/shared/_sign_in_form.html.erb
@@ -16,17 +16,17 @@
   <%= f.button(_('Sign in'), class: "btn btn-default", type: "submit") %>
   
   <% if Rails.application.config.shibboleth_enabled %>
-    <h4 class="text-center">- <%= _('or') %> -</h4>
-
-    <div class="form-group">
-      <span class="center-block btn-group-justified">
-        <% if request.fullpath != "/users/sign_up?nosplash=true" && session[:shibboleth_data].nil? then%>
+    <% if session['devise.shibboleth_data'].nil? %>
+      <h4 class="text-center">- <%= _('or') %> -</h4>
+      <div class="form-group">
+        <span class="center-block btn-group-justified">
           <% target = (Rails.application.config.shibboleth_use_filtered_discovery_service ? shibboleth_ds_path : user_shibboleth_omniauth_authorize_path) %>
           <a href="<%= target %>" class="btn btn-default"><%= _('Sign in with your institutional credentials') %></a>
-        <%else%>
-          <%= f.hidden_field :shibboleth_id, :value => session[:shibboleth_data][:uid] %>
-        <%end%>
-      </span>
-    </div>
+        </span>
+      </div>
+    <% else %>
+      <%= f.hidden_field :shibboleth_id, :value => session['devise.shibboleth_data']['uid'] %>
+    <% end %>
   <% end %>
+
 <% end %>

--- a/lib/assets/javascripts/utils/passwordHelper.js
+++ b/lib/assets/javascripts/utils/passwordHelper.js
@@ -57,11 +57,11 @@ export const addMatchingPasswordValidator = (options) => {
 /*
  *   This function is expecting your HTML to be in the following format. Only one toggle
  *   is needed per form. It will toggle all password fields within the containing form:
- *     <input type="checkbox" id="passwords_toggle" />
+ *     <input type="checkbox" class="passwords_toggle" />
  */
 export const togglisePasswords = (options) => {
   if (isObject(options) && isString(options.selector)) {
-    const toggle = $(`${options.selector} #passwords_toggle`);
+    const toggle = $(`${options.selector} .passwords_toggle`);
     const pwds = $(`${options.selector} input[type="password"]`);
 
     if (pwds && toggle) {

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -441,15 +441,11 @@ $tooltip-background: $grey;
   cursor: pointer;
   display: inline;
   position: absolute;
-  top: 0;
-  right: 0;
-  margin-top: 2px;
-  margin-right: -28px;
+  top: 6px;
+  right: 5px;
   border: none;
   background: transparent;
   color: $grey;
-  padding-top: 4px;
-  font-size: 16pt;
 }
 
 /* http://geektnt.com/how-to-remove-x-from-search-input-field-on-chrome-and-ie.html */

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -39,7 +39,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "existing user's Shibboleth id is captured" do
     Warden.on_next_request do |proxy|
-      proxy.raw_session[:shibboleth_data] = {uid: 'abcdefg'}
+      proxy.raw_session[:"devise.shibboleth_data"] = {uid: 'abcdefg'}
     end
     post user_session_path, {user: {email: @user.email}, shibboleth_data: {uid: 'abcdefg'}}
     assert_response :redirect

--- a/test/functional/users/omniauth_callbacks_controller_test.rb
+++ b/test/functional/users/omniauth_callbacks_controller_test.rb
@@ -19,15 +19,12 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
         :uid => 'foo:bar'
       })
     end
-
   end
   
   # -------------------------------------------------------------
   test "User is not signed in and valid OAuth2 response does not match a User record in DB: should redirect to registration page" do
     @schemes.each do |scheme|
       post @callback_uris[scheme.name], locale: FastGettext.locale
-
-      assert_equal I18n.t('identifier_schemes.new_login_success'), flash[:notice], "Expected a success message when simulating a valid callback from #{scheme.name}"
       
       assert @response.redirect_url.include?(new_user_registration_url), "Expected a redirect to the registration page when the user is not logged in and we received a valid callback from #{scheme.name}"
       
@@ -45,7 +42,6 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
       @user.user_identifiers << UserIdentifier.new(identifier_scheme: scheme, 
                                                    identifier: "foo:bar")
       @user.save!
-      
       post @callback_uris[scheme.name]
 
       ### Until ORCID login becomes supported.


### PR DESCRIPTION
**UPDATE: now tested on DMPonline-test**

- New dual choice layout in app/views/devise/registrations/new.html.erb
- Changes to omniauth_callbacks/application/registrations/sessions controllers to support choice post-shibboleth auth:
  - Do you have an account? Sign in to link your shibboleth credentials
  - If you don't have an account, sign up and this will link your shibboleth credentials
- Changes to sign in, create account, and password details forms for multiple onscreen "show password" tickboxes
- Aesthetic change to clear-field (X) icon (align it with input field and bring it inside)

For #305 #306