### PR TITLE
Downloads bugfix

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -87,6 +87,18 @@ class Answer < ActiveRecord::Base
     return notes.select{ |n| n.archived.blank? }.sort!{ |x,y| y.updated_at <=> x.updated_at }
   end
 
+  ##
+  # Returns True if answer text is blank, false otherwise
+  # specificly we want to remove empty hml tags and check
+  #
+  # @return [Boolean] is the answer's text blank
+  def is_blank?
+    if self.text.present?
+      return self.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank?
+    end
+    # no text so blank
+    return True
+  end
 
   ##
   # Returns the parsed JSON hash for the current answer object

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -97,7 +97,7 @@ class Answer < ActiveRecord::Base
       return self.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank?
     end
     # no text so blank
-    return True
+    return true
   end
 
   ##

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -56,15 +56,7 @@ module ExportablePlan
           phase.sections.each do |section|
             sctn = { title: section.title, number: section.number, questions: [] }
             section.questions.each do |question|
-              txt = []
-              if question.question_format.option_based?
-                opts = QuestionOption.where(question_id: question.id)
-                opts.each do |opt|
-                  txt << opt.text
-                end
-              else
-                txt << question.text
-              end
+              txt = question.text
               sctn[:questions] << { id: question.id, text: txt, format: question.question_format }
             end
             phs[:sections] << sctn

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -60,7 +60,7 @@
             <% blank = answer.present? ? answer.is_blank? : true %>
             <% options = answer.present? ? answer.question_options : [] %>
             <%# case where question has not been answered sufficiently to display%>
-            <% if @show_unanswered && (answer.blank? || (options.blank? && blank)))%>
+            <% if @show_unanswered && (answer.blank? || (options.blank? && blank))%>
               <p><%= _('Question not answered.') -%></p>
             <% else %>
               <%# case where Question has options %>

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -44,16 +44,7 @@
         <% section[:questions].each do |question| %>
           <div class="question">
             <% if @show_sections_questions && !@public_plan %>
-              <%# text in this case is an array to accomodate for option_based %>
-              <% if question[:text].length > 1 %>
-                <ul>
-                  <% question[:text].each do |txt| %>
-                    <li><%= txt %></li>
-                  <% end %>
-                </ul>
-              <% else %>
-                <p><%= raw question[:text][0].gsub(/<tr>(\s|<td>|<\/td>|&nbsp;)*(<\/tr>|<tr>)/,"") if question[:text].present? && question[:text][0].present? %></p>
-              <% end %>
+              <p><%= raw question[:text].gsub(/<tr>(\s|<td>|<\/td>|&nbsp;)*(<\/tr>|<tr>)/,"") if question[:text].present?%></p>
               <br>
             <% end %>
             <% answer = @plan.answer(question[:id], false) %>

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -19,7 +19,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title><%= @plan.title %></title>
-    <%= render partial: '/shared/export/plan_styling', 
+    <%= render partial: '/shared/export/plan_styling',
                locals: {
                  font_face: font_face,
                  font_size: "#{font_size}pt",
@@ -56,13 +56,14 @@
               <% end %>
               <br>
             <% end %>
-
             <% answer = @plan.answer(question[:id], false) %>
-            <% blank = (answer.present? && answer.is_valid?) ? answer.text.gsub(/<\/?p>/, '').gsub(/<br\s?\/?>/, '').chomp.blank? : true %>
+            <% blank = answer.present? ? answer.is_blank? : true %>
             <% options = answer.present? ? answer.question_options : [] %>
-            <% if blank && @show_unanswered && options.blank? %>
+            <%# case where question has not been answered sufficiently to display%>
+            <% if @show_unanswered && (answer.blank? || (options.blank? && blank)))%>
               <p><%= _('Question not answered.') -%></p>
-            <% elsif !blank %>
+            <% else %>
+              <%# case where Question has options %>
               <% if options.present?%>
                 <ul>
                   <% options.each do |opt| %>
@@ -70,7 +71,8 @@
                   <% end %>
                 </ul>
               <% end %>
-              <% if question[:format].rda_metadata? %>
+              <%# case for RDA answer display %>
+              <% if question[:format].rda_metadata? && !blank %>
                 <% ah = answer.answer_hash %>
                 <% if ah['standards'].present? %>
                   <ul>
@@ -80,7 +82,8 @@
                   </ul>
                 <% end %>
                 <p><%= raw ah['text'] %></p>
-              <% else %>
+              <%# case for displaying comments OR text %>
+              <% elsif !blank %>
                 <p><%= raw answer.text %></p>
               <% end %>
             <% end %>


### PR DESCRIPTION
Addresses #1239 and another reported issue.

User reported error msg on plan download (PDF)
- Due to not checking if an answer has text before attempting to .gsub  (case for option_based questions which would be valid with options but no text)
- 1239 is due to an issue in the logic where answers with blank text will not get exported, breaking export for option_based questions.

Changes:
- Refactored &fixed checking for blank to answer.rb
- Switched export to conditionally check for presence of options/text with special case to handle rda questions's hash answers.

NOTE: REBASE DEVELOPMENT and CONTRIBUTIONS after merging
