### PR TITLE
Fixed references to partials and templates.family

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -144,7 +144,7 @@ class PlansController < ApplicationController
     @all_ggs_grouped_by_org = @all_ggs_grouped_by_org.sort_by {|org,gg| (org.nil? ? '' : org.name)}
     @selected_guidance_groups = @selected_guidance_groups.collect{|gg| gg.id}
 
-    @based_on = (@plan.template.customization_of.nil? ? @plan.template : Template.where(family: @plan.template.customization_of).first)
+    @based_on = (@plan.template.customization_of.nil? ? @plan.template : Template.where(family_id: @plan.template.customization_of).first)
 
     respond_to :html
   end

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -38,7 +38,7 @@
               <%= section.title %> 
               <% if plan.present? %>
                   <span class="section-progress-<%= sectionid %>">
-                    <%= render :partial => "/sections/progress", locals: { section: section, plan: plan } %>
+                    <%= render :partial => "/org_admin/sections/progress", locals: { section: section, plan: plan } %>
                   </span>
               <% end %>
             </div>

--- a/app/views/phases/_guidances_notes.html.erb
+++ b/app/views/phases/_guidances_notes.html.erb
@@ -54,7 +54,7 @@
                 <% num_annotations = 0 %>
                 <% i = 0 %>
                 <% annotations.each do |annotation| %>
-                  <%= render partial: 'annotations/show', 
+                  <%= render partial: 'org_admin/annotations/show', 
                     locals: {
                       template: template,
                       example_answer: (annotation.example_answer? ? annotation : nil),


### PR DESCRIPTION
Fixes #1470.

Updated references to partials that were moved into the org_admin namespace. Also fixed reference to `templates.family` which should have been `family_id`