### PR TITLE
Accessibility Issues - Put back titles for missing pages issue #1441

### DIFF
--- a/app/views/home/_welcome.html.erb
+++ b/app/views/home/_welcome.html.erb
@@ -1,3 +1,4 @@
+<% title _("Welcome to #{Rails.configuration.branding[:application][:name]}.") %>
 <div>
   <h1><%= _("Welcome to #{Rails.configuration.branding[:application][:name]}.")%></h1>
   <p>

--- a/app/views/super_admin/notifications/edit.html.erb
+++ b/app/views/super_admin/notifications/edit.html.erb
@@ -1,3 +1,4 @@
+<% title 'Editing Notification' %>
 <h2><%= _('Editing Notification') %></h2>
 
 <%= render 'form' %>

--- a/app/views/super_admin/notifications/index.html.erb
+++ b/app/views/super_admin/notifications/index.html.erb
@@ -1,3 +1,4 @@
+<% title 'Notifications' %>
 <div class="row">
   <div class="col-xs-12">
     <h2><%= _('Notifications') %></h2>

--- a/app/views/super_admin/notifications/new.html.erb
+++ b/app/views/super_admin/notifications/new.html.erb
@@ -1,3 +1,4 @@
+<% title 'New Notification' %>
 <h2><%= _('New notification') %></h2>
 
 <%= render 'form' %>

--- a/app/views/usage/index.html.erb
+++ b/app/views/usage/index.html.erb
@@ -1,3 +1,5 @@
+<% title 'Usage statistics' %>
+
 <div class="row">
   <div class="col-md-12">
     <h1>Usage statistics</h1>

--- a/app/views/users/admin_grant_permissions.html.erb
+++ b/app/views/users/admin_grant_permissions.html.erb
@@ -1,3 +1,5 @@
+<% title 'Edit User Privileges' %>
+
 <% namesHash = name_and_text %>
 <div class="row">
   <div class="col-md-12">

--- a/app/views/users/admin_index.html.erb
+++ b/app/views/users/admin_index.html.erb
@@ -1,4 +1,5 @@
 <% title 'User accounts' %>
+
 <div class="row">
   <div class="col-md-12">
     <h1><%= _('User accounts') %></h1>


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
-Some of the page titles went missing as part of merge process for the issue #1441. Putting them back as part of this PR.