### PR TITLE
Remove duplicate answers Rake task

### DIFF
--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -138,9 +138,9 @@ namespace :bugfix do
                 num_text += 1
               end
               if num_text == 1 && answer.text.present?
-                text = "<p><strong>ANSWER SAVED TWICE - REQUIRES MERGING<\strong><\p>"
+                text = "<p><strong>ANSWER SAVED TWICE - REQUIRES MERGING</strong></p>"
                 text += new_answer.text
-                new_answer.text = text + "<p><strong>-------------<\strong><\p>" + answer.text
+                new_answer.text = text + "<p><strong>-------------</strong></p>" + answer.text
               end
               answer.notes.each do |note|
                 note.answer_id = new_answer.id

--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -142,6 +142,7 @@ namespace :bugfix do
                 text += new_answer.text
                 new_answer.text = text + "<p><strong>-------------</strong></p>" + answer.text
               end
+              new_answer.save
               answer.notes.each do |note|
                 note.answer_id = new_answer.id
               end

--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -143,8 +143,10 @@ namespace :bugfix do
                 new_answer.text = text + "<p><strong>-------------</strong></p>" + answer.text
               end
               new_answer.save
+              new_answer.reload
               answer.notes.each do |note|
                 note.answer_id = new_answer.id
+                note.save
               end
               answer.question_options.each do |op|
                 unless qf.dropdown?

--- a/lib/tasks/bugfix.rake
+++ b/lib/tasks/bugfix.rake
@@ -147,7 +147,7 @@ namespace :bugfix do
               end
               answer.question_options.each do |op|
                 unless qf.dropdown?
-                  new_answer.question_options << op unless op in new_answer.question_options
+                  new_answer.question_options << op unless new_answer.question_options.any? {|aop| aop.id == op.id}
                   puts "\t adding option #{op.text}"
                 end
               end


### PR DESCRIPTION
Adds rake bugfix: remove_duplicate_answers

Logic for merging duplicate answers:
- creates a new answer object in place of the old ones
- user/updated_at/created_at/plan/question are set from the most recently answered question
- Notes from ALL answers have their answer_id changed to that of the new answer
- Question Options
    - dropdown is taken from the most recently saved answer
    - all other sets of question options are merged
- Text
    - if only one answer has text, the new answer's text is that answer's text
    - If both answers have text, the new answer's text is a concatonation of the multiple texts
    - Concatonations are marked with: `<p><strong>ANSWER SAVED TWICE - REQUIRES MERGING<\strong><\p>` and separated by `<p><strong>-------------<\strong><\p>`
- Old answers are deleted