### PR TITLE
Issue 1341

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -53,53 +53,115 @@ class Template < ActiveRecord::Base
       unarchived.where(is_default: true, published: true).order(:version).last
     end
   end
-  
+
+  # Creates a copy of the current template
+  # raises ActiveRecord::RecordInvalid when save option is true and validations fails
+  def deep_copy(attributes: {}, **options)
+    copy = self.dup
+    if attributes.respond_to?(:each_pair)
+      attributes.each_pair{ |attribute, value| copy.send("#{attribute}=".to_sym, value) if copy.respond_to?("#{attribute}=".to_sym) }
+    end
+    copy.save! if options.fetch(:save, false)
+    self.phases.each{ |phase| copy.phases << phase.deep_copy(options) }
+    return copy
+  end
+
+  # Retrieves the template's org or the org of the template this one is derived
+  # from of it is a customization
+  def base_org
+    if self.customization_of.present?
+      return Template.where(family_id: self.customization_of).first.org
+    else
+      return self.org
+    end
+  end
+
   # Returns whether or not this is the latest version of the current template's family
-  def is_latest?
+  def latest?
     return (self.id == Template.latest_version(self.family_id).pluck(:id).first)
+  end
+  # Determines whether or not a new version should be generated
+  def generate_version?
+    return self.published
+  end
+  # Determines whether or not a customization for the customizing_org passed should be generated
+  def customize?(customizing_org)
+    if customizing_org.is_a?(Org)
+      return !Template.unarchived.where(customization_of: self.family_id, org: customizing_org).exists?
+    end
+    return false
+  end
+  # Determines whether or not a customized template should be upgraded
+  def upgrade_customization?
+    if customization_of.present?
+      funder_template = Template.published(self.customization_of).select(:created_at).first
+      if funder_template.present?
+        return funder_template.created_at > self.created_at
+      end
+    end
+    return false
   end
 
   # Returns a new unpublished copy of self with a new family_id, version = zero for the specified org
-  def generate_copy(org)
-    template = deep_copy(modifiable: true, version: 0, published: false, save: true)
-    template.update!({
-      family_id: new_family_id,
-      org: org,
-      is_default: false,
-      title: _('Copy of %{template}') % { template: template.title }
-    })
+  def generate_copy!(org)
+    raise _('generate_copy! requires an organisation target') unless org.is_a?(Org) # Assume customizing_org is persisted
+    template = deep_copy(
+      attributes: {
+        version: 0,
+        published: false,
+        family_id: new_family_id,
+        org: org,
+        is_default: false,
+        title: _('Copy of %{template}') % { template: self.title }
+      }, modifiable: true, save: true)
     return template
   end
 
   # Generates a new copy of self with an incremented version number
-  def generate_version
-    raise _('generate_version requires a published template') unless published
-    template = deep_copy(version: self.version+1, published: false, save: true)
+  def generate_version!
+    raise _('generate_version! requires a published template') unless published
+    template = deep_copy(
+      attributes: {
+        version: self.version+1,
+        published: false
+      }, save: true)
     return template
   end
 
   # Generates a new copy of self for the specified customizing_org
-  def customize(customizing_org)
-    raise _('customize requires an organisation target') unless customizing_org.is_a?(Org) # Assume customizing_org is persisted
-    raise _('customize requires a template from a funder') unless org.funder_only? # Assume self has org associated
-    customization = deep_copy(modifiable: false, version: 0, published: false, save: true)
-    customization.update!({
-      family_id: new_family_id,
-      customization_of: self.family_id,
-      org: customizing_org,
-      visibility: Template.visibilities[:organisationally_visible],
-      is_default: false
-    })
+  def customize!(customizing_org)
+    raise _('customize! requires an organisation target') unless customizing_org.is_a?(Org) # Assume customizing_org is persisted
+    raise _('customize! requires a template from a funder') unless org.funder_only? # Assume self has org associated
+    customization = deep_copy(
+      attributes: {
+        version: 0,
+        published: false,
+        family_id: new_family_id,
+        customization_of: self.family_id,
+        org: customizing_org,
+        visibility: Template.visibilities[:organisationally_visible],
+        is_default: false
+      }, modifiable: false, save: true)
     return customization
   end
   
   # Generates a new copy of self including latest changes from the funder this template is customized_of
-  def upgrade_customization
-    raise _('upgrade_customization requires a customised template') unless customization_of.present?
-    source = self
-    source = deep_copy(version: self.version+1, published: false) # preserves modifiable flags from the self template copied
+  def upgrade_customization!
+    raise _('upgrade_customization! requires a customised template') unless customization_of.present?
+    funder_template = Template.published(self.customization_of).first
+    raise _('upgrade_customization! cannot be carried out since there is no published template of its current funder') unless funder_template.present?
+    source = deep_copy(attributes: { version: self.version+1, published: false }) # preserves modifiable flags from the self template copied
     # Creates a new customisation for the published template whose family_id is self.customization_of
-    customization = Template.published(self.customization_of).first.customize(self.org)
+    customization = funder_template.deep_copy(
+      attributes: {
+        version: source.version,
+        published: source.published,
+        family_id: source.family_id,
+        customization_of: source.customization_of,
+        org: source.org,
+        visibility: Template.visibilities[:organisationally_visible],
+        is_default: false
+      }, modifiable: false, save: true)
     # Sorts the phases from the source template, i.e. self
     sorted_phases = source.phases.sort{ |phase1,phase2| phase1.number <=> phase2.number }
     # Merges modifiable sections or questions from source into customization template object
@@ -137,9 +199,6 @@ class Template < ActiveRecord::Base
     end
     # Appends the modifiable phases from source
     source.phases.select{ |phase| phase.modifiable }.each{ |modifiable_phase| customization.phases << modifiable_phase }
-    # Sets template properties to those from source template
-    customization.version = source.version
-    customization.family_id = source.family_id
     return customization
   end
 
@@ -186,47 +245,26 @@ class Template < ActiveRecord::Base
     return hash
   end
 
-  # Retrieves the template's org or the org of the template this one is derived
-  # from of it is a customization
-  def base_org
-    if self.customization_of.present?
-      return Template.where(family_id: self.customization_of).first.org
-    else
-      return self.org
-    end
-  end
-
   private
-  # Generate a new random family identifier
-  def new_family_id
-    family_id = loop do
-      random = rand 2147483647
-      break random unless Template.exists?(family_id: random)
+    # Generate a new random family identifier
+    def new_family_id
+      family_id = loop do
+        random = rand 2147483647
+        break random unless Template.exists?(family_id: random)
+      end
+      family_id
     end
-    family_id
-  end
-
-  # Creates a copy of the current template
-  # raises ActiveRecord::RecordInvalid when save option is true and validations fails
-  def deep_copy(**options)
-    copy = self.dup
-    copy.version = options.fetch(:version, self.version)
-    copy.published = options.fetch(:published, self.published)
-    copy.save! if options.fetch(:save, false)
-    self.phases.each{ |phase| copy.phases << phase.deep_copy(options) }
-    return copy
-  end
-  
-  # Default values to set before running any validation
-  def set_defaults
-    self.published ||= false
-    self.archived ||= false
-    self.is_default ||= false
-    self.version ||= 0
-    self.visibility = (org.present? && org.funder_only?) ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
-    self.customization_of ||= nil
-    self.family_id ||= new_family_id
-    self.archived ||= false
-    self.links ||= { funder: [], sample_plan: [] }
-  end
+    
+    # Default values to set before running any validation
+    def set_defaults
+      self.published ||= false
+      self.archived ||= false
+      self.is_default ||= false
+      self.version ||= 0
+      self.visibility = (org.present? && org.funder_only?) ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
+      self.customization_of ||= nil
+      self.family_id ||= new_family_id
+      self.archived ||= false
+      self.links ||= { funder: [], sample_plan: [] }
+    end
 end

--- a/test/functional/org_admin/templates_controller_test.rb
+++ b/test/functional/org_admin/templates_controller_test.rb
@@ -109,7 +109,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
 
   test 'get templates#edit returns ok with flash notice when template is not current' do
     @template.update_attributes(published: true)
-    new_version = @template.generate_version
+    new_version = @template.generate_version!
     sign_in @user
     get(edit_org_admin_template_path(@template.id))
     assert_response(:ok)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -254,8 +254,7 @@ class ActiveSupport::TestCase
   # Version the template
   # ----------------------------------------------------------------------
   def version_the_template
-    @template = @template.generate_version
-    @template.save
+    @template = @template.generate_version!
   end
 
   # Scaffold a new Plan based on the scaffolded Template


### PR DESCRIPTION
- Removed template.update! in favour of a more re-usable deep_copy with atomic saving.
- removed new_copy.save! from templates_controller#copy. Atomic save for upgrade_customization method
- renamed to bang notation generate_copy, generate_version, customize and upgrade_customization
- question mark methods for generate_version, customize and upgrade_customization

