### PR TITLE
Update create plan template selection

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -387,8 +387,11 @@ module OrgAdmin
               end
             end
           end
-        else
-          # If no funder was selected retrieve the Org's templates
+        end
+        
+        # If the no funder was specified OR the funder matches the org
+        if funder_id.blank? || funder_id == org_id
+          # Retrieve the Org's templates
           templates << Template.organisationally_visible.valid.where(published: true, org_id: org_id, customization_of: nil).to_a
         end
         


### PR DESCRIPTION
#1102 
adjust create plan logic so that if user selects the same Org that is both a funder and an institution/organisation (USGS edge case) as both the research org and the funder they see the internal and public templates for that org. Doing the same in every other situation only shows the selected funder's public templates.

Logic:
- Default template is used if 
  - User ticks both the 'no research org' and 'no funder' boxes 
  - User selects a Research Org that has NO templates and ticks the 'no funder' box
  - User selects a Research Org that has NO templates and a funder that has NO templates
  - User ticks the 'no Research Org' box and selects a funder that has NO templates
  - User selects a Research Org that has template(s) and a funder who has NO templates
- The research org template is used (or user is presented with list if more than one is available)
  - User selects a Research Org that has template(s) and ticks the 'no funder' box
- The funder template us used (or user is presented with list if more than one is available)
  - User ticks the 'no research org' box and selects a funder who has template(s)
  - User selects a Research Org that has NO templates and a funder who has template(s)
  - User selects a Research Org that has template(s) and a funder who has template(s)
- The user is presented with a list of both organisational and public funder templates (USGS edge case)
  - The user selects the same Org in both the Research Org and Funder boxes and that org has templates that are public and organisational