### PR TITLE
Fixed initial numbering for new phases/sections

### DIFF
--- a/app/controllers/org_admin/phases_controller.rb
+++ b/app/controllers/org_admin/phases_controller.rb
@@ -62,16 +62,18 @@ module OrgAdmin
     def new
       template = Template.includes(:phases).find(params[:template_id])
       if template.latest?
+        nbr = template.phases.maximum(:number)
         phase = Phase.new({
           template: template,
           modifiable: true,
-          number: (template.phases.length > 0 ? template.phases.collect(&:number).max{|a, b| a <=> b } + 1 : 1)
+          number: (nbr.present? ? nbr + 1 : 1)
         })
         authorize phase
         render('/org_admin/templates/container',
           locals: {
             partial_path: 'new',
             template: template,
+            phase: phase,
             referrer: request.referrer.present? ? request.referrer : org_admin_templates_path
           })
       else

--- a/app/controllers/org_admin/questions_controller.rb
+++ b/app/controllers/org_admin/questions_controller.rb
@@ -55,9 +55,6 @@ module OrgAdmin
           flash[:alert] = failed_create_error(question, _('question'))
         end
       rescue StandardError => e
-question.valid?
-puts "ERROR: #{e.message}"
-puts question.errors.collect{|e,m| "#{e} - #{m}"}.join(', ')
         flash[:alert] = _('Unable to create a new version of this template.')
       end
       redirect_to edit_org_admin_template_phase_path(template_id: section.phase.template.id, id: section.phase.id, section: section.id)

--- a/app/views/org_admin/phases/_new.html.erb
+++ b/app/views/org_admin/phases/_new.html.erb
@@ -1,5 +1,5 @@
 <h2><%= _('Phase details') %></h2>
 <p><%= _('When you create a new phase for your template, a version will automatically be created. Once you complete the form below you will be provided with options to create sections and questions.') %></p>
-<%= form_for :phase, { url: org_admin_template_phases_path(template), html: { class: 'phase_form' } } do |f| %>
+<%= form_for phase, { url: org_admin_template_phases_path(template), html: { class: 'phase_form' } } do |f| %>
   <%= render partial: 'org_admin/phases/form', locals: local_assigns.merge({ f: f }) %>
 <% end %>

--- a/app/views/org_admin/sections/_form.html.erb
+++ b/app/views/org_admin/sections/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(section, url: url, namespace: section.id.present? ? section.id : 'new_section', html: { method: method }) do |f| %>
   <div class="form-group col-md-10">
     <%= f.label(:title, _('Title') ,class: "control-label") %>
-    <%= f.text_field(:title, { class: "form-control", 'aria-required': false, placeholder: _('Enter a title for the section'), 'data-toggle': 'tooltip', title: _('Enter a title for the section')} ) %>
+    <%= f.text_field(:title, { class: "form-control", 'aria-required': false, placeholder: _('Enter a title for the section'), 'data-toggle': 'tooltip', title: _('Enter a title for the section'), 'aria-required': true} ) %>
   </div>
 
   <div class="form-group">
@@ -9,7 +9,7 @@
       <%= f.label(:number, _('Order of display'), class: "control-label") %>
     </div>
     <div class="col-md-4">
-      <%= f.number_field(:number, in: 1..15, class: "form-control", 'aria-required': false, 'data-toggle': 'tooltip', title: _('This allows you to order sections.')) %>
+      <%= f.number_field(:number, in: 1..15, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('This allows you to order sections.')) %>
     </div>
   </div>
 

--- a/app/views/org_admin/sections/_new.html.erb
+++ b/app/views/org_admin/sections/_new.html.erb
@@ -1,5 +1,5 @@
 <!-- add a section and one question. Version is passed as an argument-->
-<% number = phase.sections.last ? phase.sections.last.number : 0 %>
+<% number = phase.sections.empty? ? 0 : phase.sections.maximum(:number) %>
 <% new_section = Section.new(phase_id: phase.id, number: number + 1) %>
 <%= render partial: 'org_admin/sections/form',
            locals: local_assigns.merge({ section: new_section, method: :post, url: org_admin_template_phase_sections_path(template_id: template.id, phase_id: phase.id) }) %>

--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -27,7 +27,7 @@
     <p class="form-control-static">
       <% if template.published? %>
         <%= _('Published') %>
-      <% elsif template.version.present? && template.version <= 0 %>
+      <% elsif (template.version.present? && template.version <= 0) || !template.id.present? %>
         <%= _('Unpublished') %>
       <% else %>
         <%= _('Draft') %>

--- a/lib/assets/javascripts/views/org_admin/sections/index.js
+++ b/lib/assets/javascripts/views/org_admin/sections/index.js
@@ -1,4 +1,7 @@
+import ariatiseForm from '../../../utils/ariatiseForm';
+
 $(() => {
+  ariatiseForm({ selector: '.new_section' });
   $('.section_new_link').on('click', (e) => {
     $(e.target).hide();
     $(e.target).closest('.row').find('.section_new').show();


### PR DESCRIPTION
Fixes #1528 

Also:
- Removed debug lines from controller
- Display 'Unpublished' for status of new unsaved template
- Make sure the new template 'View all templates' link goes to correct templates tab

