### PR TITLE
fixed issue with saving other org on sup_admin edit user

### DIFF
--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -41,7 +41,7 @@ module SuperAdmin
      
     private
       def user_params
-        params.require(:super_admin_user).permit(:email, :firstname, :surname, :org_id, :language_id)
+        params.require(:user).permit(:email, :firstname, :surname, :org_id, :language_id, :other_organisation)
       end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
   <%= render partial: "layouts/navigation" %>
 </div>
 <div class="org-branding">
-  <% if user_signed_in? && !current_user.org.nil? && !current_user.org.is_other %>
+  <% if user_signed_in? && !current_user.org.nil? && (!current_user.org.is_other || current_user.can_super_admin?) %>
     <%= render partial: "layouts/branding" , locals: {max_number_links: MAX_NUMBER_LINKS_FUNDER,} %>
   <% end %>
 </div>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -10,7 +10,7 @@
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_for(user, as: :super_admin_user, url: super_admin_user_path(user), html: {method: :put, id: 'super_admin_user_edit' }) do |f| %>
+    <%= form_for(user, namespace: :superadmin, as: :user, url: super_admin_user_path(user), html: {method: :put, id: 'super_admin_user_edit' }) do |f| %>
       <div class="form-group col-xs-8">
         <%= f.label(:email, _('Email'), class: 'control-label') %>
         <%= f.email_field(:email, class: "form-control", "aria-required": true, value: user.email) %>

--- a/test/functional/super_admin/users_controller_test.rb
+++ b/test/functional/super_admin/users_controller_test.rb
@@ -28,18 +28,18 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   
   test 'unauthorized user cannot edit a user' do
     params = { firstname: 'Foo', surname: 'Bar' }
-    put super_admin_user_path(@user), { super_admin_user: params }
+    put super_admin_user_path(@user), { user: params }
     assert_unauthorized_redirect_to_root_path
     
     sign_in @user
-    put super_admin_user_path(@user), { super_admin_user: params }
+    put super_admin_user_path(@user), { user: params }
     assert_authorized_redirect_to_plans_page
   end
 
   test 'super admin can edit a user' do  
     params = { firstname: 'Foo', surname: 'Bar' }
     sign_in @super_admin
-    put super_admin_user_path(@user), { super_admin_user: params }
+    put super_admin_user_path(@user), { user: params }
     assert_response :redirect
     @user.reload
     assert_equal 'Foo', @user.firstname, "expected the User's firstname to have been updated"


### PR DESCRIPTION
For #1589 

Fixes issue with saving 'other org' on the edit user page.

Also fixed issue with super admin not having access to the admin menu after updating their org to 'other org'
