### PR TITLE
added org abbreviation to 'Guidance' sections and added customized ex…

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -58,6 +58,7 @@ class AnswersController < ApplicationController
       }).find(p_params[:plan_id])
       @question = @answer.question
       @section = @plan.get_section(@question.section_id)
+      template = @section.phase.template
 
       render json: {
         "question" => {
@@ -66,7 +67,7 @@ class AnswersController < ApplicationController
           "locking" => @stale_answer ?
             render_to_string(partial: 'answers/locking', locals: { question: @question, answer: @stale_answer, user: @answer.user }, formats: [:html]) :
             nil,
-          "form" => render_to_string(partial: 'answers/new_edit', locals: { question: @question, answer: @answer, readonly: false, locking: false }, formats: [:html]),
+          "form" => render_to_string(partial: 'answers/new_edit', locals: { template: template, question: @question, answer: @answer, readonly: false, locking: false }, formats: [:html]),
           "answer_status" => render_to_string(partial: 'answers/status', locals: { answer: @answer}, formats: [:html])
         },
         "section" => {

--- a/app/views/annotations/_show.html.erb
+++ b/app/views/annotations/_show.html.erb
@@ -1,12 +1,8 @@
 <% org = template.org.abbreviation.present? ? template.org.abbreviation : template.org.name %>
-<% if example_answer.present? || guidance.present? %>
+<% if guidance.present? %>
   <dl<%= for_plan ? ' class="dl-horizontal"' : '' %>>
-    <% if example_answer.present? %>
-      <dt><%= _('Example answer') %></dt>
-      <dd><%= raw example_answer.text %><dd>
-    <% end %>
     <% if guidance.present? %>
-      <dt><%= _('Guidance') %></dt>
+      <dt><%= template.customization_of.nil? ? _('Guidance') : _('%{org} Guidance') % { org: guidance.org.short_name } %></dt>
       <dd><%= raw guidance.text %></dd>
     <% end %>
   </dl>

--- a/app/views/answers/_locking.html.erb
+++ b/app/views/answers/_locking.html.erb
@@ -1,5 +1,6 @@
 <div class="answer_notice">
     <p><%= _('The following answer cannot be saved') %></p>
-        <%= render partial: '/answers/new_edit', locals: { question: question, answer: answer, readonly: true, locking: true } %>
+    <%# We do not need to re-show example answers in this lock conflict section so leave template nil %>
+    <%= render partial: '/answers/new_edit', locals: { template: nil, question: question, answer: answer, readonly: true, locking: true } %>
     <p><%= _('since %{name} saved the answer below while you were editing. Please, combine your changes and then save the answer again.') % { name: user.name} %></p>
 </div>

--- a/app/views/answers/_new_edit.html.erb
+++ b/app/views/answers/_new_edit.html.erb
@@ -1,4 +1,4 @@
-<%# locals: { question, answer, readonly, locking } %>
+<%# locals: { template, question, answer, readonly, locking } %>
 <!--
   This partial creates a form for each type of question. The local variables are: plan, answer, question, readonly
 -->
@@ -64,15 +64,18 @@
     <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
   </fieldset>
   <!--Example Answer area -->
-  <% annotation = question.first_example_answer %>
-  <% if annotation.present? && annotation.text.present? %>
-    <div class="panel panel-default">
-      <span class="label label-default">
-        <%="#{annotation.org.abbreviation} "%> <%=_('example answer')%>
-      </span>
-      <div class="panel-body">
-        <%= raw annotation.text %>
+  <% annotations = [question.first_example_answer] %>
+  <% annotations << question.get_example_answer(template.org.id) if template.present? && template.org.present? %>
+  <% annotations.each do |annotation| %>
+    <% if annotation.present? && annotation.org.present? %>
+      <div class="panel panel-default">
+        <span class="label label-default">
+          <%="#{annotation.org.abbreviation} "%> <%=_('example answer')%>
+        </span>
+        <div class="panel-body">
+          <%= raw annotation.text %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -63,7 +63,7 @@
                     <div class="question-form">
                       <div id="<%= "answer-locking-#{question.id}" %>" class="answer-locking"></div>
                       <div id="<%= "answer-form-#{question.id}" %>" class="answer-form"> 
-                        <%= render(partial: '/answers/new_edit', locals: { question: question, answer: answer, readonly: readonly, locking: false }) %>
+                        <%= render(partial: '/answers/new_edit', locals: { template: phase.template, question: question, answer: answer, readonly: readonly, locking: false }) %>
                       </div>
                       <div id="<%= "answer-status-#{question.id}" %>" class="mt-10">
                         <%= render(partial: '/answers/status', locals: { answer: answer }) %>


### PR DESCRIPTION
- Removed example answer from guidances section since its never used (query looks only for guidance type annotations)
- Added Org abbreviation to 'Guidance' label when the template is customized #1343
- Used existing model method to get customization example answer and display it underneath the template's original example answer (would be better to refactor into a single query later) #1344
- Updated 'Answer locked by another user' section to exclude reshowing example answers since they appear below the main answer

![screen shot 2018-04-04 at 1 02 18 pm](https://user-images.githubusercontent.com/1204467/38332868-dc84f756-380b-11e8-9a5a-89b12e32764f.png)
