### PR TITLE
fix display issue org links

### DIFF
--- a/app/views/shared/_links.html.erb
+++ b/app/views/shared/_links.html.erb
@@ -44,7 +44,7 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      <a href="#" class="new"><%= _('+ Add an additional URL') %></a>
+      <a href="#" class="new<%= links.length >= max_number_links ? ' hide' : '' %>"><%= _('+ Add an additional URL') %></a>
     </div>
   </div>
 </div>

--- a/lib/assets/javascripts/utils/links.js
+++ b/lib/assets/javascripts/utils/links.js
@@ -58,7 +58,8 @@ $(() => {
     e.preventDefault();
     const target = $(e.target);
     const max = maxNumberLinks(target);
-    if (linksLength(target) < max) {
+    const nbrLinks = linksLength(target);
+    if (nbrLinks < max) {
       const lastLink = target.closest('.links').find('.link').last();
       const clonedLink = lastLink.clone();
       changeIds(clonedLink);
@@ -68,13 +69,23 @@ $(() => {
       lastLink.after(clonedLink);
       // enableValidations for the newly added inputs
       enableValidations(clonedLink);
+      // Hide the add link if we have now reached the limit
+      if (nbrLinks + 1 >= max) {
+        $(target).closest('.links').find('a.new').addClass('hide');
+      }
     }
   });
 
   $('.links').on('click', '.delete', (e) => {
     e.preventDefault();
     const target = $(e.target);
-    if (linksLength(target) > 1) {
+    const max = maxNumberLinks(target);
+    const nbrLinks = linksLength(target);
+    if (nbrLinks > 1) {
+      // If this brought us below the max nbr of links then show the add new link
+      if ((nbrLinks - 1) < max) {
+        target.closest('.links').find('a.new').removeClass('hide');
+      }
       target.closest('.link').remove();
     } else {
       const link = target.closest('.link');
@@ -82,7 +93,6 @@ $(() => {
       disableValidations(link);
     }
   });
-
   $('.links').find('.max-number-links').each((i, el) => {
     const target = $(el);
     const max = target.closest('.links').attr('data-max-number-links');


### PR DESCRIPTION
The org details page was always displaying the 'Add an additional URL' link even if the limit had been reached. This patch will hide/show the link based on the current number of links displayed on the screen.