### PR TITLE
patch to fix issue with default template visibility setting

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -118,7 +118,7 @@ class Question < ActiveRecord::Base
   def first_example_answer
     self.annotations.where(type: Annotation.types[:example_answer]).order(:created_at).first
   end
-
+  
   ##
   # get guidance belonging to the current user's org for this question(need org 
   # to distinguish customizations)

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -268,11 +268,11 @@ class Template < ActiveRecord::Base
       self.published = false
       self.migrated = false
       self.dirty = false
-      self.visibility = 0 # Organisationally visible by default
       self.is_default = false if self.is_default.nil?
       self.version = 0 if self.version.nil?
-      self.visibility = Template.visibilities[:organisationally_visible] if self.visibility.nil?
-
+      # Organisationally visible by default unless Org is only a funder
+      self.visibility = (self.org.present? && self.org.funder_only?) ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible] 
+      
       # Generate a unique identifier for the dmptemplate_id if necessary
       if self.dmptemplate_id.nil?
         self.dmptemplate_id = loop do


### PR DESCRIPTION
Sets the template visibility to 'Public' for new funder templates and 'Organisational' for all others. Orgs that are both funder and organisation/institution still retain the ability to change the visibility after the template is created (on the edit template details page). Their templates are Organisationally visible by default though when initially created. #1342 & #1318