### PR TITLE
Gemfile without  libv8 and therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,11 +20,6 @@ gem 'pg', '~> 0.19.0'
 gem 'flag_shih_tzu', '~> 0.3'  # Allows for bitfields in activereccord
 
 # ------------------------------------------------
-#    JS <-> RUBY BRIDGE
-gem 'libv8', '~> 3.16'
-gem 'therubyracer', '>=0.11.4', platforms: :ruby
-
-# ------------------------------------------------
 #    JSON DSL - USED BY API
 gem 'jbuilder', '~> 2.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,6 @@ GEM
     kaminari-core (1.0.1)
     ledermann-rails-settings (2.4.2)
       activerecord (>= 3.1)
-    libv8 (3.16.14.15)
     locale (2.1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -264,7 +263,6 @@ GEM
     recaptcha (4.1.0)
       json
     redcarpet (3.3.4)
-    ref (2.0.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
     rolify (5.1.0)
@@ -298,9 +296,6 @@ GEM
       activesupport (>= 3)
       rails (>= 3)
     text (1.3.1)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
-      ref
     thin (1.7.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -350,7 +345,6 @@ DEPENDENCIES
   jbuilder (~> 2.6.0)
   kaminari (>= 1.0)
   ledermann-rails-settings (~> 2.4.2)
-  libv8 (~> 3.16)
   minitest-rails-capybara (~> 2.1.2)
   minitest-reporters (~> 1.1.11)
   mysql2 (~> 0.3.18)
@@ -372,7 +366,6 @@ DEPENDENCIES
   simplecov (~> 0.12)
   sqlite3 (~> 1.3.12)
   swagger-docs (>= 0.2.9)
-  therubyracer (>= 0.11.4)
   thin (~> 1.7)
   web-console (~> 2.3.0)
   webmock (~> 2.1.0)
@@ -385,4 +378,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.13.7
+   1.16.1


### PR DESCRIPTION
- removed libv8 and therubyracer since we are handling assets pipeline through webpack and nodejs directly
