### PR TITLE
added gettext markup to 'See full list' link

### DIFF
--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -156,7 +156,7 @@
       </ul>
 
       <p><%= _('Find guidance from additional organisations below') %></p>
-      <%= link_to 'See the full list', '#', 'data-toggle' =>  'modal', 'data-target' => '#modal-full-guidances', class: 'modal-guidances-window' %>
+      <%= link_to _('See the full list'), '#', 'data-toggle' =>  'modal', 'data-target' => '#modal-full-guidances', class: 'modal-guidances-window' %>
 
       <br>
       <%= f.button(_('Submit'), class: "btn btn-default", type: "submit") %>

--- a/config/locale/app.pot
+++ b/config/locale/app.pot
@@ -1706,6 +1706,9 @@ msgstr ""
 msgid "Security check"
 msgstr ""
 
+msgid "See the full list"
+msgstr ""
+
 msgid "See the full list of participating organisations"
 msgstr ""
 

--- a/config/locale/de/app.po
+++ b/config/locale/de/app.po
@@ -2024,6 +2024,10 @@ msgid "Security check"
 msgstr ""
 
 #, fuzzy
+msgid "See the full list"
+msgstr ""
+
+#, fuzzy
 msgid "See the full list of participating organisations"
 msgstr "Organisation"
 

--- a/config/locale/en_GB/app.po
+++ b/config/locale/en_GB/app.po
@@ -1726,6 +1726,9 @@ msgstr ""
 msgid "Security check"
 msgstr ""
 
+msgid "See the full list"
+msgstr ""
+
 msgid "See the full list of participating organisations"
 msgstr ""
 

--- a/config/locale/en_US/app.po
+++ b/config/locale/en_US/app.po
@@ -1784,6 +1784,9 @@ msgstr ""
 msgid "Security check"
 msgstr ""
 
+msgid "See the full list"
+msgstr ""
+
 msgid "See the full list of participating organisations"
 msgstr ""
 

--- a/config/locale/es/app.po
+++ b/config/locale/es/app.po
@@ -2028,6 +2028,10 @@ msgid "Security check"
 msgstr ""
 
 #, fuzzy
+msgid "See the full list"
+msgstr ""
+
+#, fuzzy
 msgid "See the full list of participating organisations"
 msgstr "Organización"
 

--- a/config/locale/fr_FR/app.po
+++ b/config/locale/fr_FR/app.po
@@ -2024,6 +2024,10 @@ msgid "Security check"
 msgstr ""
 
 #, fuzzy
+msgid "See the full list"
+msgstr ""
+
+#, fuzzy
 msgid "See the full list of participating organisations"
 msgstr "Organisation"
 

--- a/config/locale/pt_BR/app.po
+++ b/config/locale/pt_BR/app.po
@@ -1701,6 +1701,9 @@ msgstr "Seções"
 msgid "Security check"
 msgstr "Verificação de segurança"
 
+msgid "See the full list"
+msgstr "Veja a lista completa"
+
 msgid "See the full list of participating organisations"
 msgstr "Veja a lista completa de organizações participantes"
 


### PR DESCRIPTION
The 'See full list' string on the project details page did not have the gettext markup.
Added the markup and added the string to the POT/PO files.

Discovered and reported on dmptool stage instance: https://github.com/CDLUC3/dmptool/issues/173