### PR TITLE
Issue 1409

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,6 +1,6 @@
+require 'pp'
 class PlansController < ApplicationController
   include ConditionalUserMailer
-  require 'pp'
   helper PaginableHelper
   helper SettingsTemplateHelper
   after_action :verify_authorized, except: [:overview]
@@ -158,9 +158,7 @@ class PlansController < ApplicationController
     
     readonly = !plan.editable_by?(current_user.id)
     
-    guidance_groups_ids = plan.guidance_groups.collect(&:id)
-    
-    guidance_groups =  GuidanceGroup.where(published: true, id: guidance_groups_ids)
+    guidance_groups =  GuidanceGroup.where(published: true, id: plan.guidance_group_ids)
     # Since the answers have been pre-fetched through plan (see Plan.load_for_phase)
     # we create a hash whose keys are question id and value is the answer associated
     answers = plan.answers.reduce({}){ |m, a| m[a.question_id] = a; m }
@@ -170,7 +168,8 @@ class PlansController < ApplicationController
       plan: plan, phase: phase, readonly: readonly,
       question_guidance: plan.guidance_by_question_as_hash,
       guidance_groups: guidance_groups,
-      answers: answers })
+      answers: answers,
+      guidance_service: GuidanceService.new(plan) })
   end
   
   # PUT /plans/1

--- a/app/services/guidance_service.rb
+++ b/app/services/guidance_service.rb
@@ -1,0 +1,139 @@
+class GuidanceService
+  attr_accessor :plan
+  attr_accessor :guidance_groups
+
+  def initialize(plan)
+    @plan = plan
+    @guidance_groups = plan.guidance_groups.where(published: true)
+  end
+  # Returns an Array of orgs according to the guidance related to plan
+  # Note the Array is sorted in the following order:
+  # First funder org (if the template from the plan is a customization of another)
+  # Second template owner's org
+  # The orgs from every guidance group selected for this plan
+  def orgs
+    if !defined?(@orgs)
+      @orgs = []
+      org_found = lambda{ |orgs, org| return orgs.find{ |lookup_org| lookup_org.id == org.id }.present? }
+      orgs_from_annotations.each{ |org| @orgs << org unless org_found.call(@orgs, org) }
+      orgs_from_guidance_groups.each{ |org| @orgs << org unless org_found.call(@orgs, org) }
+    end
+    return @orgs
+  end
+  def any?(org:nil, question:nil)
+    if org.nil? && question.nil?
+      return hashified_annotations? || hashified_guidance_groups?
+    end
+    return guidance_annotations?(org: org, question: question) ||
+    guidance_groups_by_theme?(org: org, question: question)
+  end
+  # Returns true if exists any guidance_group applicable to the org and question passed
+  def guidance_groups_by_theme?(org: nil, question: nil)
+    return false unless question.respond_to?(:themes)
+    return false unless hashified_guidance_groups.has_key?(org)
+    result = guidance_groups_by_theme(org: org, question: question).detect do |gg, theme_hash|
+      if theme_hash.present?
+        theme_hash.detect{ |theme, guidances| guidances.present? }
+      else
+        false
+      end
+    end
+    return result.present?
+  end
+  # Returns true if exists any annotation applicable to the org and question passed
+  def guidance_annotations?(org: nil, question: nil)
+    return false unless question.respond_to?(:id)
+    return false unless hashified_annotations.has_key?(org)
+    return hashified_annotations[org].find{ |annotation| annotation.question_id == question.id }.present?
+  end
+  # Returns a hash of guidance groups for an org and question passed with the following structure:
+  # { guidance_group: { theme: [guidance, ...], ... }, ... }
+  def guidance_groups_by_theme(org: nil, question: nil)
+    raise ArgumentError unless question.respond_to?(:themes)
+    return {} unless hashified_guidance_groups.has_key?(org)
+    return hashified_guidance_groups[org].each_key.reduce({}) do |acc, gg|
+      filtered_gg = hashified_guidance_groups[org][gg].each_key.reduce({}) do |acc, theme|
+        acc[theme] = hashified_guidance_groups[org][gg][theme] if question.themes.include?(theme)
+        acc
+      end
+      acc[gg] = filtered_gg if filtered_gg.present?
+      acc
+    end
+  end
+  # Returns a collection of annotations (type guidance) for an org and question passed
+  def guidance_annotations(org: nil, question: nil)
+    raise ArgumentError unless question.respond_to?(:id)
+    return [] unless hashified_annotations.has_key?(org)
+    return hashified_annotations[org].select{ |annotation| annotation.question_id == question.id }
+  end
+
+  private
+    def orgs_from_guidance_groups
+      if !defined?(@orgs_from_guidance_groups)
+        @orgs_from_guidance_groups = Org.joins(:guidance_groups).where("guidance_groups.id": guidance_groups.map(&:id)).distinct("orgs.id")
+      end
+      return @orgs_from_guidance_groups
+    end
+    def orgs_from_annotations
+      if !defined?(@orgs_from_annotations)
+        @orgs_from_annotations = []
+        @orgs_from_annotations << Template.find_by(family_id: plan.template.customization_of).org if plan.template.customization_of.present?
+        @orgs_from_annotations << plan.template.org
+      end
+      return @orgs_from_annotations
+    end
+    def hashified_guidance_groups
+      @hashified_guidance_groups ||= hashify_guidance_groups
+    end
+    def hashified_guidance_groups?
+      result = hashified_guidance_groups.detect do |org, gg_hash|
+        if gg_hash.present?
+          gg_hash.detect do |gg, theme_hash|
+            if theme_hash.present?
+              theme_hash.detect{ |theme, guidances| guidances.present? }
+            else
+              false
+            end
+          end
+        else
+          false
+        end
+      end
+      return result.present?
+    end
+    def hashified_annotations
+      @hashified_annotations ||= hashify_annotations
+    end
+    def hashified_annotations?
+      return hashified_annotations.detect{ |org, annotations| annotations.present? }.present?
+    end
+    # Hashifies guidance groups for a plan according to the distinct orgs into the following structure:
+    # { org: { guidance_group: { theme: [guidance, ...], ... }, ... }, ... }
+    def hashify_guidance_groups
+      hashified_guidances = hashify_guidances
+      return orgs_from_guidance_groups.reduce({}) do |acc, org|
+        org_guidance_groups = hashified_guidances.each_key.select{ |gg| gg.org_id == org.id }
+        acc[org] = org_guidance_groups.reduce({}){ |acc, gg| acc[gg] = hashified_guidances[gg]; acc }
+        acc
+      end
+    end
+    # Hashifies guidances from a collection of guidance_groups passed into the following structure:
+    # { guidance_group: { theme: [guidance, ...], ... }, ... }
+    def hashify_guidances
+      return guidance_groups.reduce({}) do |acc, gg|
+        themes = Theme.includes(:guidances).joins(:guidances).merge(Guidance.where(guidance_group_id: gg.id, published: true))
+        acc[gg] = themes.reduce({}) do |acc, theme|
+          acc[theme] = theme.guidances
+          acc
+        end
+        acc
+      end
+    end
+    def hashify_annotations
+      return orgs_from_annotations.reduce({}) do |acc, org|
+        annotations = Annotation.where(org_id: org.id, question_id: plan.question_ids)
+        acc[org] = annotations.select{ |annotation| annotation.org_id = org.id }
+        acc
+      end
+    end
+end

--- a/app/services/guidance_service.rb
+++ b/app/services/guidance_service.rb
@@ -44,7 +44,7 @@ class GuidanceService
   def guidance_annotations?(org: nil, question: nil)
     return false unless question.respond_to?(:id)
     return false unless hashified_annotations.has_key?(org)
-    return hashified_annotations[org].find{ |annotation| annotation.question_id == question.id }.present?
+    return hashified_annotations[org].find{ |annotation| (annotation.question_id == question.id) && (annotation.type == "guidance")}.present?
   end
   # Returns a hash of guidance groups for an org and question passed with the following structure:
   # { guidance_group: { theme: [guidance, ...], ... }, ... }
@@ -64,7 +64,7 @@ class GuidanceService
   def guidance_annotations(org: nil, question: nil)
     raise ArgumentError unless question.respond_to?(:id)
     return [] unless hashified_annotations.has_key?(org)
-    return hashified_annotations[org].select{ |annotation| annotation.question_id == question.id }
+    return hashified_annotations[org].select{ |annotation| (annotation.question_id == question.id) && (annotation.type == "guidance")}
   end
 
   private
@@ -131,7 +131,7 @@ class GuidanceService
     end
     def hashify_annotations
       return orgs_from_annotations.reduce({}) do |acc, org|
-        annotations = Annotation.where(org_id: org.id, question_id: plan.question_ids)
+        annotations = Annotation.where(org_id: org.id, question_id: plan.template.question_ids)
         acc[org] = annotations.select{ |annotation| annotation.org_id = org.id }
         acc
       end

--- a/app/views/guidance_groups/_index_by_theme.html.erb
+++ b/app/views/guidance_groups/_index_by_theme.html.erb
@@ -11,22 +11,22 @@
   <% guidance_groups_by_theme.each_pair do |guidance_group, theme_hash| %>
     <% theme_hash.each_pair do |theme, guidances| %>
       <div class="panel panel-default">
-        <div 
-          class="heading-button" 
-          role="button" 
+        <div
+          class="heading-button"
+          role="button"
           data-toggle="collapse"
           href="<%= "##{guidances.object_id}" %>"
           aria-expanded="false"
           aria-controls="<%= "##{guidances.object_id}" %>">
           <div class="panel-heading" role="tab" id="<%= "panel-heading-#{guidances.object_id}" %>">
             <h2 class="panel-title">
-              <%= _("%{name} on %{title}") % { :name => guidance_group.name, :title => theme.title } %>
+              <%= theme.title %>
               <i class="fa fa-plus pull-right" aria-hidden="true"></i>
             </h2>
           </div>
         </div>
         <div
-          id="<%= "#{guidances.object_id}" %>" 
+          id="<%= "#{guidances.object_id}" %>"
           class="panel-collapse collapse"
           role="tabpanel"
           aria-labelledby="<%= "panel-heading-#{guidances.object_id}" %>">

--- a/app/views/guidance_groups/_index_by_theme.html.erb
+++ b/app/views/guidance_groups/_index_by_theme.html.erb
@@ -1,0 +1,42 @@
+<%# locals{ guidance_groups_by_theme } %>
+<% parent_id = guidance_groups_by_theme.object_id %>
+<div id="<%= parent_id %>" class="panel-group" role="tablist" aria-multiselectable="true">
+  <div id="guidance-accordion-controls">
+    <div class="accordion-controls" data-parent="<%= parent_id %>">
+      <a href="#" data-toggle-direction="show"><%= _('expand all') %></a>
+        <span>|</span>
+      <a href="#" data-toggle-direction="hide"><%= _('collapse all') %></a>
+    </div>
+  </div>
+  <% guidance_groups_by_theme.each_pair do |guidance_group, theme_hash| %>
+    <% theme_hash.each_pair do |theme, guidances| %>
+      <div class="panel panel-default">
+        <div 
+          class="heading-button" 
+          role="button" 
+          data-toggle="collapse"
+          href="<%= "##{guidances.object_id}" %>"
+          aria-expanded="false"
+          aria-controls="<%= "##{guidances.object_id}" %>">
+          <div class="panel-heading" role="tab" id="<%= "panel-heading-#{guidances.object_id}" %>">
+            <h2 class="panel-title">
+              <%= _("%{name} on %{title}") % { :name => guidance_group.name, :title => theme.title } %>
+              <i class="fa fa-plus pull-right" aria-hidden="true"></i>
+            </h2>
+          </div>
+        </div>
+        <div
+          id="<%= "#{guidances.object_id}" %>" 
+          class="panel-collapse collapse"
+          role="tabpanel"
+          aria-labelledby="<%= "panel-heading-#{guidances.object_id}" %>">
+          <div class="panel-body">
+            <% guidances.each do |guidance| %>
+              <%= raw(guidance.text) %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/org_admin/annotations/_show.html.erb
+++ b/app/views/org_admin/annotations/_show.html.erb
@@ -1,13 +1,11 @@
 <% if example_answer.present? || guidance.present? %>
   <dl<%= for_plan ? ' class="dl-horizontal"' : '' %>>
     <% if example_answer.present? %>
-      <% label = (for_plan && template.customization_of.present?) ? _('%{org} Example Answer') % { org: example_answer.org.short_name } : _('Example Answer') %>
-      <dt><%= label %></dt>
+      <dt><%= _('%{org} Example Answer') % { org: example_answer.org.short_name } %></dt>
       <dd><%= raw example_answer.text %><dd>
     <% end %>
     <% if guidance.present? %>
-      <% label = (for_plan && template.customization_of.present?) ? _('%{org} Guidance') % { org: guidance.org.short_name } : _('Guidance') %>
-      <dt><%= label %></dt>
+      <dt><%= _('Question Specific Guidance') %></dt>
       <dd><%= raw guidance.text %></dd>
     <% end %>
   </dl>

--- a/app/views/org_admin/phases/preview.html.erb
+++ b/app/views/org_admin/phases/preview.html.erb
@@ -31,19 +31,20 @@
       <div role="tabpanel" class="tab-pane active">
         <div class="panel panel-default">
           <div class="panel-body">
-            <%= render partial: '/phases/edit_plan_answers', 
+            <%= render partial: '/phases/edit_plan_answers',
                   locals: {
-                    plan: nil, 
-                    phase: phase, 
-                    readonly: true, 
-                    question_guidance: {}, 
-                    edit: false, 
-                    guidance_groups: [], 
-                    base_template_org: template.base_org } %>
+                    plan: nil,
+                    phase: phase,
+                    readonly: true,
+                    question_guidance: {},
+                    edit: false,
+                    guidance_groups: [],
+                    base_template_org: template.base_org,
+                    guidance_service: GuidanceService.new(Plan.new(template: phase.template)) } %>
           </div>
         </div>
       </div>
     </div>
-    
+
   </div>
 </div>

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -72,7 +72,12 @@
                   </div>
                   <div class="col-md-4">
                     <!-- Guidances and notes partial view -->
-                    <%= render partial: '/phases/guidances_notes', locals: { plan: plan, template: phase.template, question: question, answer: answer, question_guidance: question_guidance, guidance_groups: guidance_groups, base_template_org: base_template_org } %>
+                    <%= render partial: '/phases/guidances_notes', locals: {
+                      plan: plan,
+                      template: phase.template,
+                      question: question,
+                      answer: answer,
+                      guidance_service: guidance_service } %>
                   </div>
                 </div>
                 <%= raw('<hr />') if i != section.questions.length - 1 %>

--- a/app/views/phases/_guidances_notes.html.erb
+++ b/app/views/phases/_guidances_notes.html.erb
@@ -1,7 +1,6 @@
-<%# locals: { plan, template, question, answer, question_guidance, guidance_groups } %>
-<% annotations = question.annotations.where(type: Annotation.types[:guidance]) %>
-<% guidance_set = question_guidance[question.id] || {} %>
-<% guidances_active = (annotations.present? || guidance_set.length > 0) %>
+<%# locals: { plan, template, question, answer, guidance_service } %>
+<% guidances_active = guidance_service.any? %>
+<% active_nav = nil %>
 <div id="plan-guidance-tab">
   <!-- Nav tabs -->
   <ul class="nav nav-pills nav-justified mb-10" role="tablist">
@@ -25,59 +24,45 @@
   <div class="tab-content">
     <div id="guidances-<%= question.id %>" role="tabpanel" class="tab-pane <%= 'active' if guidances_active %>">
       <ul class="nav nav-tabs" role="tablist">
-        <% if annotations.present? %>
-          <li role="presentation" class="active">
-            <a data-target="#annotations-<%= question.id %>" aria-controls="annotations-<%= question.id %>" role="tab" data-toggle="tab" 
-               class="view-plan-guidance">
-              <%= base_template_org.short_name %>
-            </a>
-          </li>
-        <% end %>
-        <% guidance_set.keys.each do |group| %>
-          <% obj = guidance_groups.select{ |gg| gg.name == group }.first %>
-          <% if obj.present? %>
-            <li role="presentation">
-              <a data-target="#guidance-<%= question.id %>-<%= obj.id %>" aria-controls="guidance-<%= question.id %>-<%= obj.id %>" 
-                 role="tab" data-toggle="tab" class="view-plan-guidance">
-                <%= group[0..15] %>
-              </a>
-            </li>
-          <% end %>
+        <% guidance_service.orgs.each_with_index do |org, i| %>
+            <% if guidance_service.any?(org: org, question: question) %>
+              <% active_nav ||= org.id %>
+              <li role="presentation" <%= active_nav == org.id ? "class=active" : "" %>>
+                <a
+                  data-target="<%= "#guidance_per_question_#{question.id}_#{i}" %>"
+                  aria-controls="<%= "#guidance_per_question_#{question.id}_#{i}" %>"
+                  role="tab"
+                  data-toggle="tab"
+                  class="view-plan-guidance">
+                  <%= org.abbreviation %>
+                </a>
+              </li>
+            <% end %>
         <% end %>
       </ul>
       <div class="tab-content">
-        <% if annotations.present? %>
-          <div id="annotations-<%= question.id %>" role="tabpanel" class="tab-pane active">
-            <div class="panel panel-default">
-              <div class="panel-body">
-                <!-- annotations with type guidance -->
-                <% num_annotations = 0 %>
-                <% i = 0 %>
-                <% annotations.each do |annotation| %>
-                  <%= render partial: 'org_admin/annotations/show', 
-                    locals: {
-                      template: template,
-                      example_answer: (annotation.example_answer? ? annotation : nil),
-                      guidance: (annotation.guidance? ? annotation : nil),
-                      for_plan: true 
-                  } %>
-                  <% num_annotations += 1%>
-                  <% i += 1 %>
-                <% end %>
-              </div>
-            </div>
-          </div>
-        <% end %>
-        <% guidance_accordion_id = 0 %>
-        <% guidance_set.keys.each_with_index do |group, i| %>
-          <% obj = guidance_groups.select{ |gg| gg.name == group }.first %>
-          <% if obj.present? %>
-            <% accordion_id = "#{question.id}-#{obj.id}" %>
-            <div id="guidance-<%= accordion_id %>" role="tabpanel" class="tab-pane<%= annotations.present? ? '' : ' active' %>">
+        <% guidance_service.orgs.each_with_index do |org, i| %>
+          <% if guidance_service.any?(org: org, question: question) %>
+            <div id="<%= "guidance_per_question_#{question.id}_#{i}" %>" role="tabpanel" class="tab-pane <%= active_nav == org.id ? 'active' : '' %>">
               <div class="panel panel-default">
                 <div class="panel-body">
-                  <%= render partial: 'guidance_groups/show', 
-                             locals: { group: guidance_set[group], question: question, guidance_accordion_id: "#{accordion_id}-#{i}" } %>
+                  <% guidance_service.guidance_annotations(org: org, question: question).each do |annotation| %>
+                    <%= 
+                      render partial: 'org_admin/annotations/show', locals: {
+                        template: template,
+                        example_answer: nil, 
+                        guidance: annotation, 
+                        for_plan: true } 
+                    %>
+                  <% end %>
+                  <% if guidance_service.guidance_annotations?(org: org, question: question) &&
+                    guidance_service.guidance_groups_by_theme?(org: org, question: question) %>
+                    <hr />
+                  <% end %>
+                  <% if guidance_service.guidance_groups_by_theme?(org: org, question: question) %>
+                    <%= render partial: 'guidance_groups/index_by_theme',
+                        locals: { guidance_groups_by_theme: guidance_service.guidance_groups_by_theme(org: org, question: question) } %>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,7 @@ module DMPRoadmap
     config.active_support.escape_html_entities_in_json = true
     
     config.eager_load_paths << "app/models/scopes"
+    config.eager_load_paths << "app/services"
 
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,


### PR DESCRIPTION
Introduces a service to delegate the behaviour of selecting annotations and guidances by theme for a question from a plan. This service introduces some good patterns:
- lazy initialisation of instance variables
- memoization of hash structures representing guidances or annotation for each org
- reduction and improvement of server burden in terms of db queries
- dump partials to display the structures according to the service
- preventing polluting models and controllers with methods specific to a specific data structure
