### PR TITLE
Preserves ordering by number for sections/questions

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -730,8 +730,8 @@ class Plan < ActiveRecord::Base
   def self.load_for_phase(id, phase_id)
     plan = Plan
       .joins(template: { phases: { sections: :questions }})
+      .preload(template: { phases: { sections: :questions }}) # Preserves the default order defined in the model relationships
       .where("plans.id = :id AND phases.id = :phase_id", { id: id, phase_id: phase_id })
-      .includes(template: { phases: { sections: :questions }})
       .merge(Plan.includes(answers: :notes))[0]
     phase = plan.template.phases.first
     return plan, phase

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -24,7 +24,7 @@
       </div>
     </div>
     <div class="panel-group" id="sections-accordion" role="tablist" aria-multiselectable="true">
-    <% phase.sections.order(:number).each do |section| %>
+    <% phase.sections.each do |section| %>
       <% sectionid = section.id %>
       <div class="panel panel-default">
         <div class="heading-button" role="button" data-toggle="collapse"


### PR DESCRIPTION
This PR addresses a bug encountered after introducing a more performant pre-fetching of the current phase for a plan.

Apparently, has many relationship with predefined order is not preserved when used with includes (see reference at https://github.com/rails/rails/issues/6769). This workaround is using preload instead, however we run now a query for each relationship included.


