### PR TITLE
Only display Draft icon if template is Draft on History page

### DIFF
--- a/app/views/paginable/templates/_history.html.erb
+++ b/app/views/paginable/templates/_history.html.erb
@@ -14,7 +14,7 @@
         <tr>
           <td>
             <%= template.title%>
-            <% if current == template.version %>
+            <% if template.draft? && template.latest? %>
               &nbsp;&nbsp;<i class="fa fa-pencil-square-o" aria-hidden="true"></i>&nbsp;&nbsp;<em><%=_('Draft')%></em>
             <% end %>
           </td>


### PR DESCRIPTION
Fixes #1497
updated history to use new template.draft? logic to determine when to display Draft icon