### PR TITLE
Fix 'back' button on preview so that it goes to appropriate edit/show

### DIFF
--- a/app/controllers/org_admin/phases_controller.rb
+++ b/app/controllers/org_admin/phases_controller.rb
@@ -29,15 +29,20 @@ module OrgAdmin
       if !phase.template.latest?
         flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
       end
-      section = params.fetch(:section, nil)
-      render('container',
-        locals: { 
-          partial_path: 'edit',
-          template: phase.template,
-          phase: phase,
-          sections: phase.sections.order(:number).select(:id, :title, :modifiable),
-          current_section: section.present? ? Section.find_by(id: section, phase_id: phase.id) : nil
-        })
+      # User cannot edit a phase if its a customization so redirect to show
+      if phase.template.customization_of.present?
+        redirect_to org_admin_template_phase_path(template_id: phase.template, id: phase.id)
+      else
+        section = params.fetch(:section, nil)
+        render('container',
+          locals: { 
+            partial_path: 'edit',
+            template: phase.template,
+            phase: phase,
+            sections: phase.sections.order(:number).select(:id, :title, :modifiable),
+            current_section: section.present? ? Section.find_by(id: section, phase_id: phase.id) : nil
+          })
+      end
     end
 
     #preview a phase

--- a/app/views/org_admin/phases/preview.html.erb
+++ b/app/views/org_admin/phases/preview.html.erb
@@ -4,7 +4,15 @@
     <h1><%= template.title %></h1>
     <div class="pull-right">
       <ul class="list-inline">
-        <li><%= link_to _('Back to edit phase'), edit_org_admin_template_phase_path(template_id: template.id, id: phase.id), class: 'btn btn-primary' %></li>
+        <% if template.latest? %>
+          <% if template.customization_of.present? %>
+            <li><%= link_to _('Back to customise phase'), org_admin_template_phase_path(template_id: template.id, id: phase.id), class: 'btn btn-primary' %></li>
+          <% else %>
+            <li><%= link_to _('Back to edit phase'), edit_org_admin_template_phase_path(template_id: template.id, id: phase.id), class: 'btn btn-primary' %></li>
+          <% end %>
+        <% else %>
+          <li><%= link_to _('Back to phase'), org_admin_template_phase_path(template_id: template.id, id: phase.id), class: 'btn btn-primary' %></li>
+        <% end %>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Fixes #1477 .
- Added checks for `template.latest?` and `customization_of` when determining which back button to present to user
- Added redirect on phases_controller.edit to phases_controller.show if edit page is accessed but the template is a customization