### PR TITLE
ensured sections/questions are in correct order

### DIFF
--- a/app/views/phases/edit.html.erb
+++ b/app/views/phases/edit.html.erb
@@ -22,7 +22,8 @@
 <div class="project-tabs-body">
 
   <div class="accordion" id="sections-accordion">
-    <% @phase.sections.each do |section| %>
+    <% sections = @phase.sections.sort_by {|section| section.number} %>
+    <% sections.each do |section| %>
 
       <% sectionid = section.id %>
 
@@ -61,7 +62,8 @@
 
             <!-- the section body -->
             <div class="loaded">
-              <% section.questions.each do |question| %>
+              <% questions = section.questions.sort_by {|question| question.number } %>
+              <% questions.each do |question| %>
                 <% if question.id == session[:question_id_comments].to_i then id_css = "current_question" end %>
                 <div id="<%= id_css%>">
 


### PR DESCRIPTION
Sorting done in ruby to avoid hitting the DB again and loosing prefetching
I dont have a DB for the live service so was unable to test this fix

Users reported an issue with the ordering of sections/questions not displaying in correct order