### PR TITLE
allow uppercase in emails

### DIFF
--- a/lib/assets/javascripts/utils/isValidInputType.js
+++ b/lib/assets/javascripts/utils/isValidInputType.js
@@ -10,7 +10,7 @@ import {
 */
 export const isValidEmail = (value) => {
   if (isString(value)) {
-    return /[^@\s]+@(?:[-a-z0-9]+\.)+[a-z]{2,}$/.test(value);
+    return /[^@\s]+@(?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,}$/.test(value);
   }
   return false;
 };


### PR DESCRIPTION
#1200 
Fix for JS validation of emails which prevents capital letters in email addresses. We auto-populate the email returned from Shibboleth IdPs so we cannot guarantee lowercase