### PR TITLE
added tests for upgrade_customization

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -123,6 +123,10 @@ class Template < ActiveRecord::Base
     target.phases.select{ |phase| phase.modifiable }.each do |modifiable_phase|
       customization.phases << modifiable_phase
     end
+    
+    # Update the upgraded customization's version number
+    customization.version = target.version
+
     return customization
   end
 


### PR DESCRIPTION
- Had to add a line to template.rb to set the version of the returned template
- Added tests to check version number
- Added initial test for upgraded customizations to verify that the correct components appear in the new template (this one fails due to an issue between an array vs ActiveRecord collection. Feel free to update the test as needed, its kind of psuedo-code at this point
