### PR TITLE
Add overview of phases to templates page

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -81,11 +81,16 @@ module OrgAdmin
     
     # GET /org_admin/templates/[:id]
     def show
-      template = Template.includes(:org, :phases).find(params[:id])
+      template = Template.find(params[:id])
       authorize template
+      # Load the info needed for the overview section if the authorization check passes!
+      phases = template.phases.includes(sections: { questions: :question_options }).
+                        order('phases.number', 'sections.number', 'questions.number', 'question_options.number').
+                        select('phases.title', 'phases.description', 'sections.title', 'questions.text', 'question_options.text')
       render 'container', locals: { 
         partial_path: 'show', 
         template: template,
+        phases: phases,
         referrer: request.referrer.present? ? request.referrer : org_admin_templates_path }
     end
     
@@ -94,12 +99,17 @@ module OrgAdmin
     def edit
       template = Template.includes(:org, :phases).find(params[:id])
       authorize template
+      # Load the info needed for the overview section if the authorization check passes!
+      phases = template.phases.includes(sections: { questions: :question_options }).
+                        order('phases.number', 'sections.number', 'questions.number', 'question_options.number').
+                        select('phases.title', 'phases.description', 'sections.title', 'questions.text', 'question_options.text')
       if !template.latest?
         flash[:notice] = _("You are viewing a historical version of this #{template_type(template)}. You will not be able to make changes.")
       end
       render 'container', locals: { 
         partial_path: 'edit', 
         template: template,
+        phases: phases,
         referrer: request.referrer.present? ? request.referrer : org_admin_templates_path }
     end
     

--- a/app/views/org_admin/phases/_overview.html.erb
+++ b/app/views/org_admin/phases/_overview.html.erb
@@ -1,0 +1,70 @@
+<br>
+<h2><%= _('Template Overview') %></h2>
+<% phases.each do |phase| %>
+  <hr>
+  <div class="row">
+    <div class="col-md-12">
+      <div>
+        <h3>
+          <%= phase.title %>
+          <div class="pull-right">
+            <% if template.customization_of.nil? %>
+              <%= link_to _('Edit phase'), edit_org_admin_template_phase_path(template.id, phase.id), { class: "btn btn-default", role: 'button' } %>
+            <% else %>
+              <%= link_to _('Customize phase'), org_admin_template_phase_path(template.id, phase.id), { class: "btn btn-default", role: 'button' } %>
+            <% end %>
+            <% if template.latest? && phase.modifiable %>
+              <%= link_to _('Delete phase'), org_admin_template_phase_path(template.id, phase.id),
+                          data: { confirm: _("You are about to delete the '%{phase_title}' phase. This will remove all of the sections and questions listed below. Are you sure?") % { phase_title: phase.title }, 
+                                  length: 20, omission: _('... (continued)') }, method: :delete, class: 'btn btn-default', role: 'button' %>
+            <% end %>
+          </div>
+        </h3>
+        <p class="pull-left">
+          <%= raw phase.description %>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <% if phase.sections.length > 0 %>
+        <div class="table-responsive">
+          <table class="table table-hover">
+            <thead>
+              <tr>
+                <th><%= _('Sections')%></th>
+                <th><%= _('Questions')%></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% phase.sections.each do |section| %>
+                <tr>
+                  <td><p><%= section.title %></p></td>
+                  <td>
+                    <% if section.questions.present? %>
+                      <ul>
+                        <% section.questions.each do |question| %>
+                          <li>
+                            <%= raw question.text %>
+                            <% if question.question_options.length > 0 %>
+                              <ul>
+                                <% question_options.each do |option| %>
+                                  <li><%= option.text %></li>
+                                <% end %>
+                              </ul>
+                            <% end %>
+                          </li>
+                        <% end %>
+                      </ul>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/org_admin/phases/container.html.erb
+++ b/app/views/org_admin/phases/container.html.erb
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="col-md-12">
     <h1><%= template.title %></h1>
-    <%= link_to _('View all templates'), org_admin_templates_path, class: 'btn btn-default pull-right' %>
+    <%= link_to _('View all templates'), template.customization_of.present? ? customisable_org_admin_templates_path : organisational_org_admin_templates_path, class: 'btn btn-default pull-right' %>
   </div>
 </div>
 <div class="row">

--- a/app/views/org_admin/templates/_edit.html.erb
+++ b/app/views/org_admin/templates/_edit.html.erb
@@ -7,3 +7,6 @@
     </div>
   </div>
 </div>
+
+<%# passing phases separately here because we're only pulling down the necessary attributes %>
+<%= render partial: 'org_admin/phases/overview', locals: { template: template, phases: phases } %>

--- a/app/views/org_admin/templates/_show.html.erb
+++ b/app/views/org_admin/templates/_show.html.erb
@@ -32,3 +32,6 @@
   <dt><%= _('Last updated') %></dt>
   <dd><%= l template.updated_at.to_date, formats: :short %></dd>
 </dl>
+
+<%# passing phases separately here because we're only pulling down the necessary attributes %>
+<%= render partial: 'org_admin/phases/overview', locals: { template: template, phases: phases } %>

--- a/app/views/org_admin/templates/container.html.erb
+++ b/app/views/org_admin/templates/container.html.erb
@@ -13,8 +13,6 @@
         <div class="panel panel-default">
           <div class="panel-body">
             <%= render partial: partial_path, locals: local_assigns.merge(referrer: referrer) %>
-            <%# Placeholder for overview section's phase accordion list %>
-            <%# render partial: 'phases/index', locals: { phases: template.phases } %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adding the phase/section/question overview back to the Template details tab.