### PR TITLE
removed joins from orgs index

### DIFF
--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -4,7 +4,7 @@ module SuperAdmin
 
     def index
       authorize Org
-      render 'index', locals: { orgs: Org.includes(:templates, :users).joins(:templates, :users) }
+      render 'index', locals: { orgs: Org.includes(:templates, :users) }
     end
     
     def new


### PR DESCRIPTION
#1239 
An Org will not always have users or templates so need to remove the 'joins' portion of the query.
