### PR TITLE
fixed issue with Tinymce toolbar

### DIFF
--- a/app/views/guidances/new_edit.html.erb
+++ b/app/views/guidances/new_edit.html.erb
@@ -13,7 +13,7 @@
     <%= form_for(guidance, url: options[:url], html: { method: options[:method] , id: 'new_edit_guidance'}) do |f| %>
       <div class="form-group" data-toggle="tooltip" title="<%= _('Enter your guidance here. You can include links where needed.') %>">
         <%= f.label :text, class: 'control-label' %>
-        <%= text_area_tag("guidance-text", guidance.text, class: "tinymce form-control", 'aria-required': true, rows: 10) %>
+        <%= text_area_tag("guidance-text", guidance.text, class: "guidance-text form-control", 'aria-required': true, rows: 10) %>
       </div>
       <%= render partial: 'org_admin/shared/theme_selector', 
                  locals: { f: f, all_themes: themes,

--- a/app/views/super_admin/notifications/_form.html.erb
+++ b/app/views/super_admin/notifications/_form.html.erb
@@ -48,7 +48,7 @@
   <div class="form-group">
     <%= f.label :body, _('Body'), class: 'control-label' %>
     <%= f.text_area :body,
-        class: 'form-control',
+        class: 'form-control notification-text',
         value: @notification.body,
         "aria-required": true %>
   </div>

--- a/lib/assets/javascripts/views/guidances/new_edit.js
+++ b/lib/assets/javascripts/views/guidances/new_edit.js
@@ -3,5 +3,5 @@ import { Tinymce } from '../../utils/tinymce';
 
 $(() => {
   ariatiseForm({ selector: '#new_edit_guidance' });
-  Tinymce.init({ selector: '.tinymce' });
+  Tinymce.init({ selector: '.guidance-text' });
 });

--- a/lib/assets/javascripts/views/org_admin/phases/new_edit.js
+++ b/lib/assets/javascripts/views/org_admin/phases/new_edit.js
@@ -19,7 +19,10 @@ $(() => {
   const initQuestion = (context) => {
     const target = $(context);
     if (isObject(target)) {
-      Tinymce.init({ selector: `#${context} .question` });
+      // For some reason the toolbar options are retained after the call to Tinymce.init() on
+      // the views/notifications/edit.js file. Tried 'Object.assign' instead of '$.extend' but it
+      // made no difference
+      Tinymce.init({ selector: `#${context} .question`, toolbar: 'bold italic | bullist numlist | link | table' });
       ariatiseForm({ selector: `#${context} .question_form` });
       initQuestionOption(context);
       // Swap in the question_formats when the user selects an option based question type
@@ -41,7 +44,10 @@ $(() => {
   const initSection = (selector) => {
     if (isString(selector)) {
       // Wire up the section and its Questions
-      Tinymce.init({ selector: `${selector} .section` });
+      // For some reason the toolbar options are retained after the call to Tinymce.init() on
+      // the views/notifications/edit.js file. Tried 'Object.assign' instead of '$.extend' but it
+      // made no difference
+      Tinymce.init({ selector: `${selector} .section`, toolbar: 'bold italic | bullist numlist | link | table' });
       ariatiseForm({ selector: `${selector} .section_form` });
 
       const questionForm = $(selector).find('.question_form');

--- a/lib/assets/javascripts/views/super_admin/notifications/edit.js
+++ b/lib/assets/javascripts/views/super_admin/notifications/edit.js
@@ -3,7 +3,7 @@ import { Tinymce } from '../../../utils/tinymce';
 
 $(() => {
   Tinymce.init({
-    selector: '#notification_body',
+    selector: '.notification-text',
     forced_root_block: '',
     toolbar: 'bold italic underline | link',
   });


### PR DESCRIPTION
Fixes #1594 

The `views/notifications/edit.js` passes in a new 'toolbar' option that removes tables and bullets. Subsequent `tinymce.init()` calls end up using that 'toolbar' instead of the one defined in the defaultOptions constant on `utils/tinymce.js`. 

We're using the jquery `$.extend()` method to combine the options passed in by the caller with the defaultOptions. I tried switching it to `Object.assigns()` in case it was somehow updating the defaultOptions constant. It made no difference though. I think that Tinymce itself must be doing something weird.

Using an interim solution here to pass in the full 'toolbar' options that we want on the ajax based init calls. We may need to add this in elsewhere if we find any other situations like this. Another alternate option would be to stop passing the pared down 'toolbar' options in `views/notifications/edit.js` and just rely on super admins to not use bullets and tables in their notifications.
