### PR TITLE
Fix specific to #1263 - shouldn't affect anything else

### DIFF
--- a/lib/assets/javascripts/utils/tinymce.js
+++ b/lib/assets/javascripts/utils/tinymce.js
@@ -29,6 +29,7 @@ export const defaultOptions = {
   target_list: false,
   autoresize_min_height: 130,
   autoresize_bottom_margin: 10,
+  branding: false,
   extended_valid_elements: 'iframe[tooltip] , a[href|target=_blank]',
   paste_auto_cleanup_on_paste: true,
   paste_remove_styles: true,

--- a/lib/assets/webpack.config.js
+++ b/lib/assets/webpack.config.js
@@ -47,7 +47,7 @@ module.exports = {
         }),
       },
       {
-        test: /(?:fonts\/.*)|(?:font-awesome\/fonts\/.*)(?:\.woff2?$|\.ttf$|\.eot$|\.svg$)/,
+        test: /(?:fonts\/bootstrap\/.*)|(?:font-awesome\/fonts\/.*)|(?:customfonts\/fonts\/.*)(?:\.woff2?$|\.ttf$|\.eot$|\.svg$|\.woff$)/,
         use: [
           {
             loader: 'file-loader',


### PR DESCRIPTION
Fixes #1263 .

Changes proposed in this PR:
- Only way to add custom fonts without webpack errorring out is put them inside `node_modules` - hack
