### PR TITLE
change org.links default to empty hash

### DIFF
--- a/db/migrate/20180215141222_change_org_links_default.rb
+++ b/db/migrate/20180215141222_change_org_links_default.rb
@@ -1,0 +1,8 @@
+class ChangeOrgLinksDefault < ActiveRecord::Migration
+  def up
+    change_column_default :orgs, :links, '{}' 
+  end
+  def down
+    change_column_default :orgs, :links, '[]'
+  end
+end


### PR DESCRIPTION
Fixes # .
bug encountered during setting up dev env.

Changes proposed in this PR:
- change default for orgs.links from empty array to empty hash