### PR TITLE
removed links to plans on admin plans page

### DIFF
--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -14,7 +14,7 @@
       <% scope.each do |plan| %>
         <tr>
           <td>
-            <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
+            <%= plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title %>
           </td>
           <td><%= plan.template.title %></td>
           <td><%= plan.users.first.org.name %></td>


### PR DESCRIPTION
Fixes #1220 
Changed the plan title to be text instead of a link

