### PR TITLE
added org change confirmation

### DIFF
--- a/app/views/devise/registrations/_password_confirmation.html.erb
+++ b/app/views/devise/registrations/_password_confirmation.html.erb
@@ -2,16 +2,34 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="modal-title">Please confirm your password</h4>
+        <h4 class="modal-title">Please confirm your changes</h4>
       </div>
       <div id="confirmation" class="modal-body">
-        <p><%= _('Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change.') %></p>
-        <div class="form-group">
-          <%= f.label :current_password, _('Password'), class: 'control-label', for: 'current_password' %>
-          <%= f.password_field :current_password, class: 'form-control', id: 'current_password' %>
-          <%= f.password_field :password, class: 'hide' %>
+        <div id="email-change">
+          <p><%= _('Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change.') %></p>
+          <div class="form-group">
+            <%= f.label :current_password, _('Password'), class: 'control-label', for: 'current_password' %>
+            <%= f.password_field :current_password, class: 'form-control', id: 'current_password' %>
+            <%= f.password_field :password, class: 'hide' %>
+          </div>
+        </div>
+
+        <div id="org-change" class="hide">
+          <p>
+            <%= _('Are you sure you want to change your organisational affiliation? Doing so will remove your administrative privileges.') %>
+          </p>
+          <div class="form-group">
+            <label class="control-label"><%= _('Organisation') %></label>
+          </div>
+          <div class="checkbox">
+            <label for="confirm_org_change">
+              <input type="checkbox" id="confirm_org_change" />
+              <%= _('Yes, I understand that I will lose my administrative privileges') %>
+            </label>
+          </div>
         </div>
       </div>
+
       <div class="modal-footer">
         <button type="button" class="btn btn-default" id="pwd-cancel-confirmation" 
                 data-dismiss="modal">Cancel</button>

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -27,6 +27,9 @@
   <div class="form-group col-xs-8" id="org-controls" <%= raw "data-toggle=\"tooltip\" title=\"#{_('Changing your organisation will result in the loss of your administrative privileges.')}\"" if org_admin %>>
     <%= render partial: "shared/my_org", locals: {f: f, default_org: @default_org, orgs: @orgs, allow_other_orgs: true} %>
   </div>
+  <% if org_admin %>
+    <input type="hidden" id="original_org" value="<%= @user.org_id %>">
+  <% end %>
 
   <% if MANY_LANGUAGES %>
     <div class="form-group col-xs-8">
@@ -70,12 +73,14 @@
       <%= f.label(:api_token, _('API token'), class: 'control-label') %>
       <%= @user.api_token %>
     </div>
+    <div class="form-group col-xs-8">
       <%= label_tag(:api_information, _('API Information'), class: 'control-label') %>
-    <div><a href="https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation"><%= _('How to use the API') %></a></div>
+      <a href="https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation"><%= _('How to use the API') %></a>
+    </div>
   <% end %>
 
   <div class="form-group col-xs-8">
-    <%= f.button(_('Save'), class: 'btn btn-default', type: "submit") %>
+    <%= f.button(_('Save'), class: 'btn btn-default', type: "submit", id: "personal_details_registration_form_submit") %>
   </div>
 
   <%= render partial: 'password_confirmation', locals: {f: f} %>

--- a/lib/assets/javascripts/views/devise/registrations/edit.js
+++ b/lib/assets/javascripts/views/devise/registrations/edit.js
@@ -1,5 +1,5 @@
 import ariatiseForm from '../../../utils/ariatiseForm';
-import { isObject, isString } from '../../../utils/isType';
+import { isString } from '../../../utils/isType';
 import { isValidPassword } from '../../../utils/isValidInputType';
 import { addMatchingPasswordValidator, togglisePasswords } from '../../../utils/passwordHelper';
 
@@ -10,23 +10,42 @@ $(() => {
   addMatchingPasswordValidator({ selector: '#password_details_registration_form' });
   togglisePasswords({ selector: '#password_details_registration_form' });
 
-  // If the user has changed their email address display the password
-  // confirmation modal on form submission
-  $('#personal_details_registration_form [type="submit"]').click((e) => {
-    const newEmail = $('#personal_details_registration_form #user_email');
-    if (isObject($('#original_email')) && isObject($(newEmail))) {
-      const original = $('#original_email').val();
-      const email = $(newEmail).val();
-      const pwd = $('#password-confirmation input[name="user[current_password]"]').val();
+  const sensitiveInfoCheck = (event) => {
+    const originalEmail = $('#original_email').val();
+    const originalOrg = $('#original_org').val();
+    const email = $('#personal_details_registration_form #user_email').val();
+    const org = $('#personal_details_registration_form #user_org_id').val();
+    const pwd = $('#password-confirmation input[name="user[current_password]"]').val();
+    const orgConfirm = $('#confirm_org_change').is(':checked');
+    let display = false;
 
-      // If the user changed the email and has not confirmed their password
-      if (isString(original) && isString(email)) {
-        if ((original.toLowerCase() !== email.toLowerCase()) && !isValidPassword(pwd)) {
-          e.preventDefault();
-          $('#password-confirmation').modal('show');
-        }
+    $('#email-change').addClass('hide');
+    $('#org-change').addClass('hide');
+
+    // If the Email has changed show the Password confirmation
+    if (isString(originalEmail) && isString(email)) {
+      if (originalEmail.toLowerCase() !== email.toLowerCase() && !isValidPassword(pwd)) {
+        $('#email-change').removeClass('hide');
+        display = true;
       }
     }
+    // If the orginalOrg is present and the selected Org has changed, show the confirmation box
+    if (isString(originalOrg) && isString(org)) {
+      if (originalOrg !== org && !orgConfirm) {
+        $('#org-change').removeClass('hide');
+        display = true;
+      }
+    }
+    if (display) {
+      event.preventDefault();
+      $('#password-confirmation').modal('show');
+    }
+  };
+
+  // If the user has changed their email address display the password
+  // confirmation modal on form submission
+  $('#personal_details_registration_form').submit((e) => {
+    sensitiveInfoCheck(e);
   });
 
   // Devise seems to require both the password and current_password so sync them


### PR DESCRIPTION
Update password confirmation modal that appears when user changes their email address so that it will also display a 'confirm your org affiliation change' message/checkbox if the user is an org admin. #1060
