### PR TITLE
fixed issue with template visibility for the default template

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -132,7 +132,7 @@ class Template < ActiveRecord::Base
   # Generates a new copy of self for the specified customizing_org
   def customize!(customizing_org)
     raise _('customize! requires an organisation target') unless customizing_org.is_a?(Org) # Assume customizing_org is persisted
-    raise _('customize! requires a template from a funder') unless org.funder_only? # Assume self has org associated
+    raise _('customize! requires a template from a funder') unless org.funder_only? || self.is_default # Assume self has org associated
     customization = deep_copy(
       attributes: {
         version: 0,
@@ -262,7 +262,7 @@ class Template < ActiveRecord::Base
       self.archived ||= false
       self.is_default ||= false
       self.version ||= 0
-      self.visibility = (org.present? && org.funder_only?) ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
+      self.visibility = ((self.org.present? && self.org.funder_only?) || self.is_default?) ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
       self.customization_of ||= nil
       self.family_id ||= new_family_id
       self.archived ||= false


### PR DESCRIPTION
Minor adjustment to Template creation defaults so that the default template remains publicly visible.

We discovered that our default template was no longer included in the list of customizable templates. It turned out to be an issue with the template's visibility setting. Decided to fix in sprint2 instead of master/development and add some tests since this is an edge case.
