### PR TITLE
fixed issues with create plan template selection and changing plan vi…

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -284,7 +284,7 @@ module OrgAdmin
       if org_id.present? || funder_id.present?
         unless funder_id.blank?
           # Load the funder's template(s) minus the default template (that gets swapped in below if NO other templates are available)
-          templates = Template.latest_customizable.select{ |t| !t.is_default? }
+          templates = Template.latest_customizable.where(org_id: funder_id).select{ |t| !t.is_default? }
           unless org_id.blank?
             # Swap out any organisational cusotmizations of a funder template
             templates = templates.map do |tmplt|
@@ -315,6 +315,7 @@ module OrgAdmin
           templates << (customization.present? ? customization : default)
         end
       end
+      
       templates = (templates.count > 0 ? templates.sort{|x,y| x.title <=> y.title} : [])
       render json: {"templates": templates.collect{|t| {id: t.id, title: t.title} }}.to_json
     end

--- a/app/models/scopes/template_scope.rb
+++ b/app/models/scopes/template_scope.rb
@@ -74,7 +74,7 @@ module TemplateScope
     # Retrieves the latest version of each customizable funder template (and the default template)
     scope :latest_customizable, -> {
       family_ids = families(Org.funder.collect(&:id)).distinct.pluck(:family_id) << default.family_id
-      published(family_ids.flatten)
+      published(family_ids.flatten).where('visibility = ? OR is_default = ?', visibilities[:publicly_visible], true)
     }    
     # Retrieves unarchived templates with public visibility
     scope :publicly_visible, -> { unarchived.where(:visibility => visibilities[:publicly_visible]) }

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -237,7 +237,7 @@ class Template < ActiveRecord::Base
       self.archived ||= false
       self.is_default ||= false
       self.version ||= 0
-      self.visibility = ((self.org.present? && self.org.funder_only?) || self.is_default?) ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
+      self.visibility = ((self.org.present? && self.org.funder_only?) || self.is_default?) ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible] unless self.id.present?
       self.customization_of ||= nil
       self.family_id ||= new_family_id
       self.archived ||= false

--- a/test/integration/template_selection_test.rb
+++ b/test/integration/template_selection_test.rb
@@ -10,37 +10,48 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     @funder = init_funder
     @institution = init_institution
     @organisation = init_organisation
+    @funder2 = init_funder({ name: 'Funder 2', abbreviation: 'F2' })
     
     @researcher = init_researcher(@institution)
     @org_admin = init_org_admin(@institution)
     
-    @funder_template = init_template(@funder, {
-      title: 'Test Funder Template', 
-      published: true,
-      is_default: false,
-      visibility: Template.visibilities[:publicly_visible]
+    @funder_published_public_template = init_template(@funder, {
+      title: 'Test Funder public Template', 
+      published: true
     })
-    @org_template = init_template(@institution, {
+    @funder_published_private_template = init_template(@funder, {
+      title: 'Test Funder private Template', 
+      published: true
+    })
+    # funder templates are public by default on creation so set it to organisationally_visible afterward
+    @funder_published_private_template.update!({ visibility: Template.visibilities[:organisationally_visible] })
+    @funder_unpublished_template = init_template(@funder, {
+      title: 'Test Funder unpublished Template', 
+      published: false
+    })
+    @funder2_published_public_template = init_template(@funder2, {
+      title: 'Test Funder 2 Template', 
+      published: true
+    })
+    @org_published_private_template = init_template(@institution, {
       title: 'Test Org Template', 
-      published: true,
-      is_default: false,
-      visibility: Template.visibilities[:organisationally_visible]
+      published: true
     })
-    @default_template = init_template(@organisation, {
+    @default_published_private_template = init_template(@organisation, {
       title: 'Default Template',
       published: true,
-      is_default: true,
-      visibility: Template.visibilities[:organisationally_visible]
+      is_default: true
     })
   end
+  
   # ----------------------------------------------------------
   test 'new plan gets published versions of templates not the latest version' do
-    version = @org_template.generate_version!
+    version = @org_published_private_template.generate_version!
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}"
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert_equal @org_template.id, json['templates'][0]['id'], 'expected the published version of the template'
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal @org_published_private_template.id, json['templates'][0]['id'], 'expected the published version of the template'
   end
 
   # ----------------------------------------------------------
@@ -48,104 +59,109 @@ class TemplateSelectionTest < ActionDispatch::IntegrationTest
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=&plan[funder_id]="
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert_equal @default_template.id, json['templates'][0]['id'], 'expected the default template'
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal @default_published_private_template.id, json['templates'][0]['id'], 'expected the default template'
   end
 
   # ----------------------------------------------------------
-  test 'new plan gets org template when no funder is specified' do
+  test 'new plan gets org template when a research org is specified but no funder is specified' do
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]="
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert_equal @org_template.id, json['templates'][0]['id'], 'expected 1 org template'
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal @org_published_private_template.id, json['templates'][0]['id'], 'expected 1 org template'
   end
 
   # ----------------------------------------------------------
-  test 'new plan gets funder template when no research org is specified' do
+  test 'new plan gets multiple org templates when a research org is specified but no funder is specified' do
+    template2 = init_template(@institution, {
+      title: 'Test Org Template 2', 
+      published: true,
+      is_default: false,
+    })
+    template2.update!(visibility: Template.visibilities[:organisationally_visible])
+    sign_in @researcher
+    get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]="
+    json = JSON.parse(@response.body)
+    assert_equal 2, json['templates'].size, "expected 2 templates but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    json['templates'].each{ |h| assert [@org_published_private_template.id, template2.id].include?(h['id']), 'expected the json to include only the 2 org templates' }
+  end
+
+  # ----------------------------------------------------------
+  test 'new plan gets public funder template when no research org is specified' do
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=&plan[funder_id]=#{@funder.id}"
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert_equal @funder_template.id, json['templates'][0]['id'], 'expected the funder template'
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal @funder_published_public_template.id, json['templates'][0]['id'], 'expected the funder template'
   end
 
   # ----------------------------------------------------------
-  test 'new plan gets funder template when both research org and funder are specified' do
+  test 'new plan gets multiple public funder templates when no research org is specified' do
+    template2 = init_template(@funder, {
+      title: 'Test Funder Template 2', 
+      published: true,
+      is_default: false,
+      visibility: Template.visibilities[:publicly_visible]
+    })
+    sign_in @researcher
+    get "#{org_admin_template_options_path}?plan[org_id]=&plan[funder_id]=#{@funder.id}"
+    json = JSON.parse(@response.body)
+    assert_equal 2, json['templates'].size, "expected 2 templates but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    json['templates'].each{ |h| assert [@funder_published_public_template.id, template2.id].include?(h['id']), 'expected the json to include only the 2 funder templates' }
+  end
+  
+  # ----------------------------------------------------------
+  test 'new plan gets both the public funder template when both research org and funder are specified' do
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]=#{@funder.id}"
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert json['templates'].collect{ |t| t['id'] }.include?(@funder_template.id), 'expected to find the funder template'
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal @funder_published_public_template.id, json['templates'][0]['id'], 'expected the funder template'
   end
 
   # ----------------------------------------------------------
-  test 'new plan gets customized version of funder template when the research org has customized it' do
-    customization = @funder_template.customize!(@institution)
+  test 'new plan gets the customized version of funder template when the specified research org has customized it' do
+    customization = @funder_published_public_template.customize!(@institution)
     customization.update!(title: 'Customization test', published: true)
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]=#{@funder.id}"
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert_equal customization.id, json['templates'][0]['id'], 'expected the customized version of the funder template'
-  end
-
-  # ----------------------------------------------------------
-  test 'new plan gets choice between multiple funder templates' do
-    funder_template2 = init_template(@funder, { title: 'Funder template 2', published: true, visibility: Template.visibilities[:publicly_visible] })
-    sign_in @researcher
-    get "#{org_admin_template_options_path}?plan[org_id]=&plan[funder_id]=#{@funder.id}"
-    json = JSON.parse(@response.body)
-    assert_equal 2, json['templates'].size, 'expected 2 templates'
-    json['templates'].each do |tmplt|
-      assert [@funder_template.id, funder_template2.id].include?(tmplt['id']), 'expected both funder templates to be returned'
-    end
-  end
-  
-  # ----------------------------------------------------------
-  test 'new plan gets choice between multiple funder templates when research org and funder are specified' do
-    funder_template2 = init_template(@funder, { title: 'Funder template 2', published: true, visibility: Template.visibilities[:publicly_visible] })
-    sign_in @researcher
-    get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]=#{@funder.id}"
-    json = JSON.parse(@response.body)
-    assert_equal 2, json['templates'].size, 'expected 2 templates'
-    json['templates'].each do |tmplt|
-      assert [@funder_template.id, funder_template2.id].include?(tmplt['id']), 'expected both funder templates to be returned'
-    end
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal customization.id, json['templates'][0]['id'], 'expected the customization of the funder template'
   end
     
   # ----------------------------------------------------------
-  test 'new plan gets choice between multiple research org templates when research org and no funder is specified' do
+  test 'plan gets choice between multiple funder templates when both research org and funder are specified and both the org and funder have multiple templates' do
+    funder_template2 = init_template(@funder, { title: 'Funder template 2', published: true, visibility: Template.visibilities[:publicly_visible] })
     org_template2 = init_template(@institution, { title: 'Org template 2', published: true, visibility: Template.visibilities[:organisationally_visible] })
     sign_in @researcher
-    get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]="
+    get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]=#{@funder.id}"
     json = JSON.parse(@response.body)
-    assert_equal 2, json['templates'].size, 'expected 2 templates'
-    json['templates'].each do |tmplt|
-      assert [@org_template.id, org_template2.id].include?(tmplt['id']), 'expected both org templates to be returned'
-    end
+    assert_equal 2, json['templates'].size, "expected 2 templates but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    json['templates'].each{ |h| assert [@funder.id, funder_template2.id].include?(h['id']), 'expected the json to include only the funder templates' }
   end
   
   # ----------------------------------------------------------
   test 'new plan gets default template when combination of specified funder and research org have no templates' do
-    @org_template.destroy!
-    @funder_template.destroy!
+    @org_published_private_template.destroy!
+    @funder_published_public_template.destroy!
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]=#{@funder.id}"
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert_equal @default_template.id, json['templates'][0]['id'], 'expected the default template'
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal @default_published_private_template.id, json['templates'][0]['id'], 'expected the default template'
   end
   
   # ----------------------------------------------------------
-  test 'new plan gets customized version of the default template if the research org has no template of its own' do
-    @org_template.destroy
-    customization = @default_template.customize!(@institution)
+  test 'new plan gets customized version of the default template if the research org has no template of its own but has customized the default template' do
+    @org_published_private_template.destroy
+    customization = @default_published_private_template.customize!(@institution)
     customization.update!(title: 'Default template customization test', published: true)
     sign_in @researcher
     get "#{org_admin_template_options_path}?plan[org_id]=#{@institution.id}&plan[funder_id]="
     json = JSON.parse(@response.body)
-    assert_equal 1, json['templates'].size, 'expected 1 template'
-    assert_equal customization.id, json['templates'][0]['id'], 'expected the customized version of the default template'
+    assert_equal 1, json['templates'].size, "expected 1 template but got: #{json['templates'].collect{|h| h['title'] }.join(', ')}"
+    assert_equal customization.id, json['templates'][0]['id'], "expected the customized version of the default template"
   end
 end


### PR DESCRIPTION
For #1473 
- Fixed issues with what templates are presented to the user on create plan page
- Fixed issue with organizationally visible appearing in the customizable templates tab
- Fixed issue with changing the template visibility
- Added extensive tests to cover all of the create plan scenarios (e.g. default template, no funder, etc.)