### PR TITLE
fixes for downloads

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -234,12 +234,13 @@ class PlansController < ApplicationController
 
 
   def export
-    @plan = Plan.includes(:answers).joins(:answers).find(params[:id])
+    @plan = Plan.includes(:answers).find(params[:id])
     authorize @plan
 
     @show_coversheet = params[:export][:project_details].present?
     @show_sections_questions = params[:export][:question_headings].present?
     @show_unanswered = params[:export][:unanswered_questions].present?
+    @public_plan = false
 
     @hash = @plan.as_pdf(@show_coversheet)
     @formatting = @plan.settings(:export).formatting

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -46,7 +46,7 @@ class PublicPagesController < ApplicationController
   # GET plan_export/:id
   # -------------------------------------------------------------
   def plan_export
-    @plan = Plan.includes(:answers).joins(:answers).find(params[:id])
+    @plan = Plan.includes(:answers).find(params[:id])
     # covers authorization for this action.  Pundit dosent support passing objects into scoped policies
     raise Pundit::NotAuthorizedError unless PublicPagePolicy.new(@plan, current_user).plan_organisationally_exportable? || PublicPagePolicy.new(@plan).plan_export?
     skip_authorization
@@ -54,6 +54,7 @@ class PublicPagesController < ApplicationController
     @show_coversheet = true
     @show_sections_questions = true
     @show_unanswered = true
+    @public_plan = true
 
     @hash = @plan.as_pdf(@show_coversheet)
     @formatting = @plan.settings(:export).formatting

--- a/app/policies/public_page_policy.rb
+++ b/app/policies/public_page_policy.rb
@@ -25,7 +25,7 @@ class PublicPagePolicy < ApplicationPolicy
     plan = @object
     user = @object2
     if plan.is_a?(Plan) && user.is_a?(User)
-      return plan.publicly_visible? || (plan.organisationally_visible? && plan.template.org_id == user.org_id)
+      return plan.publicly_visible? || (plan.organisationally_visible? && plan.owner.present? && plan.owner.org_id == user.org_id)
     end
     return false;
   end

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -25,7 +25,7 @@
 
         <% section[:questions].each do |question| %>
           <div class="question">
-            <% if @show_sections_questions %>
+            <% if @show_sections_questions && !@public_plan %>
               <%# text in this case is an array to accomodate for option_based %>
               <% if question[:text].length > 1 %>
                 <ul>
@@ -43,7 +43,7 @@
             <% blank = answer.present? ? answer.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank? : true %>
             <% if blank && @show_unanswered %>
               <p><%= _('Question not answered.') -%></p>
-            <% else %>
+            <% elsif !blank %>
               <% if answer.question_options.length > 0 %>
                 <ul>
                   <% answer.question_options.each do |opt| %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -42,7 +42,7 @@
       <% blank = answer.present? ? answer.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank? : true %>
       <% if blank && @show_unanswered %>
 <%= "    #{_("Question not answered.")}\n\n" %>
-      <% else %>
+      <% elsif !blank %>
         <% if answer.question_options.length > 0 %>
           <% answer.question_options.each do |opt| %>
 <%= "    #{opt.text}\n" %>


### PR DESCRIPTION
addresses issues in #1127 
- removed `.joins(:answers)` since we cannot guarantee that the plan has at least one answer before user tries to download. 
- also added check for blank answer before trying to access its options
- updated policy for organisationally visible plan download so that it compares the plan owner's org instead of the template creator's org #1126