### PR TITLE
Updated template statuses in tables

### DIFF
--- a/app/views/org_admin/templates/index.html.erb
+++ b/app/views/org_admin/templates/index.html.erb
@@ -53,12 +53,13 @@
               <ul class="nav navbar-nav">
                 <% if isActivePage(customisable_org_admin_templates_path) %>
                   <li><%= link_to _('All (%{count})') % { count: all_count}, "#{filter_path}?#{qry}", 'data-remote': "true" %></li>
-                  <li><%= link_to _('Customised (%{count})') % { count: published_count}, "#{filter_path}?f=customised&#{qry}", 'data-remote': "true" %></li>
-                  <li><%= link_to _('Not customised (%{count})') % { count: draft_count}, "#{filter_path}?f=not-customised&#{qry}", 'data-remote': "true" %></li>
+                  <li><%= link_to _('Published (%{count})') % { count: published_count}, "#{filter_path}?f=published&#{qry}", 'data-remote': "true" %></li>
+                  <li><%= link_to _('Unpublished (%{count})') % { count: unpublished_count}, "#{filter_path}?f=unpublished&#{qry}", 'data-remote': "true" %></li>
+                  <li><%= link_to _('Not customised (%{count})') % { count: not_customized_count}, "#{filter_path}?f=not-customised&#{qry}", 'data-remote': "true" %></li>
                 <% else %>
                   <li><%= link_to _('All (%{count})') % { count: all_count}, "#{filter_path}?#{qry}", 'data-remote': "true" %></li>
                   <li><%= link_to _('Published (%{count})') % { count: published_count}, "#{filter_path}?f=published&#{qry}", 'data-remote': "true" %></li>
-                  <li><%= link_to _('Draft (%{count})') % { count: draft_count}, "#{filter_path}?f=unpublished&#{qry}", 'data-remote': "true" %></li>
+                  <li><%= link_to _('Unpublished (%{count})') % { count: unpublished_count}, "#{filter_path}?f=unpublished&#{qry}", 'data-remote': "true" %></li>
                 <% end %>
               </ul>
             </div>

--- a/app/views/paginable/templates/_customisable.html.erb
+++ b/app/views/paginable/templates/_customisable.html.erb
@@ -5,7 +5,7 @@
       <tr>
         <th><%= _('Template Name') %>&nbsp;<%= paginable_sort_link('templates.title') %></th>
         <th><%= _('Funder') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
-        <th><%= _('Status') %>&nbsp;<%= paginable_sort_link('templates.published') %></th>
+        <th><%= _('Status') %></th>
         <th><%= _('Edited Date') %>&nbsp;<%= paginable_sort_link('templates.updated_at') %></th>
         <th>&nbsp;</th>
       </tr>
@@ -28,7 +28,9 @@
               <% if customization.published? %>
                 <%= _('Published') %>
               <% elsif customization.draft? %>
-                <%= _('Draft') %>
+                <% tooltip = _('You have unpublished changes! Select "Publish changes" in the Actions menu when you are ready to make them available to users.') %>
+                <%= _('Published') %> <em class="sr-only"><%= tooltip %></em>
+              &nbsp;&nbsp;<i class="fa fa-pencil-square-o red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
               <% else %>
                 <%= _('Unpublished') %>
               <% end %>

--- a/app/views/paginable/templates/_index.html.erb
+++ b/app/views/paginable/templates/_index.html.erb
@@ -5,7 +5,7 @@
       <tr>
         <th><%= _('Template Name') %>&nbsp;<%= paginable_sort_link('templates.title') %></th>
         <th><%= _('Organisation') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
-        <th><%= _('Status') %>&nbsp;<%= paginable_sort_link('templates.published') %></th>
+        <th><%= _('Status') %></th>
         <th><%= _('Edited Date') %>&nbsp;<%= paginable_sort_link('templates.updated_at') %></th>
       </tr>
     </thead>
@@ -22,7 +22,9 @@
             <% if template.published? %>
               <%= _('Published') %>
             <% elsif template.draft? %>
-              <%= _('Draft') %>
+              <% tooltip = _('This template is published changes but has unpublished changes!') %>
+              <%= _('Published') %> <em class="sr-only"><%= tooltip %></em>
+              &nbsp;&nbsp;<i class="fa fa-pencil-square-o" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
             <% else %>
               <%= _('Unpublished') %>
             <% end %>

--- a/app/views/paginable/templates/_organisational.html.erb
+++ b/app/views/paginable/templates/_organisational.html.erb
@@ -9,7 +9,7 @@
         <% else %>
           <th><%= (action == 'customizable' ? _('Funder') : _('Organisation')) %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
         <% end %>
-        <th><%= _('Status') %>&nbsp;<%= paginable_sort_link('templates.published') %></th>
+        <th><%= _('Status') %></th>
         <th><%= _('Edited Date') %>&nbsp;<%= paginable_sort_link('templates.updated_at') %></th>
         <% if action != 'index' %>
           <th>&nbsp;</th>
@@ -33,7 +33,9 @@
             <% if template.published? %>
               <%= _('Published') %>
             <% elsif template.draft? %>
-              <%= _('Draft') %>
+              <% tooltip = _('You have unpublished changes! Select "Publish changes" in the Actions menu when you are ready to make them available to users.') %>
+              <%= _('Published') %> <em class="sr-only"><%= tooltip %></em>
+              &nbsp;&nbsp;<i class="fa fa-pencil-square-o red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
             <% else %>
               <%= _('Unpublished') %>
             <% end %>


### PR DESCRIPTION
For #1507 and #1495.

- 'All templates' and 'Own templates' tabs now have only 2 statuses: Published and Unpublished. Published status will display a 'draft' icon and tooltip if there are unpublished changes.
- 'Customizable templates' tab now has 3 statuses: Published, Unpublished and Not Customized. The Published status will display 'draft' icon and tooltip if there are unpublished changes.
- Updated All, Published, Unpublished and Not Customized filters
- Removed the sort functionality from the Status columns until we address #1235 in an upcoming sprint
