### PR TITLE
Updates to Super Admin Users page

### DIFF
--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -21,6 +21,8 @@ module SuperAdmin
       org.logo = params[:logo] if params[:logo]
       if params[:org_links].present?
         org.links = JSON.parse(params[:org_links]) 
+      else
+        org.links = { org: [] }
       end
     
       begin

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -1,0 +1,47 @@
+module SuperAdmin
+  class UsersController < ApplicationController
+
+    after_action :verify_authorized
+
+    def edit
+      user = User.find(params[:id])
+      if user.present?
+        authorize user
+        languages = Language.sorted_by_abbreviation
+        orgs = Org.where(parent_id: nil).order("name")
+        identifier_schemes = IdentifierScheme.where(active: true).order(:name)
+      
+        render 'super_admin/users/edit', 
+               locals: { user: user, 
+                         languages: languages,
+                         orgs: orgs, 
+                         identifier_schemes: identifier_schemes, 
+                         default_org: user.org }
+      else
+        redirect_to admin_index_users_path, alert: _('User not found.')
+      end
+    end
+   
+    def update
+      user = User.find(params[:id])
+      if user.present?
+        authorize user
+        topic = _('%{username}\'s profile') % { username: user.name(false) }
+        if user.update_attributes(user_params)
+          redirect_to edit_super_admin_user_path(user), 
+                      notice: _('Successfully updated %{username}') % { username: topic }
+        else
+          redirect_to edit_super_admin_user_path(user), 
+                      alert: _('Unable to update %{username}') % { username: topic }
+        end
+      else
+        redirect_to edit_super_admin_user_path(user), alert: _('User not found.')
+      end
+    end
+     
+    private
+      def user_params
+        params.require(:super_admin_user).permit(:email, :firstname, :surname, :org_id, :language_id)
+      end
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -23,9 +23,11 @@ class UserMailer < ActionMailer::Base
   def permissions_change_notification(role, user)
     @role = role
     @user = user
-    FastGettext.with_locale FastGettext.default_locale do
-      mail(to: @role.user.email, 
-           subject: _('Changed permissions on a Data Management Plan in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] })
+    if user.active?
+      FastGettext.with_locale FastGettext.default_locale do
+        mail(to: @role.user.email, 
+             subject: _('Changed permissions on a Data Management Plan in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] })
+      end
     end
   end
   
@@ -33,24 +35,18 @@ class UserMailer < ActionMailer::Base
     @user = user
     @plan = plan
     @current_user = current_user
-    FastGettext.with_locale FastGettext.default_locale do
-      mail(to: @user.email, 
-           subject: "#{_('Permissions removed on a DMP in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] }}")
-    end
-  end
-
-  def api_token_granted_notification(user)
-      @user = user
+    if user.active?
       FastGettext.with_locale FastGettext.default_locale do
         mail(to: @user.email, 
-             subject: _('API rights in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] })
+             subject: "#{_('Permissions removed on a DMP in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] }}")
       end
+    end
   end
   
   def feedback_notification(recipient, plan, requestor)
     @user = requestor
     
-    if @user.org.present?
+    if @user.org.present? && recipient.active?
       @org = @user.org
       @plan = plan
       @recipient = recipient
@@ -67,16 +63,18 @@ class UserMailer < ActionMailer::Base
     @user = recipient
     @plan = plan
       
-    FastGettext.with_locale FastGettext.default_locale do
-      mail(to: recipient.email, 
-           subject: _("%{application_name}: Expert feedback has been provided for %{plan_title}") % {application_name: Rails.configuration.branding[:application][:name], plan_title: @plan.title})
+    if recipient.active?
+      FastGettext.with_locale FastGettext.default_locale do
+        mail(to: recipient.email, 
+             subject: _("%{application_name}: Expert feedback has been provided for %{plan_title}") % {application_name: Rails.configuration.branding[:application][:name], plan_title: @plan.title})
+      end
     end
   end
   
   def feedback_confirmation(recipient, plan, requestor)
     user = requestor
 
-    if user.org.present?
+    if user.org.present? && recipient.active?
       org = user.org
       plan = plan
         
@@ -96,9 +94,11 @@ class UserMailer < ActionMailer::Base
   def plan_visibility(user, plan)
     @user = user
     @plan = plan
-    FastGettext.with_locale FastGettext.default_locale do
-      mail(to: @user.email,
-        subject: _('DMP Visibility Changed: %{plan_title}') %{ :plan_title => @plan.title })
+    if user.active?
+      FastGettext.with_locale FastGettext.default_locale do
+        mail(to: @user.email,
+             subject: _('DMP Visibility Changed: %{plan_title}') %{ :plan_title => @plan.title })
+      end
     end
   end
   
@@ -106,7 +106,8 @@ class UserMailer < ActionMailer::Base
   # @param plan - Plan for which the comment is associated to
   def new_comment(commenter, plan)
     if commenter.is_a?(User) && plan.is_a?(Plan)
-      if plan.owner.present?
+      owner = plan.owner
+      if owner.present? && owner.active?
         @commenter = commenter
         @plan = plan
         FastGettext.with_locale FastGettext.default_locale do
@@ -119,9 +120,11 @@ class UserMailer < ActionMailer::Base
 
   def admin_privileges(user)
     @user = user 
-    FastGettext.with_locale FastGettext.default_locale do
-      mail(to: user.email, subject:
-        _('Administrator privileges granted in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] })
+    if user.active?
+      FastGettext.with_locale FastGettext.default_locale do
+        mail(to: user.email, subject:
+          _('Administrator privileges granted in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] })
+      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,8 +50,8 @@ class User < ActiveRecord::Base
 
   # Retrieves all of the org_admins for the specified org
   scope :org_admins, -> (org_id) { 
-    joins(:perms).where("users.org_id = ? AND perms.name IN (?)", org_id,
-      ['grant_permissions', 'modify_templates', 'modify_guidance', 'change_org_details'])
+    joins(:perms).where("users.org_id = ? AND perms.name IN (?) AND users.active = ?", org_id,
+      ['grant_permissions', 'modify_templates', 'modify_guidance', 'change_org_details'], true)
   }
 
   scope :search, -> (term) {
@@ -66,6 +66,12 @@ class User < ActiveRecord::Base
   }
 
   after_update :when_org_changes
+
+  ##
+  # This method uses Devise's built-in handling for inactive users
+  def active_for_authentication?
+    super && self.active?
+  end
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW
   #

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -28,6 +28,18 @@ class UserPolicy < ApplicationPolicy
     user.can_super_admin?
   end
   
+  def activate?
+    user.can_super_admin?
+  end
+  
+  def edit?
+    user.can_super_admin?
+  end
+  
+  def update?
+    user.can_super_admin?
+  end
+  
   class Scope < Scope
     def resolve
       scope.where(org_id: user.org_id)

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -1,3 +1,4 @@
+<% is_super_admin = current_user.can_super_admin? %>
 <div class="row">
   <div class="col-md-12">
     <div class="table-responsive">
@@ -6,10 +7,13 @@
           <tr>
               <th><%= _('Name') %>&nbsp;<%= paginable_sort_link('firstname') %></th>
               <th><%= _('Email') %>&nbsp;<%= paginable_sort_link('email') %></th>
-              <th class="text-center"><%= _('Last activity') %>&nbsp;<%= paginable_sort_link('last_sign_in_at') %></th>
+              <th><%= _('Organisation') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
+              <th class="text-center date-column"><%= _('Created date') %>&nbsp;<%= paginable_sort_link('created_at') %></th>
+              <th class="text-center date-column"><%= _('Last activity') %>&nbsp;<%= paginable_sort_link('last_sign_in_at') %></th>
               <th class="text-center sorter-false"><%= _('Plans') %></th>
               <th class="text-center sorter-false"><%= _('Current Privileges') %></th>
-              <th class="text-center sorter-false"><%= _('Edit Privileges') %></th>
+              <th class="text-center"><%= _('Active') %></th>
+              <th class="text-center sorter-false"><%= _('Privileges') %></th>
           </tr>
         </thead>
         <tbody>
@@ -18,11 +22,17 @@
                 <tr>
                   <td>
                       <% if !user.name.nil? %>
-                          <%= user.name(false) %>
+                          <%= is_super_admin ? link_to(user.name(false), edit_super_admin_user_path(user)) : user.name(false) %>
+                      <% else %>
+                          <%= is_super_admin ? link_to(_('Edit Profile'), edit_user_registration_path(user)) : '' %>
                       <% end %>
                   </td>
-                  <td>
-                      <%= user.email %>
+                  <td><%= user.email %></td>
+                  <td><%= user.org.name if user.org.present? %></td>
+                  <td class="text-center">
+                      <% if !user.created_at.nil? %>
+                      <%= l user.created_at.to_date, :formats => :short %>
+                      <% end %>
                   </td>
                   <td class="text-center">
                       <% if !user.last_sign_in_at.nil? %>
@@ -38,12 +48,20 @@
                   <td class="text-center" data-descriptor="current_privileges">
                     <%= render partial: 'users/current_privileges', locals: { user: user } %>
                   </td>
+                  <td class="text-center user-status">
+                    <% if is_super_admin %>
+                      <%= form_for user, url: activate_user_path(user), html: { method: :put, remote: true, class: 'activate-user' } do |f| %>
+                        <%= check_box_tag(:active, "1", user.active) %>
+                        <%= f.submit(_('Update'), style: 'display: none;') %>
+                      <% end %>
+                    <% else %>
+                      <%= user.active? ? _('Yes') : _('No') %>
+                    <% end %>
+                  </td>
                   <td class="text-center">
                     <%# Do not allow a user to change their own permissions or a super admin's permissions if they are not a super admin %>
-                    <% unless current_user == user || 
-                        !current_user.can_super_admin? && user.can_super_admin? %>
-                      <% b_label = _('Edit') %>
-                      <%= link_to( b_label, admin_grant_permissions_user_path(user)) %>
+                    <% unless current_user == user || !is_super_admin && user.can_super_admin? %>
+                      <%= link_to( _('Edit'), admin_grant_permissions_user_path(user)) %>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/shared/_my_org.html.erb
+++ b/app/views/shared/_my_org.html.erb
@@ -1,7 +1,7 @@
 <%= f.label :org_name, _('Organisation'), class: 'control-label' %>
 <%= render partial: "shared/accessible_combobox",
-             locals: {name: "user[org_name]",
-                      id: "user_org_name",
+             locals: {name: "#{f.object_name}[org_name]",
+                      id: "#{f.object_name}_org_name",
                       default_selection: default_org,
                       models: orgs,
                       attribute: 'name'} %>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -1,0 +1,47 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1>
+      <%= _('Editing profile for %{username}') % { username: user.name(false) } %>
+      <%= link_to(_('View all users'), admin_index_users_path, class: 'btn btn-default pull-right', role: 'button') %>
+    </h1>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= form_for(user, as: :super_admin_user, url: super_admin_user_path(user), html: {method: :put, id: 'super_admin_user_edit' }) do |f| %>
+      <div class="form-group col-xs-8">
+        <%= f.label(:email, _('Email'), class: 'control-label') %>
+        <%= f.email_field(:email, class: "form-control", "aria-required": true, value: user.email) %>
+      </div>
+
+      <div class="form-group col-xs-8">
+        <%= f.label(:firstname, _('First name'), class: 'control-label') %>
+        <%= f.text_field(:firstname, class: "form-control", "aria-required": true, value: user.firstname) %>
+      </div>
+
+      <div class="form-group col-xs-8">
+        <%= f.label(:surname, _('Last name'), class: 'control-label') %>
+        <%= f.text_field(:surname, class: "form-control", "aria-required": true, value: user.surname) %>
+      </div>
+
+      <div class="form-group col-xs-8" id="org-controls">
+        <%= render partial: "shared/my_org", locals: {f: f, default_org: default_org, orgs: orgs, allow_other_orgs: true} %>
+      </div>
+
+      <% if MANY_LANGUAGES %>
+        <div class="form-group col-xs-8">
+          <% lang_id = user.language.nil? ? Language.id_for(FastGettext.default_locale) : user.language.id %>
+          <%= f.label(:language_id, _('Language'), class: 'control-label') %>
+          <%= select_tag(:super_admin_user_language_id,
+              options_from_collection_for_select(languages, "id", "name", lang_id),
+              class: "form-control", name: 'super_admin_user[language_id]') %>
+        </div>
+      <% end %>
+
+      <div class="form-group col-xs-8">
+        <%= f.button(_('Save'), class: 'btn btn-default', type: "submit", id: "personal_details_registration_form_submit") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/_admin_grant_permissions.html.erb
+++ b/app/views/users/_admin_grant_permissions.html.erb
@@ -6,12 +6,11 @@
               data-dismiss="modal" 
               aria-label="Close">
               <span aria-hidden="true">&times;</span></button>
-      <h1 class="modal-title"><%= _('Edit user privileges') %></h1>
+      <h2 class="modal-title"><%= _('Editing privileges for %{username}') % { username: user.name(false) } %></h2>
     </div>
     
-    <%= form_tag( admin_update_permissions_user_path(user), method: :put, remote: true, class: 'admin_update_permissions' ) do %>
+    <%= form_for user, url: admin_update_permissions_user_path(user), html: { method: :put, remote: true, class: 'admin_update_permissions' } do |f| %>
       <div class="modal-body" style="text-align: left">
-        <p><%= user.name(false) %><%= _(' current user privileges are: ') %></p>
         <ul class="list-group">
          <input type="checkbox" name="org_admin_privileges" id="org_admin_privileges" />
           <%= label_tag :organisational_admin_privileges %>

--- a/config/locales/devise/devise.de.yml
+++ b/config/locales/devise/devise.de.yml
@@ -10,7 +10,7 @@ de:
       send_paranoid_instructions: "Falls Ihre E-Mail-Adresse in unserer Datenbank existiert, erhalten Sie in wenigen Minuten eine E-Mail mit einer Anleitung zur Bestätigung Ihres Zugangs."
     failure:
       already_authenticated: "Sie sind bereits angemeldet."
-      inactive: "Ihr Zugang ist noch nicht aktiviert worden."
+      inactive: "Ihr Konto ist nicht mehr aktiv. Bitte kontaktieren Sie uns, um Ihr Konto zu reaktivieren."
       invalid: "E-Mail-Adresse oder Passwort ungültig."
       invalid_token: "Ungültiges Authentifizierungs-Token."
       locked: "Ihr Zugang ist gesperrt."

--- a/config/locales/devise/devise.en_GB.yml
+++ b/config/locales/devise/devise.en_GB.yml
@@ -8,7 +8,7 @@ en_GB:
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
-      inactive: "Your account was not activated yet."
+      inactive: "Your account is no longer active. Please contact us to reactivate your account."
       invalid: "Invalid email or password."
       invalid_token: "Invalid authentication token."
       invited: "You have a pending invitation, accept it to finish creating your account."

--- a/config/locales/devise/devise.en_US.yml
+++ b/config/locales/devise/devise.en_US.yml
@@ -8,7 +8,7 @@ en_US:
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
-      inactive: "Your account was not activated yet."
+      inactive: "Your account is no longer active. Please contact us to reactivate your account."
       invalid: "Invalid email or password."
       invalid_token: "Invalid authentication token."
       invited: "You have a pending invitation, accept it to finish creating your account."

--- a/config/locales/devise/devise.es.yml
+++ b/config/locales/devise/devise.es.yml
@@ -8,7 +8,7 @@ es:
       send_paranoid_instructions: "Si su correo electrónico existe en nuestra base de datos recibirás un correo electrónico en unos minutos con instrucciones sobre cómo reiniciar su contraseña."
     failure:
       already_authenticated: "Ya ha sido identificado."
-      inactive: "su cuenta aún no ha sido activada."
+      inactive: "Su cuenta ya no está activa. Por favor contáctenos para reactivar su cuenta."
       invalid: "Correo o contraseña inválidos."
       invalid_token: "Cadena de autenticación invalida."
       locked: "Su cuenta ha sido bloqueada."

--- a/config/locales/devise/devise.fr.yml
+++ b/config/locales/devise/devise.fr.yml
@@ -9,7 +9,7 @@ fr:
       send_paranoid_instructions: "Si votre adresse électronique existe dans notre base de données, vous recevrez dans quelques minutes un courriel contenant les directives pour valider votre compte."
     failure:
       already_authenticated: "Vous êtes déjà connecté(e)."
-      inactive: "Votre compte n'est pas encore activé."
+      inactive: "Votre compte n'est plus actif. Merci de nous contacter pour réactiver votre compte."
       invalid: "Courriel ou mot de passe incorrect."
       invalid_token: "Jeton d'authentification incorrect."
       locked: "Votre compte est verrouillé."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
     member do
       get 'admin_grant_permissions'
       put 'admin_update_permissions'
+      put 'activate'
     end
   end
 
@@ -313,5 +314,6 @@ resources :token_permission_types, only: [:new, :create, :edit, :update, :index,
     namespace :super_admin do
       resources :orgs, only: [:index, :new, :create, :edit, :update, :destroy]
       resources :themes, only: [:index, :new, :create, :edit, :update, :destroy]
+      resources :users, only: [:edit, :update]
     end
 end

--- a/db/migrate/20180315161757_add_active_to_users.rb
+++ b/db/migrate/20180315161757_add_active_to_users.rb
@@ -1,0 +1,8 @@
+class AddActiveToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :active, :boolean, default: true
+  end
+  def down
+    remove_column :users, :active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180313120831) do
+ActiveRecord::Schema.define(version: 20180315161757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -413,6 +413,7 @@ ActiveRecord::Schema.define(version: 20180313120831) do
     t.string   "invited_by_type"
     t.integer  "language_id"
     t.string   "recovery_email"
+    t.boolean  "active",                 default: true
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -45,6 +45,7 @@ import './views/shared/create_account_form';
 import './views/shared/my_org';
 import './views/shared/sign_in_form';
 import './views/super_admin/themes/new_edit';
+import './views/super_admin/users/edit';
 import './views/usage/index';
 import './views/users/notification_preferences';
 import './views/users/admin_grant_permissions';

--- a/lib/assets/javascripts/utils/autoComplete.js
+++ b/lib/assets/javascripts/utils/autoComplete.js
@@ -11,7 +11,6 @@ import { isValidText } from '../utils/isValidInputType';
 const updateIdField = (el) => {
   const crosswalk = $(`#${$(el).attr('id')}_crosswalk`);
   const idField = $(el).attr('id').replace(/_name/, '_id');
-
   if (isObject(crosswalk) && isObject($(idField))) {
     const json = JSON.parse(`${$(crosswalk).val().replace(/\\"/g, '"').replace(/\\'/g, '\'')}`);
     const selection = (json[$(el).val()] === undefined ? '' : json[$(el).val()]);

--- a/lib/assets/javascripts/views/super_admin/users/edit.js
+++ b/lib/assets/javascripts/views/super_admin/users/edit.js
@@ -1,0 +1,5 @@
+import ariatiseForm from '../../../utils/ariatiseForm';
+
+$(() => {
+  ariatiseForm({ selector: '#super_admin_user_edit' });
+});

--- a/lib/assets/javascripts/views/users/admin_grant_permissions.js
+++ b/lib/assets/javascripts/views/users/admin_grant_permissions.js
@@ -1,9 +1,26 @@
 import { paginableSelector } from '../../utils/paginable';
 import { isObject, isString } from '../../utils/isType';
-import { renderNotice, renderAlert } from '../../utils/notificationHelper';
+import { renderNotice, renderAlert, hideNotifications } from '../../utils/notificationHelper';
 import { scrollTo } from '../../utils/scrollTo';
 
 $(() => {
+  // Activate/Deactivate user account
+  $(paginableSelector).on('click, change', '.activate-user input[type="checkbox"]', (e) => {
+    const form = $(e.target).closest('form');
+    hideNotifications();
+    form.submit();
+  });
+  $(paginableSelector).on('ajax:success', '.activate-user', (e, data) => {
+    if (data.code === 1 && data.msg && data.msg !== '') {
+      renderNotice(data.msg);
+    } else {
+      renderAlert(data.msg);
+    }
+  });
+  $(paginableSelector).on('ajax:error', '.activate-user', () => {
+    renderAlert('Unexpected error');
+  });
+
   let currentPrivileges = null;
   $(paginableSelector).on('click', 'a[href$="admin_grant_permissions"]', (e) => {
     e.preventDefault();

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -49,6 +49,9 @@ thead th.table-scope {
 .table-hover tbody tr:hover td, .table-hover tbody tr:hover th {
   background-color: #CCC;
 }
+th.date-column {
+  min-width: 120px;
+}
 
 // Fix issues with dropdwon within tables being cut off
 .table-responsive > .table {
@@ -83,6 +86,12 @@ thead th.table-scope {
      tbody > tr > td { border: none; }
   }
 }
+
+/* MODAL DIALOG STYLING */
+.modal-dialog {
+  background-color: $white;
+}
+
 
 /* nav-tabs and nav-pills styling */
 .nav-tabs, .nav-pills {

--- a/test/functional/super_admin/orgs_controller_test.rb
+++ b/test/functional/super_admin/orgs_controller_test.rb
@@ -51,6 +51,7 @@ class OrgsControllerTest < ActionDispatch::IntegrationTest
   test 'super admin can create an org' do  
     params = {name: 'Test Org create', abbreviation: 'ABCD'}
     sign_in @super_admin
+    
     post super_admin_orgs_path, {org: params}
     assert_response :redirect
   end

--- a/test/functional/super_admin/users_controller_test.rb
+++ b/test/functional/super_admin/users_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+  
+  setup do
+    @user = User.create!(email: "super-admin-user-test@example.com", 
+                         firstname: "Testing", surname: "User",
+                         password: "password123", password_confirmation: "password123",
+                         org: Org.last, accept_terms: true, confirmed_at: Time.zone.now)
+    @super_admin = User.find_by(email: 'super_admin@example.com')
+  end
+
+  test 'unauthorized user cannot access edit user page' do
+    get edit_super_admin_user_path(@user)
+    assert_unauthorized_redirect_to_root_path
+    
+    sign_in @user
+    get edit_super_admin_user_path(@user)
+    assert_authorized_redirect_to_plans_page
+  end
+
+  test 'super admin can access edit user page' do  
+    sign_in @super_admin
+    get edit_super_admin_user_path(@user)
+    assert_response :success
+  end
+  
+  test 'unauthorized user cannot edit a user' do
+    params = { firstname: 'Foo', surname: 'Bar' }
+    put super_admin_user_path(@user), { super_admin_user: params }
+    assert_unauthorized_redirect_to_root_path
+    
+    sign_in @user
+    put super_admin_user_path(@user), { super_admin_user: params }
+    assert_authorized_redirect_to_plans_page
+  end
+
+  test 'super admin can edit a user' do  
+    params = { firstname: 'Foo', surname: 'Bar' }
+    sign_in @super_admin
+    put super_admin_user_path(@user), { super_admin_user: params }
+    assert_response :redirect
+    @user.reload
+    assert_equal 'Foo', @user.firstname, "expected the User's firstname to have been updated"
+  end
+
+end

--- a/test/integration/user_activation_test.rb
+++ b/test/integration/user_activation_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class AnswerLockingTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = User.create!(email: "super-admin-user-test@example.com", 
+                         firstname: "Testing", surname: "User",
+                         password: "password123", password_confirmation: "password123",
+                         org: Org.last, accept_terms: true, confirmed_at: Time.zone.now)
+  end
+  
+  test 'user can login when their account is active' do
+    sign_in @user
+    get root_path
+    assert_authorized_redirect_to_plans_page
+  end
+  
+  test 'user cannot login when their account is inactive' do
+    @user.active = false
+    @user.save!
+    
+    sign_in @user
+    # Sign in throws an Exception when the user is inactive
+    assert_raise do
+      get root_path
+    end
+  end
+  
+  test 'logged in user is logged out when their account is deactivated' do
+    sign_in @user
+    get root_path
+    assert_authorized_redirect_to_plans_page
+    @user.active = false
+    @user.save!
+    get root_path
+    assert_unauthorized_redirect_to_root_path
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -139,6 +139,11 @@ class UserTest < ActiveSupport::TestCase
   end
 
   # ---------------------------------------------------
+  test "new user is active by default" do
+    assert @user.active?
+  end
+
+  # ---------------------------------------------------
   test "can only have one identifier per IdentifierScheme" do
     @scheme = IdentifierScheme.first
 


### PR DESCRIPTION
Addresses feature requests in #1275 and #1248 
- Added `users.active` flag (defaults to true)
- Added new columns to Super Admin -> Users page
  - User Name is now a link to new `super_admin/users/[:id]/edit` page
  - Organization name
  - Created date
  - Active an ajax enabled checkbox to allow admins to quickly activate/deactivate accounts
- Added new super admin user edit page (route, controller, policy, view and JS) to allow admin to update user name, email, org and language
- Added logic to User model to enable Devise to force users who are not active to be logged out
- Updated devise's default message about account being inactive
- Updated `user_mailer` so that deactivated users do not receive emails (unless its a devise email about their account or a plan is shared with them)
- Added tests

Also:
- added logic to privilege update to only show/email users if the values have changed
- Fixed failing org controller test by setting default orgs.link value if not available 
- Added 'date-column' class to stylesheet to set min-width for date columns on users table. Usable elsewhere if necessary

**Need to run `rake db:migrate`**