### PR TITLE
Issue 1341

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -37,4 +37,8 @@ class Annotation < ActiveRecord::Base
     annotation_copy.save!
     return annotation_copy
   end
+
+  def deep_copy
+    return self.dup
+  end
 end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -112,6 +112,13 @@ class Phase < ActiveRecord::Base
     return phase_copy
   end
 
+  def deep_copy(modifiable=true)
+    copy = self.dup
+    copy.modifiable = modifiable
+    copy.sections = self.sections.map{ |section| section.deep_copy(modifiable) }
+    return copy
+  end
+
   # Returns the number of answered question for the phase.
   def num_answered_questions(plan)
     return 0 if plan.nil?

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -81,6 +81,14 @@ class Question < ActiveRecord::Base
     return question_copy
   end
 
+  def deep_copy(modifiable=true)
+    copy = self.dup
+    copy.modifiable = modifiable
+    copy.question_options = self.question_options.map(&:deep_copy)
+    copy.annotations = self.annotations.map(&:deep_copy)
+    copy.themes = self.themes.map{ |theme| theme }
+    return copy
+  end
   ##
 	# guidance for org
   #

--- a/app/models/question_option.rb
+++ b/app/models/question_option.rb
@@ -23,4 +23,8 @@ class QuestionOption < ActiveRecord::Base
     question_option_copy.save!
     return question_option_copy
   end
+
+  def deep_copy
+    return self.dup
+  end
 end

--- a/app/models/scopes/template_scope.rb
+++ b/app/models/scopes/template_scope.rb
@@ -19,13 +19,13 @@ module TemplateScope
     scope :latest_version_per_family, -> (family_id = nil) {
       chained_scope = unarchived.select("MAX(version) AS version", :family_id)
       if family_id.present?
-        chained_scope = chained_scope.where(family_id: family_ids)
+        chained_scope = chained_scope.where(family_id: family_id)
       end
       chained_scope.group(:family_id)
     }
-    scope :latest_customized_version_per_customised_of, -> (customization_ofs=nil, org_id = nil) {
+    scope :latest_customized_version_per_customised_of, -> (customization_of=nil, org_id = nil) {
       chained_scope = select("MAX(version) AS version", :customization_of)
-      chained_scope = chained_scope.where(customization_of: customization_ofs)
+      chained_scope = chained_scope.where(customization_of: customization_of)
       if org_id.present?
         chained_scope = chained_scope.where(org_id: org_id)
       end
@@ -33,25 +33,25 @@ module TemplateScope
     }
     # Retrieves the latest templates, i.e. those with maximum version associated. It can be filtered down
     # if family_id is passed
-    scope :latest_version, -> (family_ids = nil) {
-      unarchived.from(latest_version_per_family(family_ids), :current)
+    scope :latest_version, -> (family_id = nil) {
+      unarchived.from(latest_version_per_family(family_id), :current)
         .joins("INNER JOIN templates ON current.version = templates.version " +
              "AND current.family_id = templates.family_id")
     }
     # Retrieves the latest customized versions, i.e. those with maximum version associated for a set
-    # of family_ids and an org
-    scope :latest_customized_version, -> (family_ids = nil, org_id = nil) {
-      unarchived.from(latest_customized_version_per_customised_of(family_ids, org_id), :current)
+    # of family_id and an org
+    scope :latest_customized_version, -> (family_id = nil, org_id = nil) {
+      unarchived.from(latest_customized_version_per_customised_of(family_id, org_id), :current)
       .joins("INNER JOIN templates ON current.version = templates.version"\
         " AND current.customization_of = templates.customization_of")
-      .where('templates.org_id = ?', org_id)
+      .where(templates: { org_id: org_id })
     }
-    # Retrieves the latest templates, i.e. those with maximum version associated for a set of org_ids passed
-    scope :latest_version_per_org, -> (org_ids = nil) {
-      if org_ids.respond_to?(:each)
-        family_ids = families(org_ids).pluck(:family_id)
+    # Retrieves the latest templates, i.e. those with maximum version associated for a set of org_id passed
+    scope :latest_version_per_org, -> (org_id = nil) {
+      if org_id.respond_to?(:each)
+        family_ids = families(org_id).pluck(:family_id)
       else
-        family_ids = families([org_ids]).pluck(:family_id)
+        family_ids = families([org_id]).pluck(:family_id)
       end
       latest_version(family_ids)
     }

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -50,4 +50,11 @@ class Section < ActiveRecord::Base
     end
     return section_copy
   end
+
+  def deep_copy(modifiable=true)
+    copy = self.dup
+    copy.modifiable = modifiable
+    copy.questions = self.questions.map{ |question| question.deep_copy(modifiable) }
+    return copy
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -215,6 +215,26 @@ class ActiveSupport::TestCase
     end
   end
 
+  def assert_deep_copy(original, copy, **options)
+    if original.class == copy.class
+        relations = options.fetch(:relations, []).map(&:to_sym)
+        assert(original.object_id != copy.object_id)
+        assert_nil(copy.id, "id should be nil for #{copy.class}") if copy.respond_to?(:id)
+        assert_nil(copy.created_at, "created_at should be nil for #{copy.class}") if copy.respond_to?(:created_at)
+        assert_nil(copy.updated_at, "updated_at should be nil for #{copy.class}") if copy.respond_to?(:updated_at)
+        relations.each do |relation|
+          if copy.respond_to?(relation)
+            relation_obj = copy.send(relation)
+            if relation_obj.respond_to?(:each)
+              relation_obj.each do |obj|
+                assert_nil(obj.id, "id should be nil for the relation object from #{obj.class}") if copy.respond_to?(:id)
+              end 
+            end
+          end
+        end
+    end
+  end
+
   # ----------------------------------------------------------------------
   def verify_has_many_relationship(object, new_association, initial_expected_count)
     # Assumes that the association name matches the pluralized name of the class

--- a/test/unit/phase_test.rb
+++ b/test/unit/phase_test.rb
@@ -35,6 +35,11 @@ class PhaseTest < ActiveSupport::TestCase
     verify_deep_copy(@phase, ['id', 'created_at', 'updated_at'])
   end
   
+  test "#deep_copy creates a new phase object and attaches new section objects" do
+    phase = scaffold_template.phases.first
+    assert_deep_copy(phase, phase.deep_copy, relations: [:sections])
+  end
+
   # ---------------------------------------------------
   test "can CRUD Phase" do
     obj = Phase.create(title: 'Testing CRUD', template: @template, number: 4)

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -72,6 +72,15 @@ class QuestionTest < ActiveSupport::TestCase
     verify_deep_copy(@question, ['id', 'created_at', 'updated_at'])
   end
 
+  test "#deep_copy creates a new question object and attaches new annotation/question_option objects" do
+    questions = scaffold_template.phases.first.sections.first.questions.select{ |q| q.option_based? }
+    questions.each do |question|
+      question_copy = question.deep_copy
+      assert_deep_copy(question, question_copy, relations: [:annotations, :question_options])
+      assert_equal(question.themes, question_copy.themes)
+    end
+  end
+
   # ---------------------------------------------------
   test "can CRUD Question" do
     obj = Question.create(section: @section, text: 'Test ABC', number: 7)

--- a/test/unit/section_test.rb
+++ b/test/unit/section_test.rb
@@ -30,6 +30,11 @@ class SectionTest < ActiveSupport::TestCase
   test "deep copy" do
     verify_deep_copy(@section, ['id', 'created_at', 'updated_at'])
   end
+
+  test "#deep_copy creates a new section object and attaches new question objects" do
+    section = scaffold_template.phases.first.sections.first
+    assert_deep_copy(section, section.deep_copy, relations: [:questions])
+  end
   
   # ---------------------------------------------------
   test "can CRUD Section" do

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -97,8 +97,10 @@ class TemplateTest < ActiveSupport::TestCase
     assert_equal false, version2.archived, 'expected the new version to no be archived'
   end
 
-
-
+  test "#deep_copy creates a new template object and attaches new phase objects" do
+    template = scaffold_template
+    assert_deep_copy(template, template.deep_copy, relations: [:phases])
+  end
 
 
   


### PR DESCRIPTION
- Removed Template::get_public_published_template_versions method
- Model#deep_copy instead of Model::deep_copy. Model#deep_copy without side effects
