### PR TITLE
Add checks to controller to redirect requests for edit to show if not the latest template

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
     hashie (3.5.7)
-    htmltoword (0.7.0)
+    htmltoword (1.0.0)
       actionpack
       nokogiri
       rubyzip (>= 1.0)

--- a/app/controllers/org_admin/phases_controller.rb
+++ b/app/controllers/org_admin/phases_controller.rb
@@ -26,12 +26,9 @@ module OrgAdmin
     def edit
       phase = Phase.includes(:template).find(params[:id])
       authorize phase
-      if !phase.template.latest?
-        flash[:notice] = _('You are viewing a historical version of this template. You will not be able to make changes.')
-      end
       section = params.fetch(:section, nil)
       # User cannot edit a phase if its a customization so redirect to show
-      if phase.template.customization_of.present?
+      if phase.template.customization_of.present? || !phase.template.latest?
         redirect_to org_admin_template_phase_path(template_id: phase.template, id: phase.id, section: section)
       else
         render('container',

--- a/app/controllers/org_admin/sections_controller.rb
+++ b/app/controllers/org_admin/sections_controller.rb
@@ -36,7 +36,8 @@ module OrgAdmin
     def edit
       section = Section.includes({phase: :template}, questions: [:question_options, { annotations: :org }]).find(params[:id])
       authorize section
-      render partial: 'edit', 
+      # User cannot edit a section if its not modifiable or the template is not the latest redirect to show
+      render partial: (section.modifiable? && section.phase.template.latest? ? 'edit' : 'show'), 
         locals: { 
           template: section.phase.template, 
           phase: section.phase, 

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -96,13 +96,14 @@ module OrgAdmin
                         order('phases.number', 'sections.number', 'questions.number', 'question_options.number').
                         select('phases.title', 'phases.description', 'sections.title', 'questions.text', 'question_options.text')
       if !template.latest?
-        flash[:notice] = _("You are viewing a historical version of this #{template_type(template)}. You will not be able to make changes.")
+        redirect_to org_admin_template_path(id: template.id)
+      else
+        render 'container', locals: { 
+          partial_path: 'edit', 
+          template: template,
+          phases: phases,
+          referrer: get_referrer(template, request.referrer) }
       end
-      render 'container', locals: { 
-        partial_path: 'edit', 
-        template: template,
-        phases: phases,
-        referrer: get_referrer(template, request.referrer) }
     end
     
     # GET /org_admin/templates/new

--- a/test/functional/org_admin/phases_controller_test.rb
+++ b/test/functional/org_admin/phases_controller_test.rb
@@ -32,6 +32,14 @@ class PhasesControllerTest < ActionDispatch::IntegrationTest
     assert_nil flash[:alert]
   end
 
+  test 'get phases#edit redirects to #show when template is not latest' do
+    new_version = @template.generate_version!
+    sign_in @org_admin
+    get(edit_org_admin_template_phase_path(@template.id, @template.phases.first.id))
+    assert_response :redirect
+    assert_redirected_to org_admin_template_phase_path(@template.id, @template.phases.first.id)
+  end
+  
   test "unauthorized user cannot access the preview phase page" do
     get preview_org_admin_template_phase_path(@template, @phase)
     assert_unauthorized_redirect_to_root_path

--- a/test/functional/org_admin/templates_controller_test.rb
+++ b/test/functional/org_admin/templates_controller_test.rb
@@ -104,12 +104,12 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     assert_nil flash[:notice], 'expected no warning messages'
   end
 
-  test 'get templates#edit returns ok with flash notice when template is not latest' do
+  test 'get templates#edit redirects to #show when template is not latest' do
     new_version = @org_template.generate_version!
     sign_in @org_admin
     get(edit_org_admin_template_path(@org_template.id))
-    assert_response :success
-    assert_not_nil flash[:notice], 'expected a warning message'
+    assert_response :redirect
+    assert_redirected_to org_admin_template_path(@org_template.id)
   end
 
   test "unauthorized user cannot access the template#new page" do


### PR DESCRIPTION
Fixes #1554 

Update template/phase/section controllers to redirect requests to the edit action over to the show action if they do not belong to the latest version of the template. We control the flow via what actions are displayed on the views but we were not properly checking in the controller.

Also updated htmltoword to pull in @vyruss patch as mentioned in #1185