### PR TITLE
removed link to edit org visible plans

### DIFF
--- a/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
@@ -20,7 +20,7 @@
                         <tbody>
                             <% scope.each do |plan| %>
                                 <tr>
-                                    <td><%= link_to "#{plan.title.length > 40 ? "#{plan.title[0..39]} ..." : plan.title}", plan_path(plan) %></td>
+                                    <td><%= plan.title.length > 40 ? "#{plan.title[0..39]} ..." : plan.title %></td>
                                     <td><%= plan.template.title %></td>
                                     <td><%= plan.owner.present? ? plan.owner.name : _('Unknown') %></td>
                                     <td><%= l(plan.updated_at.to_date, formats: :short) %></td>


### PR DESCRIPTION
The Org plans table on the My Dashboard page was using a hyperlink for the plan title. Clicking those links would result in a permission denied error. I have switched it so that it is no longer a hyperlink. 
If we want to give truly read-only access to these plans then we would need to discuss the best way to implement it and handle as a separate ticket. 