### PR TITLE
Fixed issues with Public Template page sorting and form validations 

### DIFF
--- a/app/views/guidance_groups/admin_edit.html.erb
+++ b/app/views/guidance_groups/admin_edit.html.erb
@@ -14,7 +14,7 @@
       
         <div class="form-group col-xs-8">
           <%= f.label _('Name'), for: :name, class: "control-label" %>
-          <%= f.text_field :name, as: :string, class: "form-control", 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
+          <%= f.text_field :name, as: :string, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
         </div>
 
         <div class='form-input col-xs-8'> 

--- a/app/views/guidance_groups/admin_new.html.erb
+++ b/app/views/guidance_groups/admin_new.html.erb
@@ -8,10 +8,10 @@
 
 <div class="row">
   <div class="col-md-12">
-    <%= form_for :guidance_group, url: {action: "admin_create"}, id: 'admin_create_guidance_group_form' do |f| %>
+    <%= form_for :guidance_group, url: {action: "admin_create"}, html: {id: 'admin_create_guidance_group_form'} do |f| %>
         <div class="form-group col-xs-8">
           <%= f.label _('Name'), for: :name, class: "control-label" %>
-          <%= f.text_field :name, as: :string, class: "form-control", 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
+          <%= f.text_field :name, as: :string, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
         </div>
 
         <div class='form-input col-xs-8'> 

--- a/app/views/guidances/new_edit.html.erb
+++ b/app/views/guidances/new_edit.html.erb
@@ -13,7 +13,7 @@
     <%= form_for(guidance, url: options[:url], html: { method: options[:method] , id: 'new_edit_guidance'}) do |f| %>
       <div class="form-group" data-toggle="tooltip" title="<%= _('Enter your guidance here. You can include links where needed.') %>">
         <%= f.label :text, class: 'control-label' %>
-        <%= text_area_tag("guidance-text", guidance.text, class: "guidance-text form-control", 'aria-required': true, rows: 10) %>
+        <%= text_area_tag("guidance-text", guidance.text, class: "form-control", 'aria-required': true, rows: 10) %>
       </div>
       <%= render partial: 'org_admin/shared/theme_selector',
                  locals: { f: f, all_themes: themes, as_radio: true, required: true,

--- a/app/views/public_pages/template_index.html.erb
+++ b/app/views/public_pages/template_index.html.erb
@@ -16,7 +16,8 @@
         partial: '/paginable/templates/publicly_visible',
         controller: 'paginable/templates',
         action: 'publicly_visible', 
-        scope: @templates) %>
+        scope: @templates,
+        query_params: { sort_field: 'templates.title', sort_direction: :asc }) %>
     <% end %>
   </div>
 </div>

--- a/lib/assets/javascripts/utils/ariatiseForm.js
+++ b/lib/assets/javascripts/utils/ariatiseForm.js
@@ -67,12 +67,6 @@ const blockHelp = (id, msg) => {
   }
   return '';
 };
-const ariaDescribedBy = (value) => {
-  if (value) {
-    return { 'aria-describedby': value };
-  }
-  return null;
-};
 const ariaInvalid = (value) => {
   if (isBoolean(value)) {
     return { 'aria-invalid': value };
@@ -181,14 +175,14 @@ const getValidationMessage = (el) => {
 
 const valid = (el) => {
   const target = $(el);
-  const helpBlock = target.closest('form').find(`#${target.attr('aria-describedby')}`);
+  const helpBlock = target.closest('form').find(`#${target.attr('validation-help-block')}`);
   target.parent().removeClass(validationStates.hasError);
   target.attr(ariaInvalid(false));
   helpBlock.hide();
 };
 const invalid = (el) => {
   const target = $(el);
-  const helpBlock = target.closest('form').find(`#${target.attr('aria-describedby')}`);
+  const helpBlock = target.closest('form').find(`#${target.attr('validation-help-block')}`);
   target.parent().addClass(validationStates.hasError);
   target.attr(ariaInvalid(true));
   helpBlock.show();
@@ -201,12 +195,13 @@ export default (options) => {
     // Add validation error message sections for each validatable input element
     validatable.each((i, el) => {
       const target = $(el);
+      const id = target.attr('id');
       const typ = getValidationTypeForElement(target);
-      target.attr(ariaDescribedBy(`help${i}`));
+      target.attr('validation-help-block', `help-${id}`);
       if (typ === 'radio' || typ === 'checkbox') {
-        target.closest('.form-group').before(blockHelp(`help${i}`, getValidationMessage(el)));
+        target.closest('.form-group').before(blockHelp(`help-${id}`, getValidationMessage(el)));
       } else {
-        target.after(blockHelp(`help${i}`, getValidationMessage(el)));
+        target.after(blockHelp(`help-${id}`, getValidationMessage(el)));
       }
       if (target.attr('aria-required') === 'true' && !options.excludeAsterisks) {
         addAsterisk(target);

--- a/lib/assets/javascripts/utils/validation.js
+++ b/lib/assets/javascripts/utils/validation.js
@@ -155,14 +155,14 @@ const getValidationMessage = (el) => {
 };
 const valid = (el) => {
   const target = $(el);
-  const helpBlock = target.closest('form').find(`#${target.attr('aria-describedby')}`);
+  const helpBlock = target.closest('form').find(`#${target.attr('validation-help-block')}`);
   target.parent().removeClass(validationStates.hasError);
   target.attr(ariaInvalid(false));
   helpBlock.hide();
 };
 const invalid = (el) => {
   const target = $(el);
-  const helpBlock = target.closest('form').find(`#${target.attr('aria-describedby')}`);
+  const helpBlock = target.closest('form').find(`#${target.attr('validation-help-block')}`);
   target.parent().addClass(validationStates.hasError);
   target.attr(ariaInvalid(true));
   helpBlock.show();
@@ -178,7 +178,7 @@ const addValidationMessage = (el, excludeAsterisks) => {
       } else {
         target.after(blockHelp(`help-${id}`, getValidationMessage(el)));
       }
-      target.attr('aria-describedby', `help-${id}`);
+      target.attr('validation-help-block', `help-${id}`);
       target.attr('data-validatable', 'true');
     }
   }

--- a/lib/assets/javascripts/views/guidances/new_edit.js
+++ b/lib/assets/javascripts/views/guidances/new_edit.js
@@ -3,5 +3,5 @@ import { Tinymce } from '../../utils/tinymce';
 
 $(() => {
   ariatiseForm({ selector: '#new_edit_guidance' });
-  Tinymce.init({ selector: '.guidance-text' });
+  Tinymce.init({ selector: '#guidance-text' });
 });

--- a/lib/assets/javascripts/views/org_admin/phases/new_edit.js
+++ b/lib/assets/javascripts/views/org_admin/phases/new_edit.js
@@ -48,8 +48,7 @@ $(() => {
       // the views/notifications/edit.js file. Tried 'Object.assign' instead of '$.extend' but it
       // made no difference
       Tinymce.init({ selector: `${selector} .section`, toolbar: 'bold italic | bullist numlist | link | table' });
-      ariatiseForm({ selector: `${selector} .section_form` });
-
+      ariatiseForm({ selector: `${selector} .edit_section` });
       const questionForm = $(selector).find('.question_form');
       if (questionForm.length > 0) {
         // Load Tinymce when the 'show' form has a question form.


### PR DESCRIPTION
For #1333 
Fixed issue with sort for public templates

For #1326:
We were using 'aria-describedby' to store the relationship between the input element and its help text block. Bootstrap however uses the 'aria-describedby' attribute when displaying an input's tooltip. This was causing the relationship between the input and its help block to be lost.

Switched from 'aria-describedby' to 'validation-help-block'. Also updated the id of the help block to match the id of the input field instead of a counter number. This keeps the help block ids unique across the entire page.