### PR TITLE
Switched href to data-target for guidance tabs on Write Plan

### DIFF
--- a/app/views/phases/_guidances_notes.html.erb
+++ b/app/views/phases/_guidances_notes.html.erb
@@ -27,7 +27,7 @@
       <ul class="nav nav-tabs" role="tablist">
         <% if annotations.present? %>
           <li role="presentation" class="active">
-            <a href="#annotations-<%= question.id %>" aria-controls="annotations-<%= question.id %>" role="tab" data-toggle="tab" 
+            <a data-target="#annotations-<%= question.id %>" aria-controls="annotations-<%= question.id %>" role="tab" data-toggle="tab" 
                class="view-plan-guidance">
               <%= template.org.short_name %>
             </a>
@@ -37,7 +37,7 @@
           <% obj = guidance_groups.select{ |gg| gg.name == group }.first %>
           <% if obj.present? %>
             <li role="presentation">
-              <a href="#guidance-<%= question.id %>-<%= obj.id %>" aria-controls="guidance-<%= question.id %>-<%= obj.id %>" 
+              <a data-target="#guidance-<%= question.id %>-<%= obj.id %>" aria-controls="guidance-<%= question.id %>-<%= obj.id %>" 
                  role="tab" data-toggle="tab" class="view-plan-guidance">
                 <%= group[0..15] %>
               </a>


### PR DESCRIPTION
#1309 

This isn't a great solution to the issue. We set `window.location.hash` to retain the currently selected tab if the page is refreshed/reloaded. This behavior works for the top level tabs (e.g. Project Details, Write Plan, Share, etc.) but this JS code is causing the page to jump when the user clicks on a nested tab like the ones in the guidances section of the write plan page. 

The JS code looks for the 'href' property to determine what to put in the URL, I updated it to use 'data-target' which results in `#undefined` in the URL. It keeps the page from jumping. 

A better solution would be to rethink the way the write plan pages are loaded and displayed to the user which is something we will likely need to do in the near future.  