### PR TITLE
Issue1514

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -91,7 +91,7 @@ class UsersController < ApplicationController
 
   def update_email_preferences
     prefs = params[:prefs]
-    authorize current_user, :update?
+    authorize User
     pref = current_user.pref
     # does user not have prefs?
     if pref.blank?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,52 +1,57 @@
 class UserPolicy < ApplicationPolicy
+  attr_reader :signed_in_user
   attr_reader :user
 
-  def initialize(user, users)
-    raise Pundit::NotAuthorizedError, "must be logged in" unless user
+  def initialize(signed_in_user, user)
+    raise Pundit::NotAuthorizedError, "must be logged in" unless signed_in_user
+    @signed_in_user = signed_in_user
     @user = user
-    @users = users
-  end
-
-  def admin_index?
-    @user.can_grant_permissions?
   end
 
   def index?
     admin_index?
   end
 
+  def admin_index?
+    signed_in_user.can_grant_permissions?
+  end
+
   def admin_grant_permissions?
-    @user.can_grant_permissions? && ((@users.org_id == @user.org_id) || @user.can_super_admin?)
+    (signed_in_user.can_grant_permissions? && user.org_id == signed_in_user.org_id) || signed_in_user.can_super_admin?
   end
 
   def admin_update_permissions?
-    @user.can_grant_permissions?  && ((@users.org_id == @user.org_id) || @user.can_super_admin?)
+    (signed_in_user.can_grant_permissions? && user.org_id == signed_in_user.org_id) || signed_in_user.can_super_admin?
   end
 
   # Allows the user to swap their org affiliation on the fly
   def org_swap?
-    user.can_super_admin?
+    signed_in_user.can_super_admin?
   end
 
   def activate?
-    user.can_super_admin?
+    signed_in_user.can_super_admin?
   end
 
   def edit?
-    user.can_super_admin?
+    signed_in_user.can_super_admin?
   end
 
   def update?
-    user.can_super_admin?
+    signed_in_user.can_super_admin?
+  end
+
+  def update_email_preferences?
+    true
+  end
+
+  def acknowledge_notification?
+    true
   end
 
   class Scope < Scope
     def resolve
       scope.where(org_id: user.org_id)
     end
-  end
-
-  def acknowledge_notification?
-    true
   end
 end


### PR DESCRIPTION
- Adds update_email_preferences? instance method to user_policy
- Refactors user_policy to:
  - A more sensible variable instance names, i.e. from _@user_ to signed_in_user and from _@users_ to @user
  - Uses the accessor reader instead of instance variable on each instance method, i.e. favours behavioural access instead of data access

