### PR TITLE
updated ajax success/error for section display

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -101,7 +101,9 @@
       SHIBBOLETH_DISCOVERY_SERVICE_SHOW_LIST: _('See the full list of partner institutions.'),
 
       NO_TEMPLATE_FOUND_ERROR: _('Unable to find a suitable template for the research organisation and funder you selected.'),
-      NEW_PLAN_DISABLED_TOOLTIP: _('Please select a research organisation and funder to continue.')
+      NEW_PLAN_DISABLED_TOOLTIP: _('Please select a research organisation and funder to continue.'),
+
+      AJAX_UNABLE_TO_LOAD_TEMPLATE_SECTION: _('Unable to load the section\'s content at this time.')
     }.to_json
     %>
 

--- a/lib/assets/javascripts/views/org_admin/phases/new_edit.js
+++ b/lib/assets/javascripts/views/org_admin/phases/new_edit.js
@@ -1,5 +1,6 @@
 import 'bootstrap-sass/assets/javascripts/bootstrap/collapse';
 import expandCollapseAll from '../../../utils/expandCollapseAll';
+import getConstant from '../../../constants';
 import { Tinymce } from '../../../utils/tinymce';
 import { isObject } from '../../../utils/isType';
 import ariatiseForm from '../../../utils/ariatiseForm';
@@ -17,17 +18,18 @@ $(() => {
   });
   $(parentSelector).on('ajax:success', 'a[data-remote="true"]', (e, data) => {
     const panelBody = $(e.target).parent().find('.panel-body');
+    const panel = panelBody.parent();
     if (isObject(panelBody)) {
-      const id = panelBody.closest('.collapse').attr('id');
       // Display the section's html
       panelBody.attr('data-loaded', 'true');
       panelBody.html(data);
       // Wire up the section
-      initSection(id);
+      initSection(panel.attr('id'));
     }
   });
-  $(parentSelector).on('ajax:error', 'a[data-remote="true"]', () => {
-    // TODO something generic for every error
+  $(parentSelector).on('ajax:error', 'a[data-remote="true"]', (e) => {
+    const panelBody = $(e.target).parent().find('.panel-body');
+    panelBody.html(`<p>${getConstant('AJAX_UNABLE_TO_LOAD_TEMPLATE_SECTION')}</p>`);
   });
   // Wire up the currently displayed section (if there is one and the new section form)
   initSection('collapseSectionNew');


### PR DESCRIPTION
Fixes #1486 
- updated identifier for section's panel on `ajax:success` handler
- added a default failure message on sections for `ajax:error` events

