### PR TITLE
Issue1429

### DIFF
--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 // Generic JS that is applicable across multiple pages
+import './utils/array';
 import './utils/paginable';
 import './utils/panelHeading';
 import './utils/links';

--- a/lib/assets/javascripts/utils/array.js
+++ b/lib/assets/javascripts/utils/array.js
@@ -1,0 +1,20 @@
+import { isFunction } from './isType';
+
+if (!Array.prototype.find) {
+  Array.prototype.find = function (predicate) { // eslint-disable-line no-extend-native, func-names
+    if (!isFunction(predicate)) {
+      throw new TypeError('predicate must be a function');
+    }
+    const array = Object(this);
+    const length = array.length;
+    let i = 0;
+    while (i < length) {
+      if (predicate.call(this, array[i], i, array)) {
+        return array[i];
+      }
+      i += 1;
+    }
+    return undefined;
+  };
+}
+

--- a/lib/assets/javascripts/utils/tinymce.js
+++ b/lib/assets/javascripts/utils/tinymce.js
@@ -14,7 +14,7 @@ import { isObject, isString } from './isType';
 
 // Configuration extracted from https://www.tinymce.com/docs/advanced/usage-with-module-loaders/
 require.context(
-  'file-loader?name=[path][name].[ext]&context=node_modules/tinymce!tinymce/skins',
+  'file-loader?name=./stylesheets/[path][name].[ext]&context=node_modules/tinymce!tinymce/skins',
   true,
   /.*/,
 );
@@ -42,7 +42,7 @@ export const defaultOptions = {
   table_default_attributes: {
     border: 1,
   },
-  skin_url: '/javascripts/skins/lightgray', // editorManager.baseURL is not resolved properly for IE since document.currentScript is not supported, see issue https://github.com/tinymce/tinymce/issues/3584
+  skin_url: '/stylesheets/skins/lightgray', // editorManager.baseURL is not resolved properly for IE since document.currentScript is not supported, see issue https://github.com/tinymce/tinymce/issues/3584
 };
 /*
   This function is invoked anytime a new editor is initialised (e.g. Tinymce.init())

--- a/lib/assets/javascripts/views/answers/rda_metadata.js
+++ b/lib/assets/javascripts/views/answers/rda_metadata.js
@@ -121,7 +121,7 @@ $(() => {
 
   function initStandards() {
     // for each metadata question, init selected standards according to html
-    $('.rda_metadata').each(function () {
+    $('.rda_metadata').each(function () { // eslint-disable-line func-names
       // list of selected standards
       const selectedStandards = $(this).find('.selected_standards .list');
       // form listing of standards

--- a/lib/assets/javascripts/views/usage/index.js
+++ b/lib/assets/javascripts/views/usage/index.js
@@ -10,10 +10,10 @@ $(() => {
     const topic = $(el);
     return { [topic.val()]: topic.attr('data-url') };
   }).get() // An array of objects { topic: URL }
-    .reduce((acc, value) => Object.assign(acc, value), {}); // Flatten to a single object
+    .reduce((acc, value) => $.extend(acc, value), {});
   const rangeDatesUpToLastYearFromNow = () => {
     const getLastMonth = () => moment().subtract(1, 'month').clone();
-    const rangeDates = new Array(12).fill(1).reduce((acc, v, i) => {
+    const rangeDates = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].reduce((acc, v, i) => {
       const id = getLastMonth().subtract(i, 'month').format('MMM-YY');
       acc[id] = {
         start_date: getLastMonth().startOf('month').subtract(i, 'month').format('YYYY-MM-DD'),
@@ -116,7 +116,7 @@ $(() => {
   });
   const yearlySuccesHandler = ({ data, selector } = {}) => {
     const keys = Object.keys(data); // Keys are Month-Year strings and values might be [0...N]
-    if (keys.findIndex(k => data[k] > 0) > -1) {
+    if (keys.find(k => data[k] > 0)) {
       createChart({ selector, data });
     } else {
       $(selector).prev().show();


### PR DESCRIPTION
This PR adapts some of our JS to support IE. For instance, it fixes:
- Problem to save comments with IE
- Problem to display usage stats

Technically speaking:
- polyfill for Array.prototype.find for IE. DMPRoadmap/roadmap#1429
- usage/index.js replaced Object.assign, Array.prototype.fill and Array.prototype.findIndex using $.extend, [] and Array.prototype.find respectively. DMPRoadmap/roadmap#1429
- tinymce styles moved to public/stylesheets. DMPRoadmap/roadmap#1429
