### PR TITLE
simplified logic for selected templates tab

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -30,7 +30,7 @@ module OrgAdmin
         published: published,
         current_org: current_user.org, 
         orgs: Org.all,
-        current_tab: params[:r] || 'all-templates',
+        current_tab: params[:r],
         scopes: { all: all_templates_hash[:scopes], orgs: own_hash[:scopes], funders: customizable_hash[:scopes] }
       }
     end
@@ -92,6 +92,7 @@ module OrgAdmin
           partial_path: 'edit',
           template: @template,
           current: @current,
+          edit: @template == @current,
           template_hash: @template_hash,
           current_tab: @current_tab
         })

--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -43,7 +43,7 @@ class PhasesController < ApplicationController
 
   #show and edit a phase of the template
   def admin_show
-    @phase = Phase.includes(:sections).order(:number).find(params[:id])
+    @phase = Phase.includes(:template, :sections).order(:number).find(params[:id])
     authorize @phase
 
     @current = Template.current(@phase.template.dmptemplate_id)
@@ -56,6 +56,10 @@ class PhasesController < ApplicationController
       @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
     else
       @original_org = @phase.template.org
+    end
+    
+    if @phase.template != @current
+      flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
     end
     
     render('/org_admin/templates/container',
@@ -90,6 +94,7 @@ class PhasesController < ApplicationController
       locals: {
         partial_path: 'admin_add',
         template: @template,
+        edit: true,
         current_tab: params[:r] || 'all-templates'
       })
   end

--- a/app/views/org_admin/templates/_admin_nav_tabs.html.erb
+++ b/app/views/org_admin/templates/_admin_nav_tabs.html.erb
@@ -9,7 +9,7 @@
         </li>
     <% end %>
     <!-- Add another phase button -->
-    <% if current_user.can_org_admin? && template.customization_of.nil? %>
+    <% if current_user.can_org_admin? && template.customization_of.nil? && edit %>
         <li role="presentation" <%= isActivePage(admin_add_phase_path(template)) ? ' class=active' : '' %>>
         <%= link_to(_('Add new phase'), admin_add_phase_path(template, r: current_tab), { 'aria-controls': 'add_phase', role: 'tab' }) %>
         </li>

--- a/app/views/org_admin/templates/index.html.erb
+++ b/app/views/org_admin/templates/index.html.erb
@@ -20,20 +20,21 @@
     </p>
   </div>
 </div>
+<% selected_tab = current_tab || (current_user.can_super_admin? ? 'all-templates' : 'organisation-templates') %>
 <div class="row">
   <div class="col-md-12">
     <ul class="nav nav-tabs" role="tablist">
       <% if current_user.can_super_admin? %>
-        <li role="all-templates"<%= current_tab == 'all-templates' ? 'class=active' : '' %>>
+        <li role="all-templates"<%= selected_tab == 'all-templates' ? 'class=active' : '' %>>
           <a href="#all-templates" role="tab" aria-controls="all-templates" data-toggle="tab"><%= _('All Templates') %></a>
         </li>
       <% end %>
-      <li role="organisation-templates"<%= current_tab == 'organisation-templates' ? 'class=active' : '' %>>
+      <li role="organisation-templates"<%= selected_tab == 'organisation-templates' ? 'class=active' : '' %>>
         <a href="#organisation-templates" role="tab" aria-controls="organisation-templates" data-toggle="tab"><%= current_user.can_super_admin? ? _('%{org_name} Templates') % { org_name: current_user.org.name } : _('Own Templates') %></a>
       </li>
       <!-- If the Org is not just a funder then show the customizations table -->
       <% if !current_org.funder_only? %>
-        <li role="funder-templates"<%= current_tab == 'funder-templates' ? 'class=active' : '' %>>
+        <li role="funder-templates"<%= selected_tab == 'funder-templates' ? 'class=active' : '' %>>
           <a href="#funder-templates" role="tab" aria-controls="funder-templates" data-toggle="tab"><%= _('Customizable Templates') %></a>
         </li>
       <% end %>
@@ -41,7 +42,7 @@
   
     <div class="tab-content">
       <% if current_user.can_super_admin? %>
-        <div id="all-templates" role="tabpanel" class="tab-pane<%= (current_tab == 'all-templates' || current_tab == '' ? ' active' : '') %>">
+        <div id="all-templates" role="tabpanel" class="tab-pane<%= (selected_tab == 'all-templates' ? ' active' : '') %>">
           <h2><%= _('All Templates') %></h2>
           <%= paginable_renderise(
             partial: 'paginable/templates/all',
@@ -52,7 +53,7 @@
             locals: {current_org: current_org.id, published: published, scopes: scopes[:all], hide_actions: true}) %>
         </div>
       <% end %>
-      <div id="organisation-templates" role="tabpanel" class="tab-pane<%= (!current_user.can_super_admin? && !current_tab.present?) || current_tab == 'organisation-templates' ? ' active' : '' %>">
+      <div id="organisation-templates" role="tabpanel" class="tab-pane<%= selected_tab == 'organisation-templates' ? ' active' : '' %>">
         <h2><%= current_user.can_super_admin? ? _('%{org_name} Templates') % { org_name: current_user.org.name } : _('Own Templates') %></h2>
         <%= paginable_renderise(
           partial: 'paginable/templates/orgs',
@@ -64,7 +65,7 @@
       </div>
       <!-- If the Org is not just a funder then show the customizations table -->
       <% if !current_org.funder_only? %>
-        <div id="funder-templates" role="tabpanel" class="tab-pane<%= current_tab == 'funder-templates' ? ' active' : '' %>">
+        <div id="funder-templates" role="tabpanel" class="tab-pane<%= selected_tab == 'funder-templates' ? ' active' : '' %>">
           <h2><%= _('Customizable Templates') %></h2>
           <%= paginable_renderise(
             partial: 'paginable/templates/funders',

--- a/app/views/phases/_admin_show.html.erb
+++ b/app/views/phases/_admin_show.html.erb
@@ -60,7 +60,7 @@
               <% if edit && section.modifiable %>
                 <%= render partial: 'sections/edit_section', locals: { template: template, section: section, edit: edit, phase: phase, current_tab: current_tab } %>
               <% else %>
-                <%= render partial: 'sections/show_section', locals: { template: template, section: section, current_tab: current_tab } %>
+                <%= render partial: 'sections/show_section', locals: { template: template, section: section, current_tab: current_tab, edit: edit } %>
               <% end %>
              </div>
           </div>

--- a/app/views/phases/admin_preview.html.erb
+++ b/app/views/phases/admin_preview.html.erb
@@ -12,14 +12,13 @@
 <div class="row">
   <div class="col-md-12">
     <!-- render navigation tabs for the template -->
-    <%= render partial: "/org_admin/templates/admin_nav_tabs", locals: { template: @template, active: @phase.id, current_tab: @current_tab } %>
+    <%= render partial: "/org_admin/templates/admin_nav_tabs", locals: { template: @template, active: @phase.id, edit: false, current_tab: @current_tab } %>
     <!-- render phase below -->
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane active">
         <div class="panel panel-default">
           <div class="panel-body">
-            <%= render partial: '/phases/edit_plan_answers', locals: { plan: nil, phase: @phase, readonly: true, question_guidance: {},
-                                                               guidance_groups: [] } %>
+            <%= render partial: '/phases/edit_plan_answers', locals: { plan: nil, phase: @phase, readonly: true, question_guidance: {}, edit: false, guidance_groups: [] } %>
           </div>
         </div>
       </div>

--- a/app/views/questions/_show_question.html.erb
+++ b/app/views/questions/_show_question.html.erb
@@ -89,7 +89,7 @@
           </div>
         <% end %>
         <div class="pull-right">
-          <% if (question.modifiable) %>
+          <% if (question.modifiable && edit) %>
             <%= link_to _('Edit question'), "#question_edit#{question.id}", class: "btn btn-default question_edit_link", role: "button" %>
             <%= link_to _('Delete question'), admin_destroy_question_path(question_id: question.id, r: current_tab),
               confirm: _("You are about to delete '%{question_text}'. Are you sure?") % { :question_text => question.text }, method: :delete, class: "btn btn-default", role:"button" %>

--- a/app/views/sections/_edit_section.html.erb
+++ b/app/views/sections/_edit_section.html.erb
@@ -44,7 +44,7 @@
         <% questions.each do |question| %>
           <hr />
           <div class="question_show" id="<%= "question_show#{question.id}" %>">
-            <%= render partial: 'questions/show_question', locals: {template: template, question: question, current_tab: current_tab} %>
+            <%= render partial: 'questions/show_question', locals: {template: template, question: question, current_tab: current_tab, edit: edit} %>
           </div>
           <div class="question_edit" id="<%= "question_edit#{question.id}" %>" style="display: none;">
             <%= render partial: 'questions/edit_question', locals: {template: template, question: question, current_tab: current_tab} %>
@@ -54,14 +54,15 @@
     <% end %>
   </div>
 </div>
-<div class="row">
-  <div class="col-md-12">
-    <div class="pull-right">
-      <%= link_to(_('Add Question'), '#', { class: 'btn btn-default question_new_link', role: "button" }) %>
-    </div>
-    <div class="question_new" style="display: none;">
-      <%= render partial: 'questions/add_question', locals: { section: section, current_tab: current_tab } %>
+<% if edit %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="pull-right">
+        <%= link_to(_('Add Question'), '#', { class: 'btn btn-default question_new_link', role: "button" }) %>
+      </div>
+      <div class="question_new" style="display: none;">
+        <%= render partial: 'questions/add_question', locals: { section: section, current_tab: current_tab } %>
+      </div>
     </div>
   </div>
-</div>
-  
+<% end %>

--- a/app/views/sections/_show_section.html.erb
+++ b/app/views/sections/_show_section.html.erb
@@ -13,9 +13,9 @@
       <% questions.each do |question| %>
         <hr />
         <div class="question_show" id="<%= "question_show#{question.id}" %>">
-          <%= render partial: 'questions/show_question', locals: {template: template, question: question, current_tab: current_tab} %>
+          <%= render partial: 'questions/show_question', locals: {template: template, question: question, current_tab: current_tab, edit: edit} %>
         </div>
-        <% if question.modifiable %>
+        <% if question.modifiable && edit %>
           <div class="question_edit" id="<%= "question_edit#{question.id}" %>" style="display: none;">
             <%= render partial: 'questions/edit_question', locals: {template: template, question: question, current_tab: current_tab} %>
           </div>


### PR DESCRIPTION
#1180 and #1207
- simplifies which tab is current on templates index
- carry 'edit' variable through the template->phase->section->question partials so that user cannot edit a historical version of template
- add 'You are viewing a historical version ...' to phase edit page
