### PR TITLE
Issue 1341

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -123,7 +123,8 @@ class Template < ActiveRecord::Base
     template = deep_copy(
       attributes: {
         version: self.version+1,
-        published: false
+        published: false,
+        org: self.org
       }, save: true)
     return template
   end

--- a/db/migrate/20180417124026_add_unique_index_family_id_version_to_template.rb
+++ b/db/migrate/20180417124026_add_unique_index_family_id_version_to_template.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexFamilyIdVersionToTemplate < ActiveRecord::Migration
+  def change
+    add_index(:templates, [:family_id, :version], unique: true)
+  end
+end

--- a/db/migrate/20180418115318_add_unique_index_customization_of_version_org_id_to_template.rb
+++ b/db/migrate/20180418115318_add_unique_index_customization_of_version_org_id_to_template.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexCustomizationOfVersionOrgIdToTemplate < ActiveRecord::Migration
+  def change
+    add_index(:templates, [:customization_of, :version, :org_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180405152454) do
+ActiveRecord::Schema.define(version: 20180418115318) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-  
   create_table "annotations", force: :cascade do |t|
     t.integer  "question_id"
     t.integer  "org_id"
@@ -162,8 +159,8 @@ ActiveRecord::Schema.define(version: 20180405152454) do
     t.string   "abbreviation"
     t.string   "target_url"
     t.string   "wayfless_entity"
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.integer  "parent_id"
     t.boolean  "is_other"
     t.string   "sort_name"
@@ -174,8 +171,8 @@ ActiveRecord::Schema.define(version: 20180405152454) do
     t.string   "logo_uid"
     t.string   "logo_name"
     t.string   "contact_email"
-    t.integer  "org_type",               default: 0,              null: false
-    t.text     "links",                  default: "{\"org\":[]}"
+    t.integer  "org_type",               default: 0,     null: false
+    t.text     "links",                  default: "[]"
     t.string   "contact_name"
     t.boolean  "feedback_enabled",       default: false
     t.string   "feedback_email_subject"
@@ -187,6 +184,9 @@ ActiveRecord::Schema.define(version: 20180405152454) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "perms", ["name"], name: "index_perms_on_name"
+  add_index "perms", ["name"], name: "index_roles_on_name_and_resource_type_and_resource_id"
 
   create_table "phases", force: :cascade do |t|
     t.string   "title"
@@ -344,6 +344,8 @@ ActiveRecord::Schema.define(version: 20180405152454) do
     t.text     "links",            default: "{\"funder\":[], \"sample_plan\":[]}"
   end
 
+  add_index "templates", ["customization_of", "version", "org_id"], name: "index_templates_on_customization_of_and_version_and_org_id", unique: true
+  add_index "templates", ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true
   add_index "templates", ["family_id"], name: "index_templates_on_family_id"
   add_index "templates", ["org_id", "family_id"], name: "template_organisation_dmptemplate_index"
   add_index "templates", ["org_id"], name: "index_templates_on_org_id"
@@ -426,42 +428,4 @@ ActiveRecord::Schema.define(version: 20180405152454) do
 
   add_index "users_perms", ["user_id"], name: "index_users_perms_on_user_id"
 
-  add_foreign_key "annotations", "orgs"
-  add_foreign_key "annotations", "questions"
-  add_foreign_key "answers", "plans"
-  add_foreign_key "answers", "questions"
-  add_foreign_key "answers", "users"
-  add_foreign_key "answers_question_options", "answers"
-  add_foreign_key "answers_question_options", "question_options"
-  add_foreign_key "guidance_groups", "orgs"
-  add_foreign_key "guidances", "guidance_groups"
-  add_foreign_key "notes", "answers"
-  add_foreign_key "notes", "users"
-  add_foreign_key "org_identifiers", "identifier_schemes"
-  add_foreign_key "org_identifiers", "orgs"
-  add_foreign_key "org_token_permissions", "orgs"
-  add_foreign_key "org_token_permissions", "token_permission_types"
-  add_foreign_key "orgs", "languages"
-  add_foreign_key "orgs", "regions"
-  add_foreign_key "phases", "templates"
-  add_foreign_key "plans", "templates"
-  add_foreign_key "plans_guidance_groups", "guidance_groups"
-  add_foreign_key "plans_guidance_groups", "plans"
-  add_foreign_key "question_options", "questions"
-  add_foreign_key "questions", "question_formats"
-  add_foreign_key "questions", "sections"
-  add_foreign_key "questions_themes", "questions"
-  add_foreign_key "questions_themes", "themes"
-  add_foreign_key "roles", "plans"
-  add_foreign_key "roles", "users"
-  add_foreign_key "sections", "phases"
-  add_foreign_key "templates", "orgs"
-  add_foreign_key "themes_in_guidance", "guidances"
-  add_foreign_key "themes_in_guidance", "themes"
-  add_foreign_key "user_identifiers", "identifier_schemes"
-  add_foreign_key "user_identifiers", "users"
-  add_foreign_key "users", "languages"
-  add_foreign_key "users", "orgs"
-  add_foreign_key "users_perms", "perms"
-  add_foreign_key "users_perms", "users"
 end

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -1,3 +1,4 @@
+require 'set'
 namespace :upgrade do
 
   desc "Upgrade to 1.0"
@@ -274,5 +275,98 @@ namespace :upgrade do
     end
   end
 
+  desc "Remove duplicated non customised template versions"
+  task remove_duplicated_non_customised_template_versions: :environment do
+    templates = Template
+      .select(:id, :family_id, :version, :updated_at)
+      .group(:family_id, :version, :id)
+      .order(family_id: :asc, version: :asc, updated_at: :desc)
 
+    current_family_id = nil
+    unique_versions = nil
+    duplicates = []
+    templates.each do |template|
+      if current_family_id != template.family_id
+        current_family_id = template.family_id
+        unique_versions = Set.new
+      end
+      if unique_versions.add?(template.version).nil?
+        duplicates << template
+      end
+    end
+    current_family_id = nil
+    version_counter = nil
+    duplicates.each do |template|
+      if current_family_id != template.family_id
+        current_family_id = template.family_id
+        version_counter = nil
+      end
+      num_plans = Plan.where(template_id: template.id).count
+      if num_plans > 0
+        version_counter = version_counter.nil? ? -1 : version_counter - 1
+        unsaved_template = Template.find(template.id)
+        unsaved_template.version = version_counter
+        if Template.exists?(customization_of: template.family_id)
+          puts "template with id: #{template.id} has NOT been ARCHIVED since it had customised templates"
+        else
+          puts "template with id: #{template.id} has been ARCHIVED since it had plans associated but no customised templates"
+          unsaved_template.archived = true
+        end
+        unsaved_template.save!
+      else
+        Template.destroy(template.id)
+        puts "template with id: #{template.id} has been REMOVED since it had no plans associated"
+      end
+    end
+    puts "remove_duplicated_non_customised_template_versions DONE"
+  end
+  desc "Remove duplicated customised template versions"
+  task remove_duplicated_customised_template_versions: :environment do
+    templates = Template
+      .select(:id, :customization_of, :version, :org_id, :updated_at)
+      .where('customization_of IS NOT NULL')
+      .group(:customization_of, :org_id, :version, :id)
+      .order(customization_of: :asc, org_id: :asc, version: :asc, updated_at: :desc)
+    generate_compound_key = lambda{ |customization_of, org_id| return "#{customization_of}_#{org_id}" }
+    current = nil
+    unique_versions = nil
+    duplicates = []
+    templates.each do |template|
+      key = generate_compound_key.call(template.customization_of, template.org_id)
+      if current != key
+        current = key
+        unique_versions = Set.new
+      end
+      if unique_versions.add?(template.version).nil?
+        duplicates << template
+      end
+    end
+    current = nil
+    version_counter = nil
+    duplicates.each do |template|
+      key = generate_compound_key.call(template.customization_of, template.org_id)
+      if current != key
+        current = key
+        version_counter = nil
+      end
+      num_plans = Plan.where(template_id: template.id).count
+      if num_plans > 0
+        version_counter = version_counter.nil? ? -1 : version_counter - 1
+        unsaved_template = Template.find(template.id)
+        unsaved_template.version = version_counter
+        unsaved_template.archived = true
+        unsaved_template.save!
+        puts "template with id: #{template.id} has been ARCHIVED since it had plans associated"
+      else
+        Template.destroy(template.id)
+        puts "template with id: #{template.id} has been REMOVED since it has no plans associated"
+      end
+    end
+    puts "remove_duplicated_customised_template_versions DONE"
+  end
+  desc "Remove duplicated template versions"
+  task remove_duplicated_template_versions: :environment do
+    Rake::Task['upgrade:remove_duplicated_non_customised_template_versions'].execute
+    Rake::Task['upgrade:remove_duplicated_customised_template_versions'].execute
+  end
 end

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -73,7 +73,7 @@ class QuestionTest < ActiveSupport::TestCase
   end
 
   test "#deep_copy creates a new question object and attaches new annotation/question_option objects" do
-    questions = scaffold_template.phases.first.sections.first.questions.select{ |q| q.option_based? }
+    questions = @section.questions.select{ |q| q.option_based? }
     questions.each do |question|
       question_copy = question.deep_copy
       assert_deep_copy(question, question_copy, relations: [:annotations, :question_options])

--- a/test/unit/section_test.rb
+++ b/test/unit/section_test.rb
@@ -32,8 +32,7 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test "#deep_copy creates a new section object and attaches new question objects" do
-    section = scaffold_template.phases.first.sections.first
-    assert_deep_copy(section, section.deep_copy, relations: [:questions])
+    assert_deep_copy(@section, @section.deep_copy, relations: [:questions])
   end
   
   # ---------------------------------------------------


### PR DESCRIPTION
In order to ensure thread-safe operation for:
- generate_version!
- customize!(org)

I decided to go with Optimistic Concurrence Control and its implementation requires:
- Creating an index (family_id, version) for a successful generate_version! without duplicates
- Creating an index (customization_of, version, org_id) for a successful customize!(org) without duplicates

Please, execute the following commands in the order stated:
```
rake upgrade:remove_duplicated_template_versions
rake db:migrate
```
since the templates tables has to be cleaned up before adding the above mentioned indexes. @briri, @vyruss, @xsrust, can you check the tasks created in case I missed any edge case?


