### PR TITLE
Accessibility - Form fields missing labels #1445

### DIFF
--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -55,7 +55,7 @@ module Paginable
     # Generates an HTML link to sort given a sort field.
     # sort_field {String} - Represents the column name for a table
     def paginable_sort_link(sort_field)
-      return link_to(sort_link_name(sort_field), sort_link_url(sort_field), 'data-remote': true, class: 'paginable-action')
+      return link_to(sort_link_name(sort_field), sort_link_url(sort_field), 'data-remote': true, class: 'paginable-action', "aria-label": "#{sort_field}")
     end
     # Determines whether or not the latest request included the search functionality
     def searchable?

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -51,7 +51,7 @@
                   <td class="text-center user-status">
                     <% if is_super_admin %>
                       <%= form_for user, url: activate_user_path(user), html: { method: :put, remote: true, class: 'activate-user' } do |f| %>
-                        <%= check_box_tag(:active, "1", user.active) %>
+                        <%= check_box_tag(:active, "1", user.active, "aria-label": "active" ) %>
                         <%= f.submit(_('Update'), style: 'display: none;') %>
                       <% end %>
                     <% else %>

--- a/app/views/plans/_download_form.html.erb
+++ b/app/views/plans/_download_form.html.erb
@@ -30,7 +30,7 @@
   <div class="row">
     <div class="form-group col-xs-2">
       <%= select_tag :format, options_for_select(ExportedPlan::VALID_FORMATS, :pdf), 
-                     class: 'form-control' %>
+                     class: 'form-control', "aria-labelledby": "format" %>
     </div>
   </div>
 

--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -10,7 +10,7 @@
             title: _('If applying for funding, state the name exactly as in the grant proposal.')) %>
       <div class="checkbox">
         <%= f.hidden_field :visibility %>
-        <%= f.label(:is_test, raw("#{check_box_tag(:is_test,1, @plan.is_test?)} #{_('mock project for testing, practice, or educational purposes')}"), class: 'control-label') %>
+        <%= f.label(:is_test, raw("#{check_box_tag(:is_test,1, @plan.is_test? , "aria-label": "is_test")} #{_('mock project for testing, practice, or educational purposes')}"), class: 'control-label') %>
       </div>
         </div>
       </div>

--- a/app/views/plans/_guidance_choices.html.erb
+++ b/app/views/plans/_guidance_choices.html.erb
@@ -2,7 +2,7 @@
   <% if groups && groups.size == 1 %>
     <li class="checkbox">
       <%= check_box_tag "guidance_group_ids[]", groups[0].id,
-                        current_selections.include?(groups[0].id), class: 'guidance-choice' %>
+                        current_selections.include?(groups[0].id), class: 'guidance-choice', "aria-label": "#{groups[0].id}" %>
       <%= org.name %>
     </li>
   <% elsif groups %>
@@ -13,7 +13,7 @@
           <li class="checkbox">
             <span class="sublist">└─ </span>
             <%= check_box_tag "guidance_group_ids[]", group.id,
-                              current_selections.include?(group.id), class: 'guidance-choice' %>
+                              current_selections.include?(group.id), class: 'guidance-choice', "aria-label": "#{group.id}" %>
             <%= group.name %>
           </li>
         <% end %>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -15,7 +15,7 @@
       <h2 id="project-title"><%= _('What research project are you planning?') %></h2>
       <div class="form-group row">
         <div class="col-xs-6">
-          <%= f.text_field(:title, class: 'form-control', 'aria-describedby': 'project-title', 'aria-required': 'true', 
+          <%= f.text_field(:title, class: 'form-control', 'aria-describedby': 'project-title', 'aria-required': 'true', 'aria-label': 'project-title', 
                 'data-toggle': 'tooltip',
                 title: _('If applying for funding, state the project title exactly as in the proposal.')) %>
         </div>

--- a/app/views/shared/_accessible_combobox.html.erb
+++ b/app/views/shared/_accessible_combobox.html.erb
@@ -16,6 +16,7 @@
          data-combobox-allow-suggestion-on-empty="true"
          data-toggle="<%= title == '' ? '' : 'tooltip' %>"
          title="<%= title %>"
+         aria-label= "<%= title %>",
          value="<%= default_selection[attribute] unless default_selection.nil? %>" />
   <datalist id="<%= id %>_list">
     <% models.each do |model| %>

--- a/app/views/shared/_my_org.html.erb
+++ b/app/views/shared/_my_org.html.erb
@@ -13,7 +13,8 @@
 
   <div class="clearfix"></div>
   <%= f.text_field :other_organisation, autocomplete: "off", class: "form-control hide", 
-                   placeholder: _('Please enter the name of your organisation') %>
+                   placeholder: _('Please enter the name of your organisation'),
+                   "aria-label": "other_organisation" %>
   <div class="form-group has-error">
     <span id="help-org" class="help-block" style="display:none"><%= _('Please select an organisation from the list, or enter your organisation\'s name.') %></span>
   </div>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -5,7 +5,7 @@
       <span class="input-group-addon" id="search-addon">
         <span class="fa fa-search" aria-hidden="true"></span>
       </span>
-      <%= text_field_tag(:search, search_term, class: 'form-control', 'aria-describedby': 'search-addon', 'aria-required': true) %>
+      <%= text_field_tag(:search, search_term, class: 'form-control', 'aria-labelledby': 'search', 'aria-describedby': 'search-addon', 'aria-required': true) %>
     </div>
   </div>
   <%= submit_tag(_('Search'), class: 'btn btn-default', style: 'margin-top: 8px;') %>


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- Adding  aria-labels to form fields related to Plans, Users and Search fields where the labels are missing.
