### PR TITLE
commented out version check on template update

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -136,7 +136,12 @@ module OrgAdmin
       authorize template   # NOTE if non-authorized error is raised, it performs a redirect to root_path and no JSON output is generated
 
       begin
-        template = Template.find_or_generate_version!(template)
+        # Commenting this out for ticket #1476 which requests that we not version a template
+        # if its details change (only for phase/section/question changes). Leaving the line
+        # below in the event that we determine that some attributes (e.g. title) should trigger
+        # a new version
+        #template = Template.find_or_generate_version!(template)
+
         template.links = ActiveSupport::JSON.decode(params["template-links"]) if params["template-links"].present?
         template.description = params["template-desc"]
       rescue ActiveSupport::JSON.parse_error

--- a/test/functional/org_admin/templates_controller_test.rb
+++ b/test/functional/org_admin/templates_controller_test.rb
@@ -200,16 +200,6 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     assert json_body["msg"].start_with?('Successfully') && json_body["msg"].include?('saved')
   end
 
-  test "cannot update a historical version template#update" do
-    params = {title: 'ABCD'}
-    version = @org_template.generate_version!
-    sign_in @org_admin
-    put org_admin_template_path(@org_template), {template: params}
-    assert_response :forbidden
-    json_body = ActiveSupport::JSON.decode(response.body)
-    assert json_body["msg"].include?(_('historical'))
-  end
-
   test "unauthorized user cannot customize a template#customize" do
     post customize_org_admin_template_path(@org_template)
     assert_unauthorized_redirect_to_root_path


### PR DESCRIPTION
Fixes #1476 

Commented out the call to `Template.find_or_version` for `templates_controller.update`. Left the line there in case we decide that some fields should trigger a new version (e.g. title)
