### PR TITLE
Fixes #1184 .

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -29,7 +29,7 @@ class PublicPagesController < ApplicationController
           render pdf: file_name,
           margin: @formatting[:margin],
           footer: {
-            center:    _('Template created using the %{application_name}. Last modified %{date}') % {application_name: Rails.configuration.branding[:application][:name], date: l(@template.updated_at.to_date, formats: :short)},
+            center:    _('Template created using the %{application_name} service. Last modified %{date}') % {application_name: Rails.configuration.branding[:application][:name], date: l(@template.updated_at.to_date, formats: :short)},
             font_size: 8,
             spacing:   (@formatting[:margin][:bottom] / 2) - 4,
             right:     '[page] of [topage]'
@@ -69,7 +69,7 @@ class PublicPagesController < ApplicationController
         render pdf: file_name,
           margin: @formatting[:margin],
           footer: {
-            center:    _('Created using the %{application_name}. Last modified %{date}') % {application_name: Rails.configuration.branding[:application][:name], date: l(@plan.updated_at.to_date, formats: :short)},
+            center:    _('Created using the %{application_name} service. Last modified %{date}') % {application_name: Rails.configuration.branding[:application][:name], date: l(@plan.updated_at.to_date, formats: :short)},
             font_size: 8,
             spacing:   (@formatting[:margin][:bottom] / 2) - 4,
             right:     '[page] of [topage]'

--- a/app/views/public_pages/plan_index.html.erb
+++ b/app/views/public_pages/plan_index.html.erb
@@ -4,7 +4,7 @@
     <!-- if the user has projects -->
     <% if @plans.count > 0 %>
       <p class="left-indent">
-        <%= _('Public DMPs are plans created using the %{application_name} and shared publicly by their owners. They are not vetted for quality, completeness, or adherence to funder guidelines.') % {application_name: Rails.application.config.branding[:application][:name]} %>
+        <%= _('Public DMPs are plans created using the %{application_name} service and shared publicly by their owners. They are not vetted for quality, completeness, or adherence to funder guidelines.') % {application_name: Rails.application.config.branding[:application][:name]} %>
       </p>
     <% else %>
       <p class="left-indent">

--- a/app/views/public_pages/template_export.docx.erb
+++ b/app/views/public_pages/template_export.docx.erb
@@ -21,12 +21,12 @@
         <h3><%= section.title %></h3>
         <% section.questions.each do |question|%>
           <div>
-            <p><%= raw question.text %></p>
+            <p><%= raw question.text.chomp.strip %></p>
             <% q_format = question.question_format %>
             <% if q_format.option_based? %>
               <ul>
                 <% question.question_options.each do |option| %>
-                  <li><%= option.text %></li>
+                  <li><%= option.text.chomp.strip %></li>
                 <% end %>
               </ul>
             <% end %>
@@ -36,8 +36,8 @@
             <% question.annotations.each do |annotation| %>
               <% unless annotation.text.chomp.strip.gsub(/<\/?p>/, '').gsub(/<br\s?\/>/, '').blank? %>
                 <br>
-                <p><i><%= annotation.type == 0 ? _('Example Answer') : _('Guidance') %></i>:</p>
-                <%= raw annotation.text %>
+                <p><i><%= annotation.type == 'example_answer' ? _('Example Answer') : _('Guidance') %></i>:</p>
+                <%= raw annotation.text.chomp.strip %>
               <% end %>
             <% end %>
           </div>

--- a/app/views/public_pages/template_export.pdf.erb
+++ b/app/views/public_pages/template_export.pdf.erb
@@ -65,12 +65,12 @@
         <h2><%= section.title %></h2>
         <% section.questions.each do |question| %>
         <div class="question">
-          <p><%= raw question.text %></p>
+          <p><%= raw question.text.chomp.strip %></p>
           <% q_format = question.question_format %>
           <% if q_format.option_based? %>
             <ul>
             <% question.question_options.each do |option| %>
-              <li><%= option.text %></li>
+              <li><%= option.text.chomp.strip %></li>
             <% end %>
             </ul>
           <% end %>
@@ -78,7 +78,7 @@
         <div class="annotations">
           <% question.annotations.each do |annotation| %>
             <% unless annotation.text.chomp.strip.gsub(/<\/?p>/, '').gsub(/<br\s?\/>/, '').blank? %>
-              <p><i><%= annotation.type == 0 ? _('Example Answer') : _('Guidance') %></i>:</p>
+              <p><i><%= annotation.type == 'example_answer' ? _('Example Answer') : _('Guidance') %></i>:</p>
               <div style="margin-left: 15px;"><%= raw annotation.text.chomp.strip %></div>
             <% end %>
           <% end %>

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -81,7 +81,7 @@
                 <% end %>
                 <p><%= raw ah['text'] %></p>
               <% else %>
-                <p><%= raw answer.text %></p>
+                <p><%= raw answer.text.chomp.strip %></p>
               <% end %>
             <% end %>
           </div>


### PR DESCRIPTION
Fixes #1184 .

### Changes proposed in this PR:
- example_answer/guidance test expected Integer, received String from enum
- added a few `.chomp.strip`s to fix naughty user-entered texts
- changed "Created by the %{app...}" to "Created by the %{app...} service" as it didn't look right for some service names

