### PR TITLE
Issue1105

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -179,7 +179,7 @@ module OrgAdmin
     def history
       @template = Template.find(params[:id])
       authorize @template
-      @templates = Template.where(dmptemplate_id: @template.dmptemplate_id).order(version: :desc)
+      @templates = Template.where(dmptemplate_id: @template.dmptemplate_id)
       @current = Template.current(@template.dmptemplate_id)
       @current_tab = params[:r] || 'all-templates'
     end

--- a/app/controllers/paginable/orgs_controller.rb
+++ b/app/controllers/paginable/orgs_controller.rb
@@ -5,7 +5,7 @@ class Paginable::OrgsController < ApplicationController
     authorize(Org)
     paginable_renderise(
       partial: 'index',
-      scope: Org.includes(:templates, :users).joins(:templates, :users)
-    )
+      scope: Org.includes(:templates, :users).joins(:templates, :users),
+      query_params: { sort_field: 'orgs.name', sort_direction: :asc })
   end
 end

--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -9,7 +9,8 @@ class Paginable::PlansController < ApplicationController
   def organisationally_or_publicly_visible
     raise Pundit::NotAuthorizedError unless Paginable::PlanPolicy.new(current_user).organisationally_or_publicly_visible?
     paginable_renderise(partial: 'organisationally_or_publicly_visible',
-      scope: Plan.organisationally_or_publicly_visible(current_user))
+      scope: Plan.organisationally_or_publicly_visible(current_user),
+      query_params: { sort_field: 'plans.title', sort_direction: :asc })
   end
   # GET /paginable/plans/publicly_visible/:page
   def publicly_visible

--- a/app/controllers/paginable/templates_controller.rb
+++ b/app/controllers/paginable/templates_controller.rb
@@ -86,6 +86,7 @@ class Paginable::TemplatesController < ApplicationController
     paginable_renderise(
       partial: 'history',
       scope: @templates,
+      query_params: { sort_field: :version, sort_direction: :desc },
       locals: { current: @current })
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -8,7 +8,7 @@ class PlansController < ApplicationController
   def index
     authorize Plan
     @plans = Plan.active(current_user).page(1)
-    @organisationally_or_publicly_visible = Plan.organisationally_or_publicly_visible(current_user).order(:title => :asc).page(1)
+    @organisationally_or_publicly_visible = Plan.organisationally_or_publicly_visible(current_user).page(1)
   end
 
   # GET /plans/new

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -4,7 +4,7 @@ module SuperAdmin
 
     def index
       authorize Org
-      render 'index', locals: { orgs: Org.includes(:templates, :users).joins(:templates, :users).order('orgs.name') }
+      render 'index', locals: { orgs: Org.includes(:templates, :users).joins(:templates, :users) }
     end
     
     def new

--- a/app/views/org_admin/templates/history.html.erb
+++ b/app/views/org_admin/templates/history.html.erb
@@ -18,7 +18,8 @@
         partial: '/paginable/templates/history',
         controller: 'paginable/templates',
         action: 'history',
-        path_params: { id: @template.id }, 
+        path_params: { id: @template.id },
+        query_params: { sort_field: :version, sort_direction: :desc }, 
         scope: @templates,
         locals: { current: @current }) %>
     <% else %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -36,8 +36,8 @@
         partial: '/paginable/plans/organisationally_or_publicly_visible',
         controller: 'paginable/plans',
         action: 'organisationally_or_publicly_visible',
-        scope: @organisationally_or_publicly_visible) %>
+        scope: @organisationally_or_publicly_visible,
+        query_params: { sort_field: 'plans.title', sort_direction: :asc }) %>
     <% end %>
   </div>
 </div>
-

--- a/app/views/super_admin/orgs/index.html.erb
+++ b/app/views/super_admin/orgs/index.html.erb
@@ -15,7 +15,8 @@
       partial: '/paginable/orgs/index',
       controller: 'paginable/orgs',
       action: 'index',
-      scope: orgs) %>
+      scope: orgs,
+      query_params: { sort_field: 'orgs.name', sort_direction: :asc }) %>
     <div>
   </div>
 </div>

--- a/test/integration/paginable_flows_test.rb
+++ b/test/integration/paginable_flows_test.rb
@@ -36,9 +36,9 @@ class PaginableFlowsTest < ActionDispatch::IntegrationTest
     # Fails if search form does not exists under paginable-search
     refute_empty(css_select('.paginable-search form'))
     # Fails if sort link for email does not exist
-    refute_empty(css_select('a[href$="1?search=User&sort_direction=ASC&sort_field=email"]'))
+    refute_empty(css_select('a[href$="ALL?search=User&sort_direction=ASC&sort_field=email"]'))
     # Fails if sort link for last_sign_in_at does not exist
-    refute_empty(css_select('a[href$="1?search=User&sort_direction=ASC&sort_field=last_sign_in_at"]'))
+    refute_empty(css_select('a[href$="ALL?search=User&sort_direction=ASC&sort_field=last_sign_in_at"]'))
 
     link_view_less_search_results = css_select('a[href$="/1?search=User"]').first
     refute_nil(link_view_less_search_results)
@@ -77,9 +77,9 @@ class PaginableFlowsTest < ActionDispatch::IntegrationTest
     # Fails if search form does not exists under paginable-search
     refute_empty(css_select('.paginable-search form'))
     # Fails if sort link for email does not exist
-    refute_empty(css_select('a[href$="1?sort_direction=ASC&sort_field=email"]'))
+    refute_empty(css_select('a[href$="ALL?sort_direction=ASC&sort_field=email"]'))
     # Fails if sort link for last_sign_in_at does not exist
-    refute_empty(css_select('a[href$="1?sort_direction=ASC&sort_field=last_sign_in_at"]'))
+    refute_empty(css_select('a[href$="ALL?sort_direction=ASC&sort_field=last_sign_in_at"]'))
 
     link = css_select('a[href$="/1"]').first
     # Fails if link ending with /1 does not exist


### PR DESCRIPTION
The default sorting has to be passed explicitly to paginable_renderise concern method through query_params keyword. For example:
paginable_renderise(..., query_params{ sort_field: :version, sort_direction: :asc }, ...) 

Note that query_params passed to the method are merged into the params object from the controller that included the concern and they act as a fallback ONLY for when no sort is requested through URL explicitly.

Summary of changes applied:

- page ALL is retained if latest request contains it. Sort links are now right aligned within the th. #1105
- default sorting to paginable concern specified through query_params keyword. #1105
- paginable plans including default sorting
- paginable orgs including default sorting. #1105
