### PR TITLE
Issue1341

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -201,7 +201,7 @@ module OrgAdmin
     # the funder template's id is passed through here
     # -----------------------------------------------------
     def transfer_customization
-      current_customization = Template.includes(:org).find(params[:id])
+      @template = Template.includes(:org).find(params[:id])
       @current_tab = params[:r] || 'all-templates'
       authorize @template
       new_customization = @template.upgrade_customization
@@ -214,7 +214,7 @@ module OrgAdmin
     def copy
       @template = Template.find(params[:id])
       authorize @template
-      new_copy = template.generate_copy
+      new_copy = @template.generate_copy(current_user.org)
       if new_copy.save!
         flash[:notice] = "#{@template.template_type.capitalize} was successfully copied."
         redirect_to edit_org_admin_template_path(new_copy, edit: true, r: 'organisation-templates')

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -53,10 +53,10 @@ module OrgAdmin
       @template.links = (params["template-links"].present? ? JSON.parse(params["template-links"]) : {"funder": [], "sample_plan": []})
 
       if @template.save
-        redirect_to edit_org_admin_template_path(@template), notice: success_message(@template.template_type, _('created'))
+        redirect_to edit_org_admin_template_path(@template), notice: success_message(template_type(@template), _('created'))
       else
         @hash = @template.to_hash
-        flash[:alert] = failed_create_error(@template, @template.template_type)
+        flash[:alert] = failed_create_error(@template, template_type(@template))
         render action: "new"
       end
     end
@@ -77,11 +77,11 @@ module OrgAdmin
             redirect_to(action: 'edit', id: new_version.id, r: @current_tab)
             return
           else
-            flash[:alert] = _("Unable to create a new version of this #{@template.template_type}. You are currently working with a published copy.")
+            flash[:alert] = _("Unable to create a new version of this #{template_type(@template)}. You are currently working with a published copy.")
           end
         end
       else
-        flash[:notice] = _("You are viewing a historical version of this #{@template.template_type}. You will not be able to make changes.")
+        flash[:notice] = _("You are viewing a historical version of this #{template_type(@template)}. You will not be able to make changes.")
       end
 
       # once the correct template has been generated, we convert it to hash
@@ -108,13 +108,13 @@ module OrgAdmin
 
       # Only allow the current version to be updated
       if current != @template
-        render(status: :forbidden, json: { msg: _("You can not edit a historical version of this #{@template.template_type}.")})
+        render(status: :forbidden, json: { msg: _("You can not edit a historical version of this #{template_type(@template)}.")})
       else
         template_links = nil
         begin
           template_links = JSON.parse(params["template-links"]) if params["template-links"].present?
         rescue JSON::ParserError
-          render(status: :bad_request, json: { msg: _("Error parsing links for a #{@template.template_type}") })
+          render(status: :bad_request, json: { msg: _("Error parsing links for a #{template_type(@template)}") })
           return
         end
         
@@ -130,10 +130,10 @@ module OrgAdmin
         end
       
         if @template.update_attributes(params[:template])
-          render(status: :ok, json: { msg: success_message(@template.template_type, _('saved'))})
+          render(status: :ok, json: { msg: success_message(template_type(@template), _('saved'))})
         else
           # Note failed_update_error may return HTML tags (e.g. <br/>) and therefore the client should parse them accordingly
-          render(status: :bad_request, json: { msg: failed_update_error(@template, @template.template_type)})
+          render(status: :bad_request, json: { msg: failed_update_error(@template, template_type(@template))})
         end
       end
     end
@@ -151,19 +151,19 @@ module OrgAdmin
         # Only allow the current version to be destroyed
         if current == @template
           if @template.destroy
-            flash[:notice] = success_message(@template.template_type, _('removed'))
+            flash[:notice] = success_message(template_type(@template), _('removed'))
             redirect_to org_admin_templates_path(r: current_tab)
           else
             @hash = @template.to_hash
-            flash[:alert] = failed_destroy_error(@template, @template.template_type)
+            flash[:alert] = failed_destroy_error(@template, template_type(@template))
             redirect_to org_admin_templates_path(r: current_tab)
           end
         else
-          flash[:alert] = _("You cannot delete historical versions of this #{@template.template_type}.")
+          flash[:alert] = _("You cannot delete historical versions of this #{template_type(@template)}.")
           redirect_to org_admin_templates_path(r: current_tab)
         end
       else
-        flash[:alert] = _("You cannot delete a #{@template.template_type} that has been used to create plans.")
+        flash[:alert] = _("You cannot delete a #{template_type(@template)} that has been used to create plans.")
         redirect_to org_admin_templates_path(r: current_tab)
       end
     end
@@ -216,10 +216,10 @@ module OrgAdmin
       authorize @template
       new_copy = @template.generate_copy(current_user.org)
       if new_copy.save!
-        flash[:notice] = "#{@template.template_type.capitalize} was successfully copied."
+        flash[:notice] = "#{template_type(@template).capitalize} was successfully copied."
         redirect_to edit_org_admin_template_path(new_copy, edit: true, r: 'organisation-templates')
       else
-        flash[:alert] = failed_create_error(new_copy, @template.template_type)
+        flash[:alert] = failed_create_error(new_copy, template_type(@template))
         current_tab = params[:r] || 'all-templates'
         redirect_to "#{org_admin_templates_path}##{current_tab}"
       end
@@ -234,7 +234,7 @@ module OrgAdmin
       
       # Only allow the current version to be updated
       if current != template
-        redirect_to org_admin_templates_path, alert: _("You can not publish a historical version of this #{template.template_type}.")
+        redirect_to org_admin_templates_path, alert: _("You can not publish a historical version of this #{template_type(template)}.")
       else
         # Unpublish the older published version if there is one
         live = Template.live(template.family_id)
@@ -245,8 +245,8 @@ module OrgAdmin
         template.published = true
         template.save
 
-        flash[:notice] = _("Your #{template.template_type} has been published and is now available to users.")
-        redirect_to "#{org_admin_templates_path}#{template.template_type == _('customisation') ? '#funder-templates' : '#organisation-templates'}"
+        flash[:notice] = _("Your #{template_type(template)} has been published and is now available to users.")
+        redirect_to "#{org_admin_templates_path}#{template_type(template) == _('customisation') ? '#funder-templates' : '#organisation-templates'}"
       end
     end
 
@@ -257,14 +257,14 @@ module OrgAdmin
       authorize template
 
       if template.nil?
-        flash[:alert] = _("That #{template.template_type} is not currently published.")
+        flash[:alert] = _("That #{template_type(template)} is not currently published.")
       else
         template.published = false
         template.save
-        flash[:notice] = _("Your #{template.template_type} is no longer published. Users will not be able to create new DMPs for this #{template.template_type} until you re-publish it")
+        flash[:notice] = _("Your #{template_type(template)} is no longer published. Users will not be able to create new DMPs for this #{template_type(template)} until you re-publish it")
       end
 
-      redirect_to "#{org_admin_templates_path}#{template.template_type == _('customisation') ? '#funder-templates' : '#organisation-templates'}"
+      redirect_to "#{org_admin_templates_path}#{template_type(template) == _('customisation') ? '#funder-templates' : '#organisation-templates'}"
     end
     
     # PUT /org_admin/template_options  (AJAX)
@@ -318,5 +318,10 @@ module OrgAdmin
     def plan_params
       params.require(:plan).permit(:org_id, :funder_id)
     end
+    
+    def template_type(template)
+      template.customization_of.present? ? _('customisation') : _('template')
+    end
+    
   end
 end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -96,6 +96,7 @@ class Phase < ActiveRecord::Base
   end
 =end
   
+# TODO: Remove this one in favor of the instance version
   ##
   # deep copy the given phase and all it's associations
   #

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -57,6 +57,7 @@ class Question < ActiveRecord::Base
     return self.answers.to_a.select{|ans| ans.plan_id == plan_id}
   end
 
+# TODO: Remove this one in favor of the instance version
   ##
   # deep copy the given question and all it's associations
   #

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -122,7 +122,7 @@ class Question < ActiveRecord::Base
   # @return [Array<Annotation>] the example answers for this question for the specified orgs
  	def get_example_answers(org_ids)
     org_ids = [org_ids] unless org_ids.is_a?(Array)
-    self.annotations.where(org_id: [org_ids], type: Annotation.types[:example_answer]).order(:created_at)
+    self.annotations.where(org_id: org_ids, type: Annotation.types[:example_answer]).order(:created_at)
  	end
 
   def first_example_answer

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -35,6 +35,7 @@ class Section < ActiveRecord::Base
     end
   end
 
+# TODO: Remove this one in favor of the instance version
   ##
   # deep copy of the given section and all it's associations
   #

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -53,8 +53,7 @@ class Template < ActiveRecord::Base
       unarchived.where(is_default: true, published: true).order(:version).last
     end
   end
-
-
+  
   # Returns whether or not this is the latest version of the current template's family
   def is_latest?
     return (self.id == Template.latest_version(self.family_id).pluck(:id).first)
@@ -151,6 +150,8 @@ class Template < ActiveRecord::Base
   # TODO: Themes & guidance?
   #
   # @return [hash] hash of template, phases, sections, questions, question_options, annotations
+
+# TODO: If there is time to update the UI to stop using hashes, remove this method
   def to_hash
     hash = {}
     hash[:template] = {}
@@ -183,11 +184,6 @@ class Template < ActiveRecord::Base
       end
     end
     return hash
-  end
-
-  # TODO: Determine if this should be in the controller/views instead of the model
-  def template_type
-    self.customization_of.present? ? _('customisation') : _('template')
   end
 
   # Retrieves the template's org or the org of the template this one is derived

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -61,10 +61,11 @@ class Template < ActiveRecord::Base
   end
 
   # Returns a new unpublished copy of this template with a new family_id and a version = zero
-  def generate_copy
+  def generate_copy(org)
     template = deep_copy(modifiable: true, version: 0, published: false, save: true)
     template.family_id = new_family_id 
-    template.title = _('Copy of %{template}') % template.title
+    template.org = org
+    template.title = _('Copy of %{template}') % { template: template.title }
     template.save!
     return template
   end

--- a/test/functional/org_admin/templates_controller_test.rb
+++ b/test/functional/org_admin/templates_controller_test.rb
@@ -108,7 +108,8 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'get templates#edit returns ok with flash notice when template is not current' do
-    new_version = @template.deep_copy(save: true, version: @template.version+1)
+    @template.update_attributes(published: true)
+    new_version = @template.generate_version
     sign_in @user
     get(edit_org_admin_template_path(@template.id))
     assert_response(:ok)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -148,6 +148,50 @@ class ActiveSupport::TestCase
       nil
     end
   end
+  
+  
+  # equality helpers for complex objects
+  def assert_annotations_equal(annotation1, annotation2)
+    assert_equal annotation1.text, annotation2.text, 'expected the annotations to have the same text'
+    assert_equal annotation1.type, annotation2.type, 'expected the annotations to be of the same type'
+  end
+  def assert_question_options_equal(option1, option2)
+    assert_equal option1.text, option2.text, 'expecetd the question options to have the same text'
+    assert_equal option1.number, option2.number, 'expecetd the question options to have the same number'
+    assert_equal option1.is_default, option2.is_default, 'expecetd the question options to have the same default flag value'
+  end
+  def assert_questions_equal(question1, question2)
+    assert_equal question1.number, question2.number, 'expected the question numbers to match'
+    assert_equal question1.text, question2.text, 'expected the question text to match'
+    assert_equal question1.question_format, question2.question_format, 'expected the question formats to match'
+    assert_equal question1.option_comment_display, question2.option_comment_display, 'expected the question optional comment display flags to match'
+    assert_equal question1.annotations.length, question2.annotations.length, 'expected the questions to have the same number of annotations'
+    assert_equal question1.question_options.length, question2.question_options.length, 'expected the questions to have the same number of options'
+    question1.annotations.each_with_index do |annotation, idx|
+      assert_annotations_equal(annotation, question2.annotations[idx])
+    end
+    question1.question_options.each_with_index do |option, idx|
+      assert_question_options_equal(option, question2.question_options[idx])
+    end
+  end
+  def assert_sections_equal(section1, section2)
+    assert_equal section1.number, section2.number, 'expected the section numbers to match'
+    assert_equal section1.title, section2.title, 'expected the section titles to match'
+    assert_equal section1.description, section2.description, 'expected the section descriptions to match'
+    assert_equal section1.questions.length, section2.questions.length, 'expected the sections to have the same number of questions'
+    section1.questions.each_with_index do |question, idx|
+      assert_questions_equal(question, section2.questions[idx])
+    end
+  end
+  def assert_phases_equal(phase1, phase2)
+    assert_equal phase1.number, phase2.number, 'expected the phase numbers to match'
+    assert_equal phase1.title, phase2.title, 'expected the phase titles to match'
+    assert_equal phase1.description, phase2.description, 'expected the phase descriptions to match'
+    assert_equal phase1.sections.length, phase2.sections.length, 'expected the phase to have the same number of sections'
+    phase1.sections.each_with_index do |section, idx|
+      assert_sections_equal(section, phase2.sections[idx])
+    end
+  end
 
 
   # Get the organisational admin for the Org specified or create one

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -15,7 +15,7 @@ class TemplateTest < ActiveSupport::TestCase
   end
 
   def init_full_template(template)
-    phase = init_phase(@basic_template)
+    phase = init_phase(template)
     section = init_section(phase)
     init_question(section)
   end
@@ -100,9 +100,11 @@ class TemplateTest < ActiveSupport::TestCase
     assert (@basic_template.phases.collect{ |p| p.sections.collect{ |s| s.questions.length } } - version2.phases.collect{ |p| p.sections.collect{ |s| s.questions.length } }).empty?, 'expected the new version to have the same number of questions as the base template'
   end
 
-  test "#deep_copy creates a new template object and attaches new phase objects" do
-    template = scaffold_template
-    assert_deep_copy(template, template.deep_copy, relations: [:phases])
+  test "#generate_copy creates a new template object" do
+    template = init_full_template(@basic_template)
+    copy = template.generate_copy
+    copy.save!
+    assert_deep_copy(template, copy, relations: [:phases])
   end
 
   test "can properly determine if current template is the latest version" do

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -181,14 +181,6 @@ class TemplateTest < ActiveSupport::TestCase
     assert_equal @basic_template.org, customization.base_org, 'expected a customized template to consider the parent template\'s org the base_org'
   end
 
-  test "template_type returns 'customisation' for a customized template" do
-    customization = @basic_template.customize(@institution)
-    assert_equal _('customisation'), customization.template_type, 'expected the template type to be \'customisation\' for a customized template'
-  end
-  test "template_type returns 'template' for an uncustomized template" do
-    assert_equal _('template'), @basic_template.template_type, 'expected the template type to be \'template\' for an uncustomized template'
-  end
-
   test "#generate_version raises RuntimeError when the template is not published" do
     template = init_template(@org, published: false)
     exception = assert_raises(RuntimeError) do

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -104,6 +104,7 @@ class TemplateTest < ActiveSupport::TestCase
 
   test "able to copy a template" do
     template = init_full_template(@basic_template)
+    template.update_attributes(is_default: true, published: true) # Update these flags to verify that the copy sets them properly
     copy = template.generate_copy(@institution)
     assert_not_equal template.id, copy.id, 'expecetd the copy to have a different id'
     assert_not_equal template.family_id, copy.family_id, 'expected the copy to have a different family id'

--- a/test/unit/template_test.rb
+++ b/test/unit/template_test.rb
@@ -18,6 +18,7 @@ class TemplateTest < ActiveSupport::TestCase
     phase = init_phase(template)
     section = init_section(phase)
     init_question(section)
+    return template
   end
 
   def settings(extras = {})
@@ -50,7 +51,7 @@ class TemplateTest < ActiveSupport::TestCase
     assert_not Template.new(version: 1, title: 'Tester').valid?, "expected the 'org' field to be required"
     assert_not Template.new(org: @funder, version: 1).valid?, "expected the 'title' field to be required"
   end
-  
+
   test "unarchived returns only unarchived templates" do
     # Create an unarchived and an archived template (set archived after init because it will default to false on creation)
     archived = init_template(@funder, { title: 'Archived Template' })
@@ -86,25 +87,37 @@ class TemplateTest < ActiveSupport::TestCase
   end
 
   test "able to version a template" do
-    init_full_template(@basic_template)
-    assert_equal 0, @basic_template.version, 'expected the initial template version to be zero'
-    version2 = @basic_template.generate_version
+    template = init_full_template(@basic_template)
+    assert_equal 0, template.version, 'expected the initial template version to be zero'
+    version2 = template.generate_version
     assert_equal 1, version2.version, 'expected the version number to be one more than the original template\'s'
-    assert_equal @basic_template.family_id, version2.family_id, 'expected the new version to have the same family_id'
-    assert_equal @basic_template.visibility, version2.visibility, 'expected the new version to have the same visibility'
-    assert_equal @basic_template.is_default, version2.is_default, 'expected the new version to have the same default flag'
+    assert_equal template.family_id, version2.family_id, 'expected the new version to have the same family_id'
+    assert_equal template.visibility, version2.visibility, 'expected the new version to have the same visibility'
+    assert_equal template.is_default, version2.is_default, 'expected the new version to have the same default flag'
     assert_equal false, version2.archived, 'expected the new version to no be archived'
     # All components were transferred over to the new version
-    assert_equal @basic_template.phases.length, version2.phases.length, 'expected the new version to have the same number of phases as the base template'
-    assert (@basic_template.phases.collect{ |p| p.sections.length } - version2.phases.collect{ |p| p.sections.length}).empty?, 'expected the new version to have the same number of sections as the base template'
-    assert (@basic_template.phases.collect{ |p| p.sections.collect{ |s| s.questions.length } } - version2.phases.collect{ |p| p.sections.collect{ |s| s.questions.length } }).empty?, 'expected the new version to have the same number of questions as the base template'
+    assert_equal template.phases.length, version2.phases.length, 'expected the new version to have the same number of phases'
+    template.phases.each_with_index do |phase, idx|
+      assert_phases_equal(phase, version2.phases[idx])
+    end
   end
 
-  test "#generate_copy creates a new template object" do
+  test "able to copy a template" do
     template = init_full_template(@basic_template)
-    copy = template.generate_copy
-    copy.save!
-    assert_deep_copy(template, copy, relations: [:phases])
+    copy = template.generate_copy(@institution)
+    assert_not_equal template.id, copy.id, 'expecetd the copy to have a different id'
+    assert_not_equal template.family_id, copy.family_id, 'expected the copy to have a different family id'
+    assert_equal @institution, copy.org, 'expected the copy to have the correct Org'
+    assert_equal 0, copy.version, 'expected the copy\'s version number to be zero'
+    assert_not copy.published?, 'expected the copy to not be published'
+    assert_not copy.is_default?, 'expected the copy to not be the default template'
+    assert_equal 'organisationally_visible', copy.visibility, 'expected the visibility to be organisational'
+    assert_equal 'Copy of %{template}' % { template: template.title }, copy.title, 'expected the template title to be "Copy of %{template}"'
+    assert_equal template.description, copy.description, 'expected the template descriptions to match'
+    assert_equal template.phases.length, copy.phases.length, 'expected the copy to have the same number of phases'
+    template.phases.each_with_index do |phase, idx|
+      assert_phases_equal(phase, copy.phases[idx])
+    end
   end
 
   test "can properly determine if current template is the latest version" do
@@ -131,13 +144,13 @@ class TemplateTest < ActiveSupport::TestCase
   end
 
   test "#customize generates a new template" do
-    init_full_template(@basic_template)
-    @basic_template.is_default = true
-    @basic_template.save!
-    customization = @basic_template.customize(@institution)
+    template = init_full_template(@basic_template)
+    template.is_default = true
+    template.save!
+    customization = template.customize(@institution)
 
     assert(customization.family_id.present?, 'expected a newly family_id value')
-    assert_equal(@basic_template.family_id, customization.customization_of, 'expected the customization_of id to match the base template\'s family_id')
+    assert_equal(template.family_id, customization.customization_of, 'expected the customization_of id to match the base template\'s family_id')
     assert_equal(0, customization.version, 'expected the initial customization version to be zero')
     assert_equal(@institution, customization.org, 'expected the customizatio\'s org to match the one specified')
     assert_not(customization.published, 'expected the customization to not be published')
@@ -145,17 +158,9 @@ class TemplateTest < ActiveSupport::TestCase
     assert_not(customization.is_default, 'expected the customization to not be the default template')
 
     # Following statements go further than checking that the instance method behaves adequately
-    assert_equal @basic_template.phases.length, customization.phases.length, 'expected the customization to have the same number of phases as the base template'
-    assert (@basic_template.phases.collect{ |p| p.sections.length } - customization.phases.collect{ |p| p.sections.length}).empty?, 'expected the customization to have the same number of sections as the base template'
-    assert (@basic_template.phases.collect{ |p| p.sections.collect{ |s| s.questions.length } } - customization.phases.collect{ |p| p.sections.collect{ |s| s.questions.length } }).empty?, 'expected the customization to have the same number of questions as the base template'
-    customization.phases.each do |phase|
-      assert_not phase.modifiable?, 'expected original phases to not be modifiable on the customized template'
-      phase.sections.each do |section|
-        assert_not section.modifiable?, 'expected original sections to not be modifiable on the customized template'
-        section.questions.each do |question|
-          assert_not question.modifiable?, 'expected original questions to not be modifiable on the customized template'
-        end
-      end
+    assert_equal template.phases.length, customization.phases.length, 'expected the customization to have the same number of phases as the base template'
+    template.phases.each_with_index do |phase, idx|
+      assert_phases_equal(phase, customization.phases[idx])
     end
   end
 
@@ -195,7 +200,7 @@ class TemplateTest < ActiveSupport::TestCase
     template = init_template(@org, published: true)
     new_template = template.generate_version
     assert_equal(@basic_template.version + 1, new_template.version)
-    assert(new_template.published == false)
+    assert_not(new_template.published)
   end
 
   test "#upgrade_customization raises RuntimeError when the template is not a customisation of another template" do
@@ -221,7 +226,7 @@ class TemplateTest < ActiveSupport::TestCase
     customization.phases << Phase.new(title: 'New customised phase 2', number: 3, modifiable: true)
 
     transferred = customization.upgrade_customization
-    assert(customization.object_id != transferred.object_id, 'customization and transferred are distinct objects')
+    assert_not_equal(customization.object_id, transferred.object_id, 'customization and transferred are distinct objects')
     assert_equal(3, transferred.phases.length, 'expected 3 phases after upgrading a customised template')
   end
 
@@ -232,7 +237,7 @@ class TemplateTest < ActiveSupport::TestCase
     customization.phases.first.sections << Section.new(title: 'New customised section 2', number: 3, modifiable: true)
 
     transferred = customization.upgrade_customization
-    assert(customization.object_id != transferred.object_id, 'customization and transferred are distinct objects')
+    assert_not_equal(customization.object_id, transferred.object_id, 'customization and transferred are distinct objects')
     assert_equal(3, transferred.phases.first.sections.length, 'expected 3 sections after upgrading a customised template')
   end
 
@@ -243,7 +248,7 @@ class TemplateTest < ActiveSupport::TestCase
     customization.phases.first.sections.first.questions << Question.new(text: 'New customised question 2', number: 3, modifiable: true)
 
     transferred = customization.upgrade_customization
-    assert(customization.object_id != transferred.object_id, 'customization and transferred are distinct objects')
+    assert_not_equal(customization.object_id, transferred.object_id, 'customization and transferred are distinct objects')
     assert_equal(3, transferred.phases.first.sections.first.questions.length, 'expected 3 questions after upgrading a customised template')
   end
 
@@ -261,10 +266,10 @@ class TemplateTest < ActiveSupport::TestCase
       Annotation.new(text: 'New funder example_answer', type: Annotation.types[:example_answer], org: @basic_template.org)
 
     transferred = customization.upgrade_customization
-    assert(customization.object_id != transferred.object_id, 'customization and transferred are distinct objects')
+    assert_not_equal(customization.object_id, transferred.object_id, 'customization and transferred are distinct objects')
     assert_equal(4, transferred.phases.first.sections.first.questions.first.annotations.length, 'expected 4 annotations after upgrading a customised template')
   end
-  
+ 
 =begin
   test "family_ids scope only returns the family_ids for the specific Org" do
     Org.all.each do |org|


### PR DESCRIPTION
Ok, so here's what I got done today:
- moved customize code out of the controller 
- added a generate_copy method based on logic in the controller and added test for it
- made deep_copy private on the template model so that we can ensure that the modifiable/published/default/etc. flags are always correct becasue people are using the new methods
- added some test helpers to check for equality of phases/sections/questions/annotations/options that can be used with generate_version, generate_copy, customize and the various deep_copy methods
- updated a line to stop using scaffold_template test_helper in favor of the newer more complete/accurate init_[object] methods


We should move the scopes back into the main model class and remove the few that are still in there (maybe after the controller work when we're sure they're no longer being called). We should also add an `archive` method to set `archived=true` for the template and its historical copies.