### PR TITLE
fixed sort issue for orgs page

### DIFF
--- a/app/controllers/paginable/orgs_controller.rb
+++ b/app/controllers/paginable/orgs_controller.rb
@@ -1,13 +1,11 @@
-module Paginable 
-  class OrgsController < ApplicationController
-    include Paginable
-    # /paginable/guidances/index/:page
-    def index
-      authorize(Org)
-      paginable_renderise(
-        partial: 'index',
-        scope: Org.includes(:templates, :users).all
-      )
-    end
+class Paginable::OrgsController < ApplicationController
+  include Paginable
+  # /paginable/guidances/index/:page
+  def index
+    authorize(Org)
+    paginable_renderise(
+      partial: 'index',
+      scope: Org.includes(:templates, :users).joins(:templates, :users)
+    )
   end
 end

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -4,7 +4,7 @@ module SuperAdmin
 
     def index
       authorize Org
-      render 'index', locals: { orgs: Org.includes(:templates, :users).all.order(name: :desc) }
+      render 'index', locals: { orgs: Org.includes(:templates, :users).joins(:templates, :users).order('orgs.name') }
     end
     
     def new

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -4,10 +4,6 @@ class Org < ActiveRecord::Base
   extend Dragonfly::Model::Validations
   validates_with OrgLinksValidator
   
-  ##
-  # Sort order: Name ASC
-  default_scope { order(name: :asc) }
-
   # Stores links as an JSON object: { org: [{"link":"www.example.com","text":"foo"}, ...] }
   # The links are validated against custom validator allocated at validators/template_links_validator.rb
   serialize :links, JSON

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -5,7 +5,7 @@
         <th><%= _('Organisation') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
         <th><%= _('Administrator Email') %>&nbsp;<%= paginable_sort_link('orgs.contact_email') %></th>
         <th><%= _('Organisation Type(s)') %>&nbsp;<%= paginable_sort_link('orgs.org_type') %></th>
-        <th><%= _('Templates') %>&nbsp;<%= paginable_sort_link('orgs.updated_at') %></th>
+        <th><%= _('Templates') %></th>
         <th class="sorter-false"><span aria-hidden="false" class="sr-only"><%= _('Actions') %></span></th>
       </tr>
     </thead>


### PR DESCRIPTION
addresses sorting issue on new Orgs page. An order was being set on the default scope which was conflicting with the sort selected by the user. #1056
