### PR TITLE
Updated plans controller to send user to overview after saving details

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -164,7 +164,7 @@ class PlansController < ApplicationController
         @plan.save
       
         if @plan.update_attributes(attrs)
-          format.html { redirect_to @plan, :editing => false, notice: success_message(_('plan'), _('saved')) }
+          format.html { redirect_to overview_plan_path(@plan), notice: success_message(_('plan'), _('saved')) }
           format.json {render json: {code: 1, msg: success_message(_('plan'), _('saved'))}}
         else
           flash[:alert] = failed_update_error(@plan, _('plan'))

--- a/test/functional/plans_controller_test.rb
+++ b/test/functional/plans_controller_test.rb
@@ -110,7 +110,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     put plan_path(@plan), {plan: params}
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('saved')
     assert_response :redirect
-    assert_redirected_to plan_url(@plan)
+    assert_redirected_to overview_plan_path(@plan)
     assert assigns(:plan)
     assert_equal 'Testing UPDATE', @plan.reload.title, "expected the record to have been updated"
 
@@ -200,7 +200,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     put plan_path(@plan), {plan: {id: @plan.id}, guidance_group_ids: ids}
     assert_response :redirect
-    assert_redirected_to plan_path(@plan)
+    assert_redirected_to overview_plan_path(@plan)
 
     @plan.reload
     ggs = @plan.guidance_groups.ids


### PR DESCRIPTION
User is now sent to Plan overview tab after saving Project Details #1162