### PR TITLE
fix issue with duplicate asterisks on checkboxes

### DIFF
--- a/lib/assets/javascripts/utils/validation.js
+++ b/lib/assets/javascripts/utils/validation.js
@@ -40,7 +40,7 @@ const blockHelp = (id, msg) => {
 const addAsterisk = (el) => {
   const asterisk = '<span class="red asterisk" title="This field is required.">* </span>';
   // Do not add an asterisk if one already exists!
-  if (isObject(el) && el.closest('.form-group').find('.asterisk').length <= 0) {
+  if (isObject(el) && el.closest('.form-group, .checkbox').find('.asterisk').length <= 0) {
     switch (getValidationTypeForElement(el)) {
       case 'checkbox': {
         el.after(asterisk);


### PR DESCRIPTION
Discovered this issue while merging v1.1.2 with DMPTool customizations. 
