### PR TITLE
fixed issue with capitalization of guidance groups

### DIFF
--- a/app/views/plans/_guidance_choices.html.erb
+++ b/app/views/plans/_guidance_choices.html.erb
@@ -3,23 +3,18 @@
     <li class="checkbox">
       <%= check_box_tag "guidance_group_ids[]", groups[0].id,
                         current_selections.include?(groups[0].id), class: 'guidance-choice' %>
-      <%= form.label org.name, for: groups[0].id, 
-              class: 'inline checkbox-label regular-text guidance-group-label' %>
+      <%= org.name %>
     </li>
   <% elsif groups %>
     <li class="checkbox">
-      <label class="inline checkbox-label regular-text guidance-group-label">
-        <%= org.name %>
-      </label>
-
+      <%= org.name %>
       <ul>
         <% groups.each do |group| %>
           <li class="checkbox">
-            <span class="sublist">└─ </span> 
+            <span class="sublist">└─ </span>
             <%= check_box_tag "guidance_group_ids[]", group.id,
                               current_selections.include?(group.id), class: 'guidance-choice' %>
-            <%= form.label group.name, for: group.id, 
-                     class: "left-indent checkbox-label regular-text guidance-group-label" %>
+            <%= group.name %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
#944 guidance group and org names were losing capitalization on the select guidance options