### PR TITLE
Re-enable display of themed guidance from the organisation the template belongs to

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -283,8 +283,8 @@ class Plan < ActiveRecord::Base
   def guidance_by_question_as_hash
     # Get all of the selected guidance groups for the plan
     guidance_groups_ids = self.guidance_groups.collect(&:id)
-    guidance_groups =  GuidanceGroup.joins(:org).where("guidance_groups.published = ? AND guidance_groups.id IN (?) AND orgs.id != ?", 
-                                                       true, guidance_groups_ids, self.template.org.id)
+    guidance_groups =  GuidanceGroup.joins(:org).where("guidance_groups.published = ? AND guidance_groups.id IN (?)", 
+                                                       true, guidance_groups_ids)
 
     # Gather all of the Themes used in the plan as a hash
     # {


### PR DESCRIPTION
Workaround for #1292 .

(Re-enable display of themed guidance from the organisation the template belongs to)
