### PR TITLE
Fix deep copy issue with orphaned objects

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -41,9 +41,9 @@ class Annotation < ActiveRecord::Base
     return annotation_copy
   end
 
-  def deep_copy
+  def deep_copy(**options)
     copy = self.dup
-    copy.question_id = nil
+    copy.question_id = options.fetch(:question_id, nil)
     return copy
   end
 end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -35,8 +35,9 @@ class Phase < ActiveRecord::Base
   def deep_copy(**options)
     copy = self.dup
     copy.modifiable = options.fetch(:modifiable, self.modifiable)
-    copy.template_id = nil
+    copy.template_id = options.fetch(:template_id, nil)
     copy.save!(validate:false)  if options.fetch(:save, false)
+    options[:phase_id] = id
     self.sections.each{ |section| copy.sections << section.deep_copy(options) }
     return copy
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -87,10 +87,11 @@ class Question < ActiveRecord::Base
   def deep_copy(**options)
     copy = self.dup
     copy.modifiable = options.fetch(:modifiable, self.modifiable)
-    copy.section_id = nil
+    copy.section_id = options.fetch(:section_id, nil)
     copy.save!(validate: false)  if options.fetch(:save, false)
-    self.question_options.each{ |question_option| copy.question_options << question_option.deep_copy }
-    self.annotations.each{ |annotation| copy.annotations << annotation.deep_copy }
+    options[:question_id] = copy.id
+    self.question_options.each{ |question_option| copy.question_options << question_option.deep_copy(options) }
+    self.annotations.each{ |annotation| copy.annotations << annotation.deep_copy(options) }
     self.themes.each{ |theme| copy.themes << theme }
     return copy
   end

--- a/app/models/question_option.rb
+++ b/app/models/question_option.rb
@@ -24,9 +24,9 @@ class QuestionOption < ActiveRecord::Base
     return question_option_copy
   end
 
-  def deep_copy
+  def deep_copy(**options)
     copy = self.dup
-    copy.question_id = nil
+    copy.question_id = options.fetch(:question_id, nil)
     return copy
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -56,8 +56,9 @@ class Section < ActiveRecord::Base
   def deep_copy(**options)
     copy = self.dup
     copy.modifiable = options.fetch(:modifiable, self.modifiable)
-    copy.phase_id = nil
+    copy.phase_id = options.fetch(:phase_id, nil)
     copy.save!(validate: false)  if options.fetch(:save, false)
+    options[:section_id] = id
     self.questions.map{ |question| copy.questions << question.deep_copy(options) }
     return copy
   end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -71,6 +71,7 @@ class Template < ActiveRecord::Base
       attributes.each_pair{ |attribute, value| copy.send("#{attribute}=".to_sym, value) if copy.respond_to?("#{attribute}=".to_sym) }
     end
     copy.save! if options.fetch(:save, false)
+    options[:template_id] = copy.id
     self.phases.each{ |phase| copy.phases << phase.deep_copy(options) }
     return copy
   end

--- a/test/unit/concerns/versionable_test.rb
+++ b/test/unit/concerns/versionable_test.rb
@@ -194,17 +194,17 @@ class VersionableTest < ActiveSupport::TestCase
     section = @template.phases.first.sections.first
     new_section = get_modifiable(section)
     assert_equal(section.id, new_section.id, 'returns the same section id')
-    assert_equal(section.template, new_section.template, 'returns the section without generating a new template hierarchy')
+    assert_equal(section.phase.template, new_section.phase.template, 'returns the section without generating a new template hierarchy')
     # Looking for a question
     question = @template.phases.first.sections.first.questions.first
     new_question = get_modifiable(question)
     assert_equal(question.id, new_question.id, 'returns the same question id')
-    assert_equal(question.template, new_question.template, 'returns the question without generating a new template hierarchy')
+    assert_equal(question.section.phase.template, new_question.section.phase.template, 'returns the question without generating a new template hierarchy')
     # Looking for an annotation
     annotation = @template.phases.first.sections.first.questions.first.annotations.first
     new_annotation = get_modifiable(annotation)
     assert_equal(annotation.id, new_annotation.id, 'returns the same annotation id')
-    assert_equal(annotation.template, new_annotation.template, 'returns the annotation without generating a new template hierarchy')
+    assert_equal(annotation.question.section.phase.template, new_annotation.question.section.phase.template, 'returns the annotation without generating a new template hierarchy')
   end
 
   test "#get_modifiable returns new phase when template is published" do
@@ -222,7 +222,7 @@ class VersionableTest < ActiveSupport::TestCase
     section = @template.phases.first.sections.first
     new_section = get_modifiable(section)
     assert_not_equal(section.id, new_section.id, 'returns different section id')
-    assert_not_equal(section.template, new_section.template, 'returns different template belonging')
+    assert_not_equal(section.phase.template, new_section.phase.template, 'returns different template belonging')
   end
 
   test "#get_modifiable returns new question when template is published" do
@@ -231,7 +231,7 @@ class VersionableTest < ActiveSupport::TestCase
     question = @template.phases.first.sections.first.questions.first
     new_question = get_modifiable(question)
     assert_not_equal(question.id, new_question.id, 'returns different question id')
-    assert_not_equal(question.template, new_question.template, 'returns different template belonging')
+    assert_not_equal(question.section.phase.template, new_question.section.phase.template, 'returns different template belonging')
   end
 
   test "#get_modifiable returns new annotation when template is published" do
@@ -240,6 +240,18 @@ class VersionableTest < ActiveSupport::TestCase
     annotation = @template.phases.first.sections.first.questions.first.annotations.first
     new_annotation = get_modifiable(annotation)
     assert_not_equal(annotation.id, new_annotation.id, 'returns different annotation id')
-    assert_not_equal(annotation.template, new_annotation.template, 'returns different template belonging')
+    assert_not_equal(annotation.question.section.phase.template, new_annotation.question.section.phase.template, 'returns different template belonging')
+  end
+  
+  test "#get_modifiable returns new question_option when template is published" do
+    @template.published = true
+    @template.save!
+    question = @template.phases.first.sections.first.questions.first
+    question.question_options << init_question_option(question)
+    question_option = question.question_options.first
+    new_question = get_modifiable(question)
+    new_question_option = new_question.question_options.first
+    assert_not_equal(question_option.id, new_question_option.id, 'returns different question_option id')
+    assert_not_equal(question_option.question.section.phase.template, new_question_option.question.section.phase.template, 'returns different template belonging')
   end
 end


### PR DESCRIPTION
- Passing parent id to children during deep_copy. 
- Updated tests to traverse hierarchy normally like `section.phase.template` instead of shortcuts like `section.template`