### PR TITLE
DB migrations for templates table rework

### DIFF
--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -16,7 +16,6 @@ class AnnotationsController < ApplicationController
 
     if !flash[:notice].blank? || !flash[:alert].blank?
       template = question.section.phase.template
-      template.dirty = true
       template.save!
     end
     tab = params[:r] || 'all-templates'

--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -28,7 +28,7 @@ module Api
         if @template.customization_of.nil?
           @plan.funder_name = @template.org.name
         else
-          @plan.funder_name = Template.where(dmptemplate_id: @template.customization_of).first.org.name
+          @plan.funder_name = Template.where(family_id: @template.customization_of).first.org.name
         end
         @plan.template = @template
         @plan.title = params[:plan][:title]

--- a/app/controllers/api/v0/statistics_controller.rb
+++ b/app/controllers/api/v0/statistics_controller.rb
@@ -137,7 +137,7 @@ module Api
           if @templates[template.title].blank?
             @templates[template.title] = {}
             @templates[template.title][:title]  = template.title
-            @templates[template.title][:id]     = template.dmptemplate_id
+            @templates[template.title][:id]     = template.family_id
             if template.plans.present?
               @templates[template.title][:uses] = restrict_date_range(template.plans).length
             else
@@ -174,7 +174,7 @@ module Api
           if @templates[plan.template.title].blank?
             @templates[plan.template.title] = {}
             @templates[plan.template.title][:title] = plan.template.title
-            @templates[plan.template.title][:id] = plan.template.dmptemplate_id
+            @templates[plan.template.title][:id] = plan.template.family_id
             @templates[plan.template.title][:uses] = 1
           else
             @templates[plan.template.title][:uses] += 1

--- a/app/controllers/api/v0/templates_controller.rb
+++ b/app/controllers/api/v0/templates_controller.rb
@@ -18,26 +18,26 @@ module Api
 
         published_templates.each do |temp|
           if @org_templates[temp.org].present?
-            if @org_templates[temp.org][:own][temp.dmptemplate_id].nil?
-              @org_templates[temp.org][:own][temp.dmptemplate_id] = temp
+            if @org_templates[temp.org][:own][temp.family_id].nil?
+              @org_templates[temp.org][:own][temp.family_id] = temp
             end
           else
             @org_templates[temp.org] = {}
             @org_templates[temp.org][:own] = {}
             @org_templates[temp.org][:cust] = {}
-            @org_templates[temp.org][:own][temp.dmptemplate_id] = temp
+            @org_templates[temp.org][:own][temp.family_id] = temp
           end
         end
         customized_templates.each do |temp|
           if @org_templates[temp.org].present?
-            if @org_templates[temp.org][:cust][temp.dmptemplate_id].nil?
-              @org_templates[temp.org][:cust][temp.dmptemplate_id] = temp
+            if @org_templates[temp.org][:cust][temp.family_id].nil?
+              @org_templates[temp.org][:cust][temp.family_id] = temp
             end
           else
             @org_templates[temp.org] = {}
             @org_templates[temp.org][:own] = {}
             @org_templates[temp.org][:cust] = {}
-            @org_templates[temp.org][:cust][temp.dmptemplate_id] = temp
+            @org_templates[temp.org][:cust][temp.family_id] = temp
           end
         end
         respond_with @org_templates

--- a/app/controllers/paginable/templates_controller.rb
+++ b/app/controllers/paginable/templates_controller.rb
@@ -13,7 +13,7 @@ class Paginable::TemplatesController < ApplicationController
     hash[:templates] = hash[:templates].page(params[:page]) if params[:page] != 'ALL'
     
     # Gather up all of the publication dates for the live versions of each template.
-    published = get_publication_dates(hash[:scopes][:dmptemplate_ids])
+    published = get_publication_dates(hash[:scopes][:family_ids])
     
     paginable_renderise partial: 'all',
                         scope: hash[:templates],
@@ -34,7 +34,7 @@ class Paginable::TemplatesController < ApplicationController
     hash[:templates] = hash[:templates].page(params[:page]) if params[:page] != 'ALL'
     
     # Gather up all of the publication dates for the live versions of each template.
-    published = get_publication_dates(hash[:scopes][:dmptemplate_ids])
+    published = get_publication_dates(hash[:scopes][:family_ids])
     
     paginable_renderise partial: 'funders',
                         scope: hash[:templates],
@@ -55,7 +55,7 @@ class Paginable::TemplatesController < ApplicationController
     hash[:templates] = hash[:templates].page(params[:page]) if params[:page] != 'ALL'
     
     # Gather up all of the publication dates for the live versions of each template.
-    published = get_publication_dates(hash[:scopes][:dmptemplate_ids])
+    published = get_publication_dates(hash[:scopes][:family_ids])
     
     paginable_renderise partial: 'orgs',
                         scope: hash[:templates],
@@ -68,7 +68,7 @@ class Paginable::TemplatesController < ApplicationController
   # GET /paginable/templates/publicly_visible/:page  (AJAX)
   # -----------------------------------------------------
   def publicly_visible
-    templates = Template.live(Template.families(Org.funder.pluck(:id)).pluck(:dmptemplate_id)).publicly_visible.pluck(:id) <<
+    templates = Template.live(Template.families(Org.funder.pluck(:id)).pluck(:family_id)).publicly_visible.pluck(:id) <<
     Template.where(is_default: true).valid.published.pluck(:id)
     
     paginable_renderise(
@@ -81,8 +81,8 @@ class Paginable::TemplatesController < ApplicationController
   def history
     @template = Template.find(params[:id])
     authorize @template
-    @templates = Template.where(dmptemplate_id: @template.dmptemplate_id)
-    @current = Template.current(@template.dmptemplate_id)
+    @templates = Template.where(family_id: @template.family_id)
+    @current = Template.current(@template.family_id)
     paginable_renderise(
       partial: 'history',
       scope: @templates,

--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -46,14 +46,14 @@ class PhasesController < ApplicationController
     @phase = Phase.includes(:template, :sections).order(:number).find(params[:id])
     authorize @phase
 
-    @current = Template.current(@phase.template.dmptemplate_id)
+    @current = Template.current(@phase.template.family_id)
     @edit = (@phase.template.org == current_user.org) && (@phase.template == @current)
 
     if params.has_key?(:question_id)
       @question_id = params[:question_id].to_i
     end
     if @phase.template.customization_of.present?
-      @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+      @original_org = Template.where(family_id: @phase.template.customization_of).first.org
     else
       @original_org = @phase.template.org
     end
@@ -109,9 +109,6 @@ class PhasesController < ApplicationController
     @phase.modifiable = true
     @current_tab = params[:r] || 'all-templates'
     if @phase.save
-      @phase.template.dirty = true
-      @phase.template.save!
-
       redirect_to admin_show_phase_path(id: @phase.id, r: @current_tab), notice: success_message(_('phase'), _('created'))
     else
       flash[:alert] = failed_create_error(@phase, _('phase'))
@@ -129,9 +126,6 @@ class PhasesController < ApplicationController
     @phase.description = params["phase-desc"]
     @current_tab = params[:r] || 'all-templates'
     if @phase.update_attributes(params[:phase])
-      @phase.template.dirty = true
-      @phase.template.save!
-
       redirect_to admin_show_phase_path(@phase, r: @current_tab), notice: success_message(_('phase'), _('saved'))
     else
       @sections = @phase.sections
@@ -144,7 +138,7 @@ class PhasesController < ApplicationController
       @question_id = (params[:question_id].nil? ? nil : params[:question_id].to_i)
       flash[:alert] = failed_update_error(@phase, _('phase'))
       if @phase.template.customization_of.present?
-        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+        @original_org = Template.where(family_id: @phase.template.customization_of).first.org
       else
         @original_org = @phase.template.org
       end
@@ -159,9 +153,6 @@ class PhasesController < ApplicationController
     @template = @phase.template
     @current_tab = params[:r] || 'all-templates'
     if @phase.destroy
-      @template.dirty = true
-      @template.save!
-
       redirect_to edit_org_admin_template_path(@template, r: @current_tab), notice: success_message(_('phase'), _('deleted'))
     else
       @sections = @phase.sections
@@ -174,7 +165,7 @@ class PhasesController < ApplicationController
       @question_id = (params[:question_id].nil? ? nil : params[:question_id].to_i)
       flash[:alert] = failed_destroy_error(@phase, _('phase'))
       if @phase.template.customization_of.present?
-        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+        @original_org = Template.where(family_id: @phase.template.customization_of).first.org
       else
         @original_org = @phase.template.org
       end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -144,7 +144,7 @@ class PlansController < ApplicationController
     @all_ggs_grouped_by_org = @all_ggs_grouped_by_org.sort_by {|org,gg| (org.nil? ? '' : org.name)}
     @selected_guidance_groups = @selected_guidance_groups.collect{|gg| gg.id}
 
-    @based_on = (@plan.template.customization_of.nil? ? @plan.template : Template.where(dmptemplate: @plan.template.customization_of).first)
+    @based_on = (@plan.template.customization_of.nil? ? @plan.template : Template.where(family: @plan.template.customization_of).first)
 
     respond_to :html
   end
@@ -360,13 +360,13 @@ class PlansController < ApplicationController
   end
 
 
-  # different versions of the same template have the same dmptemplate_id
+  # different versions of the same template have the same family_id
   # but different version numbers so for each set of templates with the
-  # same dmptemplate_id choose the highest version number.
+  # same family_id choose the highest version number.
   def get_most_recent( templates )
     groups = Hash.new
     templates.each do |t|
-      k = t.dmptemplate_id
+      k = t.family_id
       if !groups.has_key?(k)
         groups[k] = t
       else

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -4,7 +4,7 @@ class PublicPagesController < ApplicationController
   # GET template_index
   # -----------------------------------------------------
   def template_index
-    templates = Template.live(Template.families(Org.funder.pluck(:id)).pluck(:dmptemplate_id)).publicly_visible.pluck(:id) <<
+    templates = Template.live(Template.families(Org.funder.pluck(:id)).pluck(:family_id)).publicly_visible.pluck(:id) <<
     Template.where(is_default: true).valid.published.pluck(:id)
     @templates = Template.includes(:org).where(id: templates.uniq.flatten).valid.published.order(title: :asc).page(1)
   end
@@ -12,7 +12,7 @@ class PublicPagesController < ApplicationController
   # GET template_export/:id
   # -----------------------------------------------------
   def template_export
-    # only export live templates, id passed is dmptemplate_id
+    # only export live templates, id passed is family_id
     @template = Template.live(params[:id])
     # covers authorization for this action.  Pundit dosent support passing objects into scoped policies
     raise Pundit::NotAuthorizedError unless PublicPagePolicy.new( @template).template_export?

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -15,8 +15,6 @@ class QuestionsController < ApplicationController
         @question.default_value = params["question-default-value-textarea"]
       end
       if @question.save
-        @question.section.phase.template.dirty = true
-        @question.section.phase.template.save!
         if params[:example_answer].present?
           example_answer = Annotation.new({question_id: @question.id, org_id: current_user.org_id, text: params[:example_answer], type: Annotation.types[:example_answer]})
           example_answer.save
@@ -37,7 +35,7 @@ class QuestionsController < ApplicationController
 
         flash[:alert] = failed_create_error(@question, _('question'))
         if @phase.template.customization_of.present?
-          @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+          @original_org = Template.where(family_id: @phase.template.customization_of).first.org
         else
           @original_org = @phase.template.org
         end
@@ -90,9 +88,6 @@ class QuestionsController < ApplicationController
     attrs[:theme_ids] = [] unless attrs[:theme_ids]
     
     if @question.update_attributes(attrs)
-      @phase.template.dirty = true
-      @phase.template.save!
-
       redirect_to admin_show_phase_path(id: @phase.id, section_id: @section.id, question_id: @question.id, r: current_tab), notice: success_message(_('question'), _('saved'))
     else
       @edit = (@phase.template.org == current_user.org)
@@ -103,7 +98,7 @@ class QuestionsController < ApplicationController
 
       flash[:alert] = failed_update_error(@question, _('question'))
       if @phase.template.customization_of.present?
-        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+        @original_org = Template.where(family_id: @phase.template.customization_of).first.org
       else
         @original_org = @phase.template.org
       end
@@ -119,9 +114,6 @@ class QuestionsController < ApplicationController
     @phase = @section.phase
     current_tab = params[:r] || 'all-templates'
     if @question.destroy
-      @phase.template.dirty = true
-      @phase.template.save!
-
       redirect_to admin_show_phase_path(id: @phase.id, section_id: @section.id, r: current_tab), notice: success_message(_('question'), _('deleted'))
     else
       redirect_to admin_show_phase_path(id: @phase.id, section_id: @section.id, r: current_tab), alert: failed_destroy_error(@question, 'question')

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -11,9 +11,6 @@ class SectionsController < ApplicationController
     @phase = @section.phase
     current_tab = params[:r] || 'all-templates'
     if @section.save
-      @section.phase.template.dirty = true
-      @section.phase.template.save!
-
       redirect_to admin_show_phase_path(id: @section.phase_id, r: current_tab,
         :section_id => @section.id), notice: success_message(_('section'), _('created'))
     else
@@ -24,7 +21,7 @@ class SectionsController < ApplicationController
       @question_id = nil
       flash[:alert] = failed_create_error(@section, _('section'))
       if @phase.template.customization_of.present?
-        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+        @original_org = Template.where(family_id: @phase.template.customization_of).first.org
       else
         @original_org = @phase.template.org
       end
@@ -41,9 +38,6 @@ class SectionsController < ApplicationController
     @phase = @section.phase
     current_tab = params[:r] || 'all-templates'
     if @section.update_attributes(params[:section])
-      @section.phase.template.dirty = true
-      @section.phase.template.save!
-
       redirect_to admin_show_phase_path(id: @phase.id, section_id: @section.id, r: current_tab), notice: success_message(_('section'), _('saved'))
     else
       @edit = (@phase.template.org == current_user.org)
@@ -53,7 +47,7 @@ class SectionsController < ApplicationController
       @question_id = nil
       flash[:alert] = failed_update_error(@section, _('section'))
       if @phase.template.customization_of.present?
-        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+        @original_org = Template.where(family_id: @phase.template.customization_of).first.org
       else
         @original_org = @phase.template.org
       end
@@ -69,8 +63,6 @@ class SectionsController < ApplicationController
     @phase = @section.phase
     current_tab = params[:r] || 'all-templates'
     if @section.destroy
-      @phase.template.dirty = true
-      @phase.template.save!
       redirect_to admin_show_phase_path(id: @phase.id, r: current_tab), notice: success_message(_('section'), _('deleted'))
     else
       @edit = (@phase.template.org == current_user.org)
@@ -81,7 +73,7 @@ class SectionsController < ApplicationController
 
       flash[:alert] = failed_destroy_error(@section, _('section'))
       if @phase.template.customization_of.present?
-        @original_org = Template.where(dmptemplate_id: @phase.template.customization_of).first.org
+        @original_org = Template.where(family_id: @phase.template.customization_of).first.org
       else
         @original_org = @phase.template.org
       end

--- a/app/dashboards/template_dashboard.rb
+++ b/app/dashboards/template_dashboard.rb
@@ -14,7 +14,7 @@ class TemplateDashboard < Administrate::BaseDashboard
     sections: Field::HasMany,
     questions: Field::HasMany,
     customizations: Field::HasMany.with_options(class_name: "Template"),
-    dmptemplate: Field::BelongsTo.with_options(class_name: "Template"),
+    family: Field::BelongsTo.with_options(class_name: "Template"),
     setting_objects: Field::HasMany.with_options(class_name: "Settings::Template"),
     id: Field::Number,
     title: Field::String,
@@ -27,9 +27,8 @@ class TemplateDashboard < Administrate::BaseDashboard
     version: Field::Number,
     visibility: Field::Number,
     customization_of: Field::Number,
-    dmptemplate_id: Field::Number,
-    migrated: Field::Boolean,
-    dirty: Field::Boolean,
+    family_id: Field::Number,
+    archived: Field::Boolean,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -55,7 +54,7 @@ class TemplateDashboard < Administrate::BaseDashboard
     :sections,
     :questions,
     :customizations,
-    :dmptemplate,
+    :family,
     :setting_objects,
     :id,
     :title,
@@ -68,9 +67,8 @@ class TemplateDashboard < Administrate::BaseDashboard
     :version,
     :visibility,
     :customization_of,
-    :dmptemplate_id,
-    :migrated,
-    :dirty,
+    :family_id,
+    :archived,
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -83,7 +81,7 @@ class TemplateDashboard < Administrate::BaseDashboard
     :sections,
     :questions,
     :customizations,
-    :dmptemplate,
+    :family,
     :setting_objects,
     :title,
     :description,
@@ -93,9 +91,8 @@ class TemplateDashboard < Administrate::BaseDashboard
     :version,
     :visibility,
     :customization_of,
-    :dmptemplate_id,
-    :migrated,
-    :dirty,
+    :family_id,
+    :archived,
   ].freeze
 
   # Overwrite this method to customize how templates are displayed

--- a/app/models/guidance.rb
+++ b/app/models/guidance.rb
@@ -54,7 +54,7 @@ class Guidance < ActiveRecord::Base
   # returns all templates belgonging to a specified guidance group
   #
   # @param guidance_group [Integer] the integer id for an guidance_group
-  # @return [Array<Dmptemplates>] list of templates
+  # @return [Array<Templates>] list of templates
 	def get_guidance_group_templates? (guidance_group)
     # DISCUSS - here we have yet another way of finding a specific or group of
     # an object.  Would it make sense to standardise the project by only using

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -126,7 +126,7 @@ class Org < ActiveRecord::Base
   ##
   # returns all published templates belonging to the organisation
   #
-  # @return [Array<Dmptemplate>] published dmptemplates
+  # @return [Array<Template>] published templates
 	def published_templates
 		return templates.where("published = ?", true)
 	end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -97,7 +97,6 @@ class Plan < ActiveRecord::Base
   def settings(key)
     self_settings = self.super_settings(key)
     return self_settings if self_settings.value?
-#    self.dmptemplate.settings(key)
     self.template.settings(key) unless self.template.nil?
   end
 
@@ -116,7 +115,7 @@ class Plan < ActiveRecord::Base
     base = nil
     t = self.template
     if t.customization_of.present?
-      base = Template.where("dmptemplate_id = ? and created_at < ?", t.customization_of, self.created_at).order(version: :desc).first
+      base = Template.where("family_id = ? and created_at < ?", t.customization_of, self.created_at).order(version: :desc).first
     end
     return base
   end
@@ -864,12 +863,12 @@ class Plan < ActiveRecord::Base
   end
 
   ##
-  # creates a plan for each phase in the dmptemplate associated with this project
+  # creates a plan for each phase in the template associated with this project
   # unless the phase is unpublished, it creates a new plan, and a new version of the plan and adds them to the project's plans
   #
   # @return [Array<Plan>]
   def create_plans
-    dmptemplate.phases.each do |phase|
+    self.template.phases.each do |phase|
       latest_published_version = phase.latest_published_version
       unless latest_published_version.nil?
         new_plan = Plan.new
@@ -899,7 +898,7 @@ class Plan < ActiveRecord::Base
 
     margin_height    = @formatting[:margin][:top].to_i + @formatting[:margin][:bottom].to_i
     page_height      = A4_PAGE_HEIGHT - margin_height # 297mm for A4 portrait
-    available_height = page_height * self.dmptemplate.settings(:export).max_pages
+    available_height = page_height * self.template.settings(:export).max_pages
 
     percentage = (used_height / available_height) * 100
     (percentage / ROUNDING).ceil * ROUNDING # round up to nearest five
@@ -934,7 +933,7 @@ class Plan < ActiveRecord::Base
     (num_lines * font_height) + vertical_margin + leading
   end
 
-  # Initialize the title and dirty flags for new templates
+  # Initialize the title for new templates
   # --------------------------------------------------------
   def set_creation_defaults
     # Only run this before_validation because rails fires this before save/create

--- a/app/views/api/v0/plans/show.json.jbuilder
+++ b/app/views/api/v0/plans/show.json.jbuilder
@@ -8,6 +8,5 @@ json.project do
   json.created_by @project.owner.email
   json.id         @project.id
   json.created_at @project.created_at
-  #json.template   @project.dmptemplate
-  json.dmptemplate @project.dmptemplate.title
+  json.template @project.template.title
 end

--- a/app/views/api/v0/statistics/plans.json.jbuilder
+++ b/app/views/api/v0/statistics/plans.json.jbuilder
@@ -6,7 +6,7 @@ json.plans @org_plans.each do |plan|
   json.title          plan.title
   json.template do
     json.title        plan.template.title
-    json.id           plan.template.dmptemplate_id
+    json.id           plan.template.family_id
   end
   json.funder do
     json.name         (plan.template.org.funder? ? plan.template.org.name : '')

--- a/app/views/api/v0/templates/index.json.jbuilder
+++ b/app/views/api/v0/templates/index.json.jbuilder
@@ -1,4 +1,4 @@
-# builds a json response to api query for a list of all dmptemplates
+# builds a json response to api query for a list of all templates
 json.prettify!
 
 json.templates @org_templates.each do |org, templates|
@@ -7,12 +7,12 @@ json.templates @org_templates.each do |org, templates|
   json.is_funder            org.funder?
   json.organisation_templates templates[:own].each do |_, template|
     json.title              template.title
-    json.id                 template.dmptemplate_id
+    json.id                 template.family_id
     json.description        template.description
   end
   json.customized_templates  templates[:cust].each do |_,template|
     json.title              template.title
-    json.id                 template.dmptemplate_id
+    json.id                 template.family_id
     json.customization_of   template.customization_of
     json.description        template.description
   end

--- a/app/views/org_admin/templates/_edit_template.html.erb
+++ b/app/views/org_admin/templates/_edit_template.html.erb
@@ -31,8 +31,9 @@
       <p class="form-control-static">
         <% if template_hash[:live].nil? %>
           <%= _('Unpublished') %>
-        <% elsif template_hash[:current].dirty? %>
-          <%= _('You have unpublished changes') %>
+        <%# Leaving this line here as a placeholder for determining how to notify user of changes now that dirty flag is removed %>
+        <%# elsif template_hash[:current].dirty? %>
+          <%# _('You have unpublished changes') %>
         <% else %>
           <%= _('Published') %>
         <% end %>

--- a/app/views/org_admin/templates/_show_template.html.erb
+++ b/app/views/org_admin/templates/_show_template.html.erb
@@ -11,8 +11,9 @@
     <% if template_hash[:live].nil? %>
       <%= _('Unpublished') %>
     
-    <% elsif template_hash[:current].dirty? %>
-      <%= _('You have unpublished changes') %>
+    <%# Leaving this line here as a placeholder for determining how to notify user of changes now that dirty flag is removed %>
+    <%# elsif template_hash[:current].dirty? %>
+      <%# _('You have unpublished changes') %>
     
     <% else %>
       <%= _('Published') %>

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -15,7 +15,7 @@
           <td><%= org.name %></td>
           <td><%= org.contact_email %></td>
           <td><%= org.org_type_to_s %></td>
-          <td><%= org.templates.collect(&:dmptemplate_id).uniq.length %></td>
+          <td><%= org.templates.collect(&:family_id).uniq.length %></td>
           <td>
             <div class="dropdown">
               <button

--- a/app/views/paginable/templates/_all.html.erb
+++ b/app/views/paginable/templates/_all.html.erb
@@ -6,7 +6,7 @@
       <% if scopes.present? %>
         <tr><th colspan="4" class="sorter-false table-scope"><ul class="nav navbar-nav">
           <% scopes.keys.each do |k| %>
-            <% unless k == :dmptemplate_ids %>
+            <% unless k == :family_ids %>
               <li><%= link_to "#{k.capitalize} (#{scopes[k]})", 
                               "#{all_paginable_templates_path(1)}?scope=#{k}", 
                               class: 'template-scope', 'data-remote': true %></li>
@@ -31,9 +31,11 @@
             <%= template.org.name %>
           </td>
           <td>
-            <% if template.dirty? %>
-              <%= _('Unpublished changes') %>
-            <% elsif template.published? %>
+            <%# Leaving this line here as a placeholder for determining how to notify user of changes now that dirty flag is removed %>
+            <%# if template.dirty? %>
+              <%# _('Unpublished changes') %>
+
+            <% if template.published? %>
               <%= _('Published') %>
             <% else %>
               <%= _('Unpublished') %>

--- a/app/views/paginable/templates/_funders.html.erb
+++ b/app/views/paginable/templates/_funders.html.erb
@@ -6,7 +6,7 @@
       <% if scopes.present? %>
         <tr><th colspan="5" class="sorter-false table-scope"><ul class="nav navbar-nav">
           <% scopes.keys.each do |k| %>
-            <% unless k == :dmptemplate_ids %>
+            <% unless k == :family_ids %>
               <% label = (['published', 'unpublished'].include?(k.to_s) ? _('Customization %{publication_status}') % { publication_status: k } : k.capitalize) %>
               <li><%= link_to "#{label} (#{scopes[k]})", "#{funders_paginable_templates_path(1)}?scope=#{k}", class: 'template-scope', 'data-remote': true %></li>
             <% end %>
@@ -23,7 +23,7 @@
     </thead>
     <tbody>
     <% scope.each do |template| %>
-      <% customization = customizations[template.dmptemplate_id] %>
+      <% customization = customizations[template.family_id] %>
       <tr>
         <td>
           <%= "#{template.is_default? ? '* ' : ''}#{template.title}" %>
@@ -39,8 +39,11 @@
               <% elsif !template.published? %>
                 <!-- The template does not have a live version -->
                 <%= b_label = _('Funder version is unpublished') %>
-              <% elsif customization.dirty? %>
-                <%= _('You have unpublished changes') %>
+
+              <%# Leaving this line here as a placeholder for determining how to notify user of changes now that dirty flag is removed %>
+              <%# elsif customization.dirty? %>
+                <%# _('You have unpublished changes') %>
+
               <% elsif customization.published? %>
                 <%= _('Published') %>
               <% else %>

--- a/app/views/paginable/templates/_orgs.html.erb
+++ b/app/views/paginable/templates/_orgs.html.erb
@@ -6,7 +6,7 @@
       <% if scopes.present? %>
         <tr><th colspan="5" class="sorter-false table-scope"><ul class="nav navbar-nav">
           <% scopes.keys.each do |k| %>
-            <% unless k == :dmptemplate_ids %>
+            <% unless k == :family_ids %>
               <li><%= link_to "#{k.capitalize} (#{scopes[k]})", "#{orgs_paginable_templates_path(1)}?scope=#{k}", class: 'template-scope', 'data-remote': true %></li>
             <% end %>
           <% end %>
@@ -30,7 +30,7 @@
             <%= raw(template.description) %>
           </td>
           <td>
-            <% if published[template.dmptemplate_id].present? && !template.published? %>
+            <% if published[template.family_id].present? && !template.published? %>
               <%= _('Unpublished changes') %>
             <% elsif template.published? %>
               <%= _('Published') %>
@@ -55,7 +55,7 @@
               <ul class="dropdown-menu">
                 <li><%= link_to _('Edit'), edit_org_admin_template_path(id: template.id, edit: "true", r: 'organisation-templates') %></li>
                 <li><%= link_to _('History'), history_org_admin_template_path(id: template.id, r: 'organisation-templates') %></li>
-                <% if !published[template.dmptemplate_id].present? %>
+                <% if !published[template.family_id].present? %>
                   <li><%= link_to _('Publish'), publish_org_admin_template_path(template, r: 'organisation-templates') %></li>
                 <% elsif !template.published? %>
                   <li><%= link_to _('Publish changes'), publish_org_admin_template_path(template, r: 'organisation-templates') %></li>

--- a/app/views/paginable/templates/_publicly_visible.html.erb
+++ b/app/views/paginable/templates/_publicly_visible.html.erb
@@ -15,8 +15,8 @@
         <tr>
           <td><%= template.title %></td>
           <td class="text-center">
-            <%= link_to _('DOCX'), template_export_path(template.dmptemplate_id, format: :docx), target: '_blank' %><br>
-            <%= link_to _('PDF'), template_export_path(template.dmptemplate_id, format: :pdf), target: '_blank' %>
+            <%= link_to _('DOCX'), template_export_path(template.family_id, format: :docx), target: '_blank' %><br>
+            <%= link_to _('PDF'), template_export_path(template.family_id, format: :pdf), target: '_blank' %>
           </td>
           <td><%= template.org.name %></td>
           <td><%= l(template.updated_at.to_date, formats: :short) %></td>

--- a/db/migrate/20180405151713_rename_template_fields.rb
+++ b/db/migrate/20180405151713_rename_template_fields.rb
@@ -1,0 +1,11 @@
+class RenameTemplateFields < ActiveRecord::Migration
+  def up
+    rename_column :templates, :migrated, :archived
+    rename_column :templates, :dmptemplate_id, :family_id
+  end
+  
+  def down
+    rename_column :templates, :archived, :migrated
+    rename_column :templates, :family_id, :dmptemplate_id
+  end
+end

--- a/db/migrate/20180405151942_remove_dirty_from_templates.rb
+++ b/db/migrate/20180405151942_remove_dirty_from_templates.rb
@@ -1,0 +1,9 @@
+class RemoveDirtyFromTemplates < ActiveRecord::Migration
+  def up
+    remove_column :templates, :dirty
+  end
+  
+  def down
+    add_column :templates, :dirty, :boolean, default: false
+  end
+end

--- a/db/migrate/20180405152454_add_family_id_index_to_templates.rb
+++ b/db/migrate/20180405152454_add_family_id_index_to_templates.rb
@@ -1,0 +1,9 @@
+class AddFamilyIdIndexToTemplates < ActiveRecord::Migration
+  def up
+    add_index :templates, :family_id
+  end
+
+  def down
+    remove_index :templates, :family_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180315161757) do
+ActiveRecord::Schema.define(version: 20180405152454) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
+  
   create_table "annotations", force: :cascade do |t|
     t.integer  "question_id"
     t.integer  "org_id"
@@ -339,13 +339,13 @@ ActiveRecord::Schema.define(version: 20180315161757) do
     t.integer  "version"
     t.integer  "visibility"
     t.integer  "customization_of"
-    t.integer  "dmptemplate_id"
-    t.boolean  "migrated"
-    t.boolean  "dirty",            default: false
+    t.integer  "family_id"
+    t.boolean  "archived"
     t.text     "links",            default: "{\"funder\":[], \"sample_plan\":[]}"
   end
 
-  add_index "templates", ["org_id", "dmptemplate_id"], name: "template_organisation_dmptemplate_index"
+  add_index "templates", ["family_id"], name: "index_templates_on_family_id"
+  add_index "templates", ["org_id", "family_id"], name: "template_organisation_dmptemplate_index"
   add_index "templates", ["org_id"], name: "index_templates_on_org_id"
 
   create_table "themes", force: :cascade do |t|
@@ -384,11 +384,11 @@ ActiveRecord::Schema.define(version: 20180315161757) do
   create_table "users", force: :cascade do |t|
     t.string   "firstname"
     t.string   "surname"
-    t.string   "email",                  default: "", null: false
+    t.string   "email",                  default: "",   null: false
     t.string   "orcid_id"
     t.string   "shibboleth_id"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "encrypted_password",     default: ""
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/lib/template_filter.rb
+++ b/lib/template_filter.rb
@@ -12,7 +12,7 @@ module TemplateFilter
       # If the user is an Org Admin look for customizations to funder templates
       customizations = {}
       if current_user.can_org_admin?
-        families = templates.collect(&:dmptemplate_id).uniq
+        families = templates.collect(&:family_id).uniq
         Template.org_customizations(families, current_user.org_id).each do |customization|
           customizations[customization.customization_of] = customization if customization.present?
         end
@@ -23,7 +23,7 @@ module TemplateFilter
       # We scope based on the customizations
       if params[:scope].present? && params[:scope] != 'all'
         scoped = templates.select do |t| 
-          c = customizations[t.dmptemplate_id]
+          c = customizations[t.family_id]
           (params[:scope] == 'unpublished' && (!c.present? || !c.published?)) || (params[:scope] == 'published' && c.present? && c.published?)
         end
         templates = Template.where(id: scoped.collect(&:id))
@@ -53,11 +53,11 @@ module TemplateFilter
   private
     # Gets the nbr of templates and nbr of published/unpublished templates
     def calculate_table_scopes(templates, customizations)
-      scopes = { all: templates.length, published: 0, unpublished: 0, dmptemplate_ids: templates.collect(&:dmptemplate_id).uniq }
+      scopes = { all: templates.length, published: 0, unpublished: 0, family_ids: templates.collect(&:family_id).uniq }
       templates.each do |t|
         # If we have customizations use their status
         if customizations.keys.length > 0
-          c = customizations[t.dmptemplate_id]
+          c = customizations[t.family_id]
           # If the template was not customized then its unpublished
           if c.nil?
             scopes[:unpublished] += 1
@@ -78,7 +78,7 @@ module TemplateFilter
       published = {}
       lives = Template.live(family_ids)
       lives.each do |live|
-        published[live.dmptemplate_id] = live.updated_at
+        published[live.family_id] = live.updated_at
       end
       published
     end

--- a/test/functional/org_admin/templates_controller_test.rb
+++ b/test/functional/org_admin/templates_controller_test.rb
@@ -168,7 +168,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     id = @template.id
     sign_in @user
 
-    family = @template.dmptemplate_id
+    family = @template.family_id
     prior = Template.current(family)
 
     version_the_template
@@ -237,7 +237,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     params = {title: 'ABCD'}
     sign_in @user
 
-    family = @template.dmptemplate_id
+    family = @template.family_id
     prior = Template.current(family)
 
     version_the_template
@@ -287,11 +287,11 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     # Sign in as the regular user so we can customize the funder template
     sign_in @user
 
-    template = Template.live(funder_template.dmptemplate_id)
+    template = Template.live(funder_template.family_id)
 
     get customize_org_admin_template_path(template)
 
-    customization = Template.where(customization_of: template.dmptemplate_id).last
+    customization = Template.where(customization_of: template.family_id).last
 
     assert_response :redirect
     assert_redirected_to edit_org_admin_template_url(Template.last, r: 'funder-templates')
@@ -299,7 +299,6 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 0, customization.version
     assert_not customization.published?
-    assert customization.dirty?
 
     # Make sure the funder templates data is not modifiable!
     customization.phases.each do |p|
@@ -326,7 +325,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
   test "publish a template" do
     sign_in @user
 
-    family = @template.dmptemplate_id
+    family = @template.family_id
     prior = Template.current(family)
 
     version_the_template
@@ -360,7 +359,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
   test "unpublish a template" do
     sign_in @user
 
-    family = @template.dmptemplate_id
+    family = @template.family_id
 
     prior = Template.current(family)
 
@@ -428,38 +427,38 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     institution_org = Org.find_by(org_type: 1)
     other_org = Org.create!(name: 'Another Org', abbreviation: 'BLAH', org_type: 3, links: {"org":[]})
     
-    params = [{ title: 'Default template', org: default_org, migrated: false, dmptemplate_id: '00000100', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: true },
-              { title: 'UOS published A', org: institution_org, migrated: false, dmptemplate_id: '00000099', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'UOS published B', org: institution_org, migrated: false, dmptemplate_id: '00000098', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'UOS unpublished C', org: institution_org, migrated: false, dmptemplate_id: '00000097', published: false, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'UOS unpublished Dv0', org: institution_org, migrated: false, dmptemplate_id: '00000096', published: false, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'UOS published Dv1', org: institution_org, migrated: false, dmptemplate_id: '00000096', published: true, version: 1, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'UOS published Ev0', org: institution_org, migrated: false, dmptemplate_id: '00000095', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'UOS unpublished Ev1', org: institution_org, migrated: false, dmptemplate_id: '00000095', published: false, version: 1, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'BLAH internal published A', org: other_org, migrated: false, dmptemplate_id: '00000079', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'BLAH public published B', org: other_org, migrated: false, dmptemplate_id: '00000078', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
-              { title: 'Funder public published A', org: funder_org, migrated: false, dmptemplate_id: '00000089', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
-              { title: 'Funder internal published B', org: funder_org, migrated: false, dmptemplate_id: '00000088', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'Funder internal unpublished B', org: funder_org, migrated: false, dmptemplate_id: '00000088', published: false, version: 1, visibility: Template.visibilities[:organisationally_visible], is_default: false },
-              { title: 'Funder public unpublished C', org: funder_org, migrated: false, dmptemplate_id: '00000087', published: false, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
-              { title: 'Funder public unpublished Dv0', org: funder_org, migrated: false, dmptemplate_id: '00000086', published: false, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
-              { title: 'Funder public published Dv1', org: funder_org, migrated: false, dmptemplate_id: '00000086', published: true, version: 1, visibility: Template.visibilities[:publicly_visible], is_default: false },
-              { title: 'Funder public published Ev0', org: funder_org, migrated: false, dmptemplate_id: '00000085', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
-              { title: 'Funder public unpublished Ev1', org: funder_org, migrated: false, dmptemplate_id: '00000085', published: false, version: 1, visibility: Template.visibilities[:publicly_visible], is_default: false }]
+    params = [{ title: 'Default template', org: default_org, archived: false, family_id: '00000100', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: true },
+              { title: 'UOS published A', org: institution_org, archived: false, family_id: '00000099', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'UOS published B', org: institution_org, archived: false, family_id: '00000098', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'UOS unpublished C', org: institution_org, archived: false, family_id: '00000097', published: false, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'UOS unpublished Dv0', org: institution_org, archived: false, family_id: '00000096', published: false, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'UOS published Dv1', org: institution_org, archived: false, family_id: '00000096', published: true, version: 1, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'UOS published Ev0', org: institution_org, archived: false, family_id: '00000095', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'UOS unpublished Ev1', org: institution_org, archived: false, family_id: '00000095', published: false, version: 1, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'BLAH internal published A', org: other_org, archived: false, family_id: '00000079', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'BLAH public published B', org: other_org, archived: false, family_id: '00000078', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
+              { title: 'Funder public published A', org: funder_org, archived: false, family_id: '00000089', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
+              { title: 'Funder internal published B', org: funder_org, archived: false, family_id: '00000088', published: true, version: 0, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'Funder internal unpublished B', org: funder_org, archived: false, family_id: '00000088', published: false, version: 1, visibility: Template.visibilities[:organisationally_visible], is_default: false },
+              { title: 'Funder public unpublished C', org: funder_org, archived: false, family_id: '00000087', published: false, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
+              { title: 'Funder public unpublished Dv0', org: funder_org, archived: false, family_id: '00000086', published: false, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
+              { title: 'Funder public published Dv1', org: funder_org, archived: false, family_id: '00000086', published: true, version: 1, visibility: Template.visibilities[:publicly_visible], is_default: false },
+              { title: 'Funder public published Ev0', org: funder_org, archived: false, family_id: '00000085', published: true, version: 0, visibility: Template.visibilities[:publicly_visible], is_default: false },
+              { title: 'Funder public unpublished Ev1', org: funder_org, archived: false, family_id: '00000085', published: false, version: 1, visibility: Template.visibilities[:publicly_visible], is_default: false }]
     
     params.each do |hash|
       begin
         template = Template.new(hash)
         template.save!
         # Template's have default values when created, so override those defaults
-        template.update_attributes!(published: hash[:published], visibility: hash[:visibility], is_default: hash[:is_default], dmptemplate_id: hash[:dmptemplate_id])
+        template.update_attributes!(published: hash[:published], visibility: hash[:visibility], is_default: hash[:is_default], family_id: hash[:family_id])
         
         if template.is_default?
-          cust = Template.create!({ title: 'UOS customization of Default template', org: institution_org, migrated: false, version: 0})
-          cust.update_attributes(published: true, customization_of: template.dmptemplate_id, visibility: Template.visibilities[:organisationally_visible])
+          cust = Template.create!({ title: 'UOS customization of Default template', org: institution_org, archived: false, version: 0})
+          cust.update_attributes(published: true, customization_of: template.family_id, visibility: Template.visibilities[:organisationally_visible])
         elsif template.title == 'Funder public published A'
-          cust = Template.create!({ title: 'UOS customization of Funder public published A', org: institution_org, migrated: false, version: 0})
-          cust.update_attributes(published: false, customization_of: template.dmptemplate_id, visibility: Template.visibilities[:organisationally_visible])
+          cust = Template.create!({ title: 'UOS customization of Funder public published A', org: institution_org, archived: false, version: 0})
+          cust.update_attributes(published: false, customization_of: template.family_id, visibility: Template.visibilities[:organisationally_visible])
         end
       rescue ActiveRecord::RecordInvalid
         puts "EXCEPTION: #{template.errors.collect{ |e, m| "#{e}: #{m}" }.join(', ')}"
@@ -484,7 +483,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
         # An Org Admin (for a non-funder Org) should only see their current templates in the own templates table
         templates.each do |template|
           # Expect to see the most current version of organisational templates
-          current = Template.current(template.dmptemplate_id)
+          current = Template.current(template.family_id)
           if template == current
             assert el.to_s.include?(template.title), "expected #{user.email}'s own templates table to have the institutional template: '#{template.title}'"
           else

--- a/test/functional/phases_controller_test.rb
+++ b/test/functional/phases_controller_test.rb
@@ -141,10 +141,7 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "create a phase " do
     params = {template_id: @template.id, title: 'Phase: Tester 2', number: 2}
-    
-    @template.dirty = false
-    @template.save!
-    
+        
     # Should redirect user to the root path if they are not logged in!
     post admin_create_phase_path(@template.phases.first), {phase: params}
     assert_unauthorized_redirect_to_root_path
@@ -157,10 +154,7 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_show_phase_path(id: Phase.last.id, r: 'all-templates')
     assert assigns(:phase)
     assert_equal 'Phase: Tester 2', Phase.last.title, "expected the record to have been created!"
-    
-    # Make sure that the template's dirty flag got set
-    assert @template.reload.dirty?, "expected the templates dirty flag to be true"
-    
+        
     # Invalid object
     post admin_create_phase_path(@template.phases.first), {phase: {template_id: @template.id}}
     assert flash[:alert].starts_with?(_('Could not create your'))
@@ -173,9 +167,6 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "update the phase" do
     params = {title: 'Phase - UPDATE'}
-    
-    @template.dirty = false
-    @template.save!
     
     # Should redirect user to the root path if they are not logged in!
     put admin_update_phase_path(@template.phases.first), {phase: params}
@@ -190,10 +181,7 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_show_phase_url(@template.phases.first, r: 'all-templates')
     assert assigns(:phase)
     assert_equal 'Phase - UPDATE', @template.phases.first.title, "expected the record to have been updated"
-    
-    # Make sure that the template's dirty flag got set
-    assert @template.reload.dirty?, "expected the templates dirty flag to be true"
-    
+        
     # Invalid save
     put admin_update_phase_path(@template.phases.first), {phase: {title: nil}}
     assert flash[:alert].starts_with?(_('Could not update your'))
@@ -209,9 +197,6 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
   test "delete the phase" do
     id = @template.phases.first.id
     
-    @template.dirty = false
-    @template.save!
-    
     # Should redirect user to the root path if they are not logged in!
     # TODO: Why are we not just using id: here? shouldn't need to specify the key
     delete admin_destroy_phase_path(id: @template.phases.first.id, phase_id: id)
@@ -226,9 +211,5 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
     assert_raise ActiveRecord::RecordNotFound do 
       Phase.find(id).nil?
     end
-    
-    # Make sure that the template's dirty flag got set
-    assert @template.reload.dirty?, "expected the templates dirty flag to be true"
   end
-
 end

--- a/test/functional/public_pages_controller_test.rb
+++ b/test/functional/public_pages_controller_test.rb
@@ -17,9 +17,9 @@ class PublicPagesControllerTest < ActionDispatch::IntegrationTest
                                        roles: [Role.new(user: User.last, creator: true)])
     end
 
-    @inst_tmplt = Template.create!(title: 'Inst template', org: Org.institution.first, migrated: false, published: true)
-    @dflt_tmplt = Template.create!(title: 'Dflt template', org: Org.managing_orgs.first, migrated: false, published: true)
-    @fndr_tmplt = Template.create!(title: 'Fndr template', org: Org.funder.first, migrated: false, published: true)
+    @inst_tmplt = Template.create!(title: 'Inst template', org: Org.institution.first, archived: false, published: true)
+    @dflt_tmplt = Template.create!(title: 'Dflt template', org: Org.managing_orgs.first, archived: false, published: true)
+    @fndr_tmplt = Template.create!(title: 'Fndr template', org: Org.funder.first, archived: false, published: true)
 
     [@inst_tmplt, @dflt_tmplt, @fndr_tmplt].each do |t|
       t.published = true
@@ -77,31 +77,31 @@ class PublicPagesControllerTest < ActionDispatch::IntegrationTest
     get public_templates_path
     assert_response :success
     assert assigns(:templates)
-    assert @response.body.include?(template_export_path(@fndr_tmplt.dmptemplate_id)), "expected to see the funder template download link when NOT logged in"
-    assert @response.body.include?(template_export_path(@dflt_tmplt.dmptemplate_id)), "expected to see the default template download link when NOT logged in"
-    assert_not @response.body.include?(template_export_path(@inst_tmplt.dmptemplate_id)), "expected to NOT see the institution template download link when NOT logged in"
+    assert @response.body.include?(template_export_path(@fndr_tmplt.family_id)), "expected to see the funder template download link when NOT logged in"
+    assert @response.body.include?(template_export_path(@dflt_tmplt.family_id)), "expected to see the default template download link when NOT logged in"
+    assert_not @response.body.include?(template_export_path(@inst_tmplt.family_id)), "expected to NOT see the institution template download link when NOT logged in"
 
     # Verify the same results are received when the user is logged in
     sign_in @user
     get public_templates_path
     assert_response :success
     assert assigns(:templates)
-    assert @response.body.include?(template_export_path(@fndr_tmplt.dmptemplate_id)), "expected to see the funder template download link when NOT logged in"
-    assert @response.body.include?(template_export_path(@dflt_tmplt.dmptemplate_id)), "expected to see the default template download link when NOT logged in"
-    assert_not @response.body.include?(template_export_path(@inst_tmplt.dmptemplate_id)), "expected to NOT see the institution template download link when NOT logged in"
+    assert @response.body.include?(template_export_path(@fndr_tmplt.family_id)), "expected to see the funder template download link when NOT logged in"
+    assert @response.body.include?(template_export_path(@dflt_tmplt.family_id)), "expected to see the default template download link when NOT logged in"
+    assert_not @response.body.include?(template_export_path(@inst_tmplt.family_id)), "expected to NOT see the institution template download link when NOT logged in"
   end
   
 # TODO: Need to install the wkhtmltopdf library on Travis for this to work!
-  # GET /template_export/:dmptemplate_id (template_export_path)
+  # GET /template_export/:family_id (template_export_path)
   # ----------------------------------------------------------
   test 'export a public template' do
-#    get template_export_path(@fndr_tmplt.dmptemplate_id, format: :pdf)
+#    get template_export_path(@fndr_tmplt.family_id, format: :pdf)
 #    assert_response :success
 
-#    get template_export_path(@dflt_tmplt.dmptemplate_id, format: :pdf)
+#    get template_export_path(@dflt_tmplt.family_id, format: :pdf)
 #    assert_response :success
 
-#    get template_export_path(@inst_tmplt.dmptemplate_id, format: :pdf)
+#    get template_export_path(@inst_tmplt.family_id, format: :pdf)
 #    assert_response :redirect
 #    assert_equal "You need to sign in or sign up before continuing.", flash[:alert]
 #    assert_redirected_to root_path

--- a/test/functional/questions_controller_test.rb
+++ b/test/functional/questions_controller_test.rb
@@ -39,9 +39,6 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   # ----------------------------------------------------------
   test "create a new question" do
     params = {section_id: @section.id, text: 'Test Question', number: 9, question_format_id: @question_format.id}
-
-    @section.phase.template.dirty = false
-    @section.phase.template.save!
     
     # Should redirect user to the root path if they are not logged in!
     post admin_create_question_path(@section), {question: params}
@@ -59,9 +56,6 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_show_phase_url(id: @section.phase.id, section_id: @section.id, question_id: Question.last.id, r: 'all-templates')
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('created')
     assert_equal 'Test Question', Question.last.text, "expected the record to have been created!"
-    
-    # Make sure that the template's dirty flag got set
-    assert @section.phase.template.reload.dirty?, "expected the templates dirty flag to be true"
     
     # Invalid object
     post admin_create_question_path(@section), {question: {section_id: @section.id, text: nil, question_format_id: @question_format.id}}
@@ -81,9 +75,6 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   test "update the question" do
     params = {text: 'Question - UPDATE'}
     
-    @section.phase.template.dirty = false
-    @section.phase.template.save!
-    
     # Should redirect user to the root path if they are not logged in!
     put admin_update_question_path(@section.questions.first), {question: params}
     assert_unauthorized_redirect_to_root_path
@@ -99,9 +90,6 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     assert assigns(:section)
     assert assigns(:question)
     assert_equal 'Question - UPDATE', @section.questions.first.text, "expected the record to have been updated"
-    
-    # Make sure that the template's dirty flag got set
-    assert @section.phase.template.reload.dirty?, "expected the templates dirty flag to be true"
     
     # Invalid save
     put admin_update_question_path(@section.questions.first), {question: {text: nil}}
@@ -122,9 +110,6 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   test "delete the question" do
     id = @section.questions.first.id
     
-    @section.phase.template.dirty = false
-    @section.phase.template.save!
-    
     # Should redirect user to the root path if they are not logged in!
     delete admin_destroy_question_path(id: @section.id, question_id: id)
     assert_unauthorized_redirect_to_root_path
@@ -142,8 +127,5 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
       Question.find(id).nil?
     end
     
-    # Make sure that the template's dirty flag got set
-    assert @section.phase.template.reload.dirty?, "expected the templates dirty flag to be true"
   end
-  
 end

--- a/test/functional/sections_controller_test.rb
+++ b/test/functional/sections_controller_test.rb
@@ -39,9 +39,6 @@ class SectionsControllerTest < ActionDispatch::IntegrationTest
   test "create a new section" do
     params = {phase_id: @phase.id, title: 'Section Tester', number: 99}
     
-    @phase.template.dirty = false
-    @phase.template.save!
-    
     # Should redirect user to the root path if they are not logged in!
     post admin_create_section_path(@phase), {section: params}
     assert_unauthorized_redirect_to_root_path
@@ -53,9 +50,6 @@ class SectionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to admin_show_phase_url(id: @phase.id, section_id: Section.last.id, r: 'all-templates')
     assert flash[:notice].start_with?('Successfully') && flash[:notice].include?('created')
     assert_equal 'Section Tester', Section.last.title, "expected the record to have been created!"
-    
-    # Make sure that the template's dirty flag got set
-    assert @phase.template.reload.dirty?, "expected the templates dirty flag to be true"
     
     # Invalid object
     post admin_create_section_path(@phase), {section: {phase_id: @phase.id, title: nil}}
@@ -73,9 +67,6 @@ class SectionsControllerTest < ActionDispatch::IntegrationTest
   test "update the section" do
     params = {title: 'Phase - UPDATE'}
     
-    @phase.template.dirty = false
-    @phase.template.save!
-    
     # Should redirect user to the root path if they are not logged in!
     put admin_update_section_path(@phase.sections.first), {section: params}
     assert_unauthorized_redirect_to_root_path
@@ -88,9 +79,6 @@ class SectionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to admin_show_phase_url(id: @phase.id, section_id: @phase.sections.first.id, r: 'all-templates')
     assert_equal 'Phase - UPDATE', @phase.sections.first.title, "expected the record to have been updated"
-    
-    # Make sure that the template's dirty flag got set
-    assert @phase.template.reload.dirty?, "expected the templates dirty flag to be true"
     
     # Invalid save
     put admin_update_section_path(@phase.sections.first), {section: {title: nil}}
@@ -109,9 +97,6 @@ class SectionsControllerTest < ActionDispatch::IntegrationTest
   test "delete the section" do
     id = @phase.sections.first.id
     
-    @phase.template.dirty = false
-    @phase.template.save!
-    
     # Should redirect user to the root path if they are not logged in!
     delete admin_destroy_section_path(id: @phase.id, section_id: id)
     assert_unauthorized_redirect_to_root_path
@@ -127,9 +112,5 @@ class SectionsControllerTest < ActionDispatch::IntegrationTest
     assert_raise ActiveRecord::RecordNotFound do 
       Section.find(id).nil?
     end
-    
-    # Make sure that the template's dirty flag got set
-    assert @phase.template.reload.dirty?, "expected the templates dirty flag to be true"
   end
-  
 end

--- a/test/integration/template_selection_test.rb
+++ b/test/integration/template_selection_test.rb
@@ -11,14 +11,14 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     scaffold_org_admin(@template.org)
 
     @funder = Org.find_by(org_type: 2)
-    @funder_template = @funder.templates.where(published: true).first #Template.create(title: 'Funder template', org: @funder, migrated: false)
+    @funder_template = @funder.templates.where(published: true).first #Template.create(title: 'Funder template', org: @funder, archived: false)
     # Template can't be published on creation so do it afterward
     @funder_template.published = true
     @funder_template.visibility = Template.visibilities[:publicly_visible]
     @funder_template.save
 
     @org = @researcher.org
-    @org_template = Template.create(title: 'Org template', org: @org, migrated: false)
+    @org_template = Template.create(title: 'Org template', org: @org, archived: false)
     # Template can't be published on creation so do it afterward
     @org_template.published = true
     @org_template.visibility = Template.visibilities[:organisationally_visible]
@@ -38,7 +38,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, json['templates'].size
     assert_equal original_id, json['templates'][0]['id']
-    assert_equal original_id, Template.live(@template.dmptemplate_id).id
+    assert_equal original_id, Template.live(@template.family_id).id
 
     # Version the template again
     original_id = template.id
@@ -51,7 +51,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, json['templates'].size
     assert_equal original_id, json['templates'][0]['id']
-    assert_equal original_id, Template.live(@template.dmptemplate_id).id
+    assert_equal original_id, Template.live(@template.family_id).id
 
     # Update the template and make sure the published version stayed the same
     sign_in @user
@@ -65,7 +65,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, json['templates'].size
     assert_equal original_id, json['templates'][0]['id']
-    assert_equal original_id, Template.live(@template.dmptemplate_id).id
+    assert_equal original_id, Template.live(@template.family_id).id
   end
 
   # ----------------------------------------------------------
@@ -128,7 +128,7 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     # Template can't be published on creation so do it afterward
     customization.published = true
     customization.visibility = Template.visibilities[:organisationally_visible]
-    customization.customization_of = @funder_template.dmptemplate_id
+    customization.customization_of = @funder_template.family_id
     customization.save
 
     sign_in @researcher
@@ -165,6 +165,6 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     # ----------------------------------------------------------
     def version_template(template)
       get publish_org_admin_template_path(template)
-      Template.current(template.dmptemplate_id)
+      Template.current(template.family_id)
     end
 end

--- a/test/integration/template_versioning_test.rb
+++ b/test/integration/template_versioning_test.rb
@@ -16,62 +16,56 @@ class TemplateVersioningTest < ActionDispatch::IntegrationTest
     @initial_id = @template.id
     @initial_version = @template.version
     @initial_title = @template.title
-    @dmptemplate_id = @template.dmptemplate_id
+    @family_id = @template.family_id
   end
 
   # ----------------------------------------------------------
   test 'template gets versioned when its phases are modified and it is already published' do
-    @template.dirty = false
-    @template.save!
-
-    put admin_update_phase_path @template.phases.first, {phase: {title: 'UPDATED'}}
-    @template.reload
-    assert @template.dirty
+# REINSTATE THIS TEST AFTER REFACTORING TEMPLATE VERSIONING
+#    put admin_update_phase_path @template.phases.first, {phase: {title: 'UPDATED'}}
+#    @template.reload
+#    assert_not_equal @initial_version, @template.version, "expected the version to have incremented"
   end
 
   # ----------------------------------------------------------
   test 'template gets versioned when its sections are modified and it is already published' do
-    @template.dirty = false
-    @template.save!
-
-    put admin_update_section_path @template.phases.first.sections.first, {section: {title: 'UPDATED'}}
-    @template.reload
-    assert @template.dirty
+# REINSTATE THIS TEST AFTER REFACTORING TEMPLATE VERSIONING
+#    put admin_update_section_path @template.phases.first.sections.first, {section: {title: 'UPDATED'}}
+#    @template.reload
+#    assert_not_equal @initial_version, @template.version, "expected the version to have incremented"
   end
 
   # ----------------------------------------------------------
   test 'template gets versioned when its questions are modified and it is already published' do
-    @template.dirty = false
-    @template.save!
-
-    put admin_update_question_path @template.phases.first.sections.first.questions.first, {question: {text: 'UPDATED'}}
-    @template.reload
-    assert @template.dirty
+# REINSTATE THIS TEST AFTER REFACTORING TEMPLATE VERSIONING
+#    put admin_update_question_path @template.phases.first.sections.first.questions.first, {question: {text: 'UPDATED'}}
+#    @template.reload
+#    assert_not_equal @initial_version, @template.version, "expected the version to have incremented"
   end
 
   # ----------------------------------------------------------
   test 'template does NOT get versioned if its unpublished' do
     # Change the title after its been published
     put org_admin_template_path(@template), {template: {title: "Blah blah blah"}}
-    @template = Template.current(@dmptemplate_id)
+    @template = Template.current(@family_id)
 
     assert_equal @initial_version, @template.version, "expected the version to have stayed the same"
     assert_equal @initial_id, @template.id, "expected the id to been the same"
-    assert_equal @dmptemplate_id, @template.dmptemplate_id, "expected the dmptemplate_id to match"
+    assert_equal @family_id, @template.family_id, "expected the family_id to match"
     assert_equal false, @template.published?, "expected the version to have remained unpublished"
   end
 
   # ----------------------------------------------------------
   test 'publishing a plan unpublishes the old published plan' do
     get publish_org_admin_template_path(@template)
-    assert_not Template.live(@dmptemplate_id).nil?
-    assert_equal 1, Template.where(org: @user.org, dmptemplate_id: @dmptemplate_id, published: true).count
+    assert_not Template.live(@family_id).nil?
+    assert_equal 1, Template.where(org: @user.org, family_id: @family_id, published: true).count
   end
 
   # ----------------------------------------------------------
   test 'unpublishing a plan makes all historical versions unpublished' do
     get publish_org_admin_template_path(@template)
     get unpublish_org_admin_template_path(@template)
-    assert Template.live(@dmptemplate_id).nil?
+    assert Template.live(@family_id).nil?
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -8,7 +8,7 @@ class UserMailerPreview < ActionMailer::Preview
                               password: "password123", password_confirmation: "password123", org: @org, 
                               accept_terms: true, confirmed_at: Time.zone.now)
     @template = Template.new(title: 'Test template', description: 'My test template', org: @org, 
-                                 migrated: false, dmptemplate_id: "9999999")
+                                 archived: false, family_id: "9999999")
     @plan = Plan.new(template: @template, title: 'Test Plan', grant_number: 'Grant-123',
                      principal_investigator: 'Researcher', principal_investigator_identifier: 'researcher-1234',
                      description: "this is my plan's informative description",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,7 +52,7 @@ class ActiveSupport::TestCase
     template = Template.new(title: 'Test template',
                             description: 'My test template', 
                             links: {"funder":[],"sample_plan":[]},
-                            org: Org.first, migrated: false, dmptemplate_id: "0000009999")
+                            org: Org.first, archived: false, family_id: "0000009999")
 
     template.phases << Phase.new(title: 'Test phase',
                                  description: 'My test phase',

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -31,39 +31,39 @@ class TemplateTest < ActiveSupport::TestCase
   end
 
   # ---------------------------------------------------
-  test "family_ids scope only returns the dmptemplate_ids for the specific Org" do
+  test "family_ids scope only returns the family_ids for the specific Org" do
     Org.all.each do |org|
-      family_ids = Template.valid.all.pluck(:dmptemplate_id).uniq
-      scoped = Template.dmptemplate_ids
+      family_ids = Template.valid.all.pluck(:family_id).uniq
+      scoped = Template.family_ids
       assert_equal family_ids.count, scoped.count
       
       family_ids.each do |id|
         assert scoped.include?(id), "expected the family_ids scope to contain #{id} for Org: #{org.id}"
       end
       scoped.each do |id|
-        assert family_ids.include?(id), "expected #{id} to be a valid dmptemplate_id for Org: #{org.id}"
+        assert family_ids.include?(id), "expected #{id} to be a valid family_id for Org: #{org.id}"
       end
     end
   end
 
   # ---------------------------------------------------
-  test "current scope only returns the most recent version for each dmptemplate_id" do
+  test "current scope only returns the most recent version for each family_id" do
     Org.all.each do |org|
-      Template.dmptemplate_ids.each do |dmptemplate_id|
-        latest = Template.where(dmptemplate_id: dmptemplate_id).order(updated_at: :desc).first
+      Template.family_ids.each do |family_id|
+        latest = Template.where(family_id: family_id).order(updated_at: :desc).first
         
-        assert_equal latest, Template.current(dmptemplate_id), "Expected the template.id #{latest.id} to be the current record for Org: #{org.id}, dmptemplate_id: #{dmptemplate_id}"
+        assert_equal latest, Template.current(family_id), "Expected the template.id #{latest.id} to be the current record for Org: #{org.id}, family_id: #{family_id}"
       end
     end
   end
   
   # ---------------------------------------------------
-  test "published scope only returns the current published version for each dmptemplate_id" do
+  test "published scope only returns the current published version for each family_id" do
     Org.all.each do |org|
-      Template.dmptemplate_ids.each do |dmptemplate_id|
-        latest = Template.where(dmptemplate_id: dmptemplate_id, published: true).order(updated_at: :desc).first
+      Template.family_ids.each do |family_id|
+        latest = Template.where(family_id: family_id, published: true).order(updated_at: :desc).first
 
-        assert_equal latest, Template.live(dmptemplate_id), "Expected the #{latest.nil? ? 'template to have never been published' : "template.id #{latest.id} to be the published record"} for Org: #{org.id}, dmptemplate_id: #{dmptemplate_id}"
+        assert_equal latest, Template.live(family_id), "Expected the #{latest.nil? ? 'template to have never been published' : "template.id #{latest.id} to be the published record"} for Org: #{org.id}, family_id: #{family_id}"
       end
     end
   end
@@ -154,21 +154,21 @@ class TemplateTest < ActiveSupport::TestCase
     tC = Template.create!(title: 'My test C', version: 0, org: @org)
     
     # Test 1 - Multiple versions
-    cAv0 = Template.create!(title: 'My test customization A', version: 0, customization_of: tA.dmptemplate_id, org: Org.first)
+    cAv0 = Template.create!(title: 'My test customization A', version: 0, customization_of: tA.family_id, org: Org.first)
     cAv1 = Template.deep_copy(cAv0)
     cAv1.update_attributes(version: 1)
     
     # Test 2 - Only one version
-    cBv0 = Template.create!(title: 'My test customization B', version: 0, customization_of: tB.dmptemplate_id, org: Org.first)
+    cBv0 = Template.create!(title: 'My test customization B', version: 0, customization_of: tB.family_id, org: Org.first)
 
     # Test 3 - Make sure it always returns the latest version regardless of published statuses
-    cCv0 = Template.create!(title: 'My test customization C', version: 0, customization_of: tC.dmptemplate_id, org: Org.first)
+    cCv0 = Template.create!(title: 'My test customization C', version: 0, customization_of: tC.family_id, org: Org.first)
     cCv1 = Template.deep_copy(cCv0)
     cCv1.update_attributes(version: 1, published: true)
     cCv2 = Template.deep_copy(cCv1)
     cCv2.update_attributes(version: 2)
     
-    latest = Template.org_customizations([tA, tB, tC].collect(&:dmptemplate_id), Org.first.id)
+    latest = Template.org_customizations([tA, tB, tC].collect(&:family_id), Org.first.id)
     assert latest.include?(cAv1), 'expected to get customization A - version 1.'
     assert latest.include?(cBv0), 'expected to get customization B - version 0.'
     assert latest.include?(cCv2), 'expected to get customization C - version 2.'


### PR DESCRIPTION
DB changes for template versioning #1331 
- added db migration files
- switched all references of 'migrated' to 'archived'
- switched all references of 'dmptemplate_id' to 'family_id'
- switched all references of 'dmptemplate' to 'family'
- removed code that referenced old 'templates.dirty' flag
