### PR TITLE
switched devise/bootstrap/contact_us yml locale files from fr to fr_FR

### DIFF
--- a/config/locales/bootstrap/fr_FR.bootstrap.yml
+++ b/config/locales/bootstrap/fr_FR.bootstrap.yml
@@ -1,0 +1,17 @@
+
+fr_FR:
+  helpers:
+    actions: "Actions"
+    links:
+      back: "Retour"
+      cancel: "Annuler"
+      confirm: "Êtes-vous sûr?"
+      destroy: "Supprimer"
+      new: "Nouveau"
+      edit: "Modifier"
+    titles:
+      edit: "Modifier"
+      save: "Enregistrer"
+      new: "Nouveau"
+      delete: "Supprimer"
+

--- a/config/locales/contact_us/contact_us.fr_FR.yml
+++ b/config/locales/contact_us/contact_us.fr_FR.yml
@@ -1,0 +1,25 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+fr_FR:
+  contact_us:
+    contact_mailer:
+      contact_email:
+        sent_by_contact_form: "Envoyé depuis le fomulaire de contact par %{email}"
+        sent_by_name: "Envoyé par %{name} depuis %{email}"
+        subject: "Message 'Contactez nous' de %{email}"
+    contacts:
+      new: &new
+        contact_us: "Contactez Nous"
+        email: "Email"
+        message: "Message"
+        name: "Nom"
+        subject: "Sujet"
+        submit: "Envoyer"
+      new_formtastic:
+        <<: *new
+      new_simple_form:
+        <<: *new
+    notices:
+      error: "Merci de saisir les deux champs."
+      success: "Votre message a bien été envoyé."

--- a/config/locales/devise/devise.fr_FR.yml
+++ b/config/locales/devise/devise.fr_FR.yml
@@ -1,0 +1,82 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+fr_FR:
+  devise:
+    confirmations:
+      confirmed: "Votre compte a bien été validé. Veuillez vous connecter."
+      send_instructions: "Vous recevrez dans quelques minutes un courriel contenant les directives pour activer votre compte."
+      resend_instructions: "Envoyer de nouveau les directives" 
+      send_paranoid_instructions: "Si votre adresse électronique existe dans notre base de données, vous recevrez dans quelques minutes un courriel contenant les directives pour valider votre compte."
+    failure:
+      already_authenticated: "Vous êtes déjà connecté(e)."
+      inactive: "Votre compte n'est plus actif. Merci de nous contacter pour réactiver votre compte."
+      invalid: "Courriel ou mot de passe incorrect."
+      invalid_token: "Jeton d'authentification incorrect."
+      locked: "Votre compte est verrouillé."
+      not_found_in_database: "Courriel ou mot de passe incorrect."
+      timeout: "Votre session est expirée. Veuillez vous reconnecter pour continuer."
+      unauthenticated: "Vous devez vous connecter ou vous inscrire pour continuer."
+      unconfirmed: "Vous devez confirmer votre compte pour continuer."
+    mailer:
+      app_name: "Assistant PGD"
+      confirmation_instructions:
+        subject: "Valider votre compte Assistant PGD"
+        link: "Cliquer ici pour activer votre compte"
+        email: "<p>Bienvenue dans l'Assistant PGD, %{email}</p>
+        <p>Merci de vous être inscrit(e) à %{app_link}. Veuillez confirmer votre adresse électronique : </p>
+        <p>%{confirmation_link} (ou copier %{confirmation_direct_url} dans votre navigateur).</p>"
+      reset_password_instructions:
+        subject: "Directives pour réinitialiser le mot de passe"
+        link: "Réinitialiser mon mot de passe"
+        email: "<p>Bonjour %{resource_email}!</p>
+        <p>Un changement de mot de passe a été demandé pour %{app_link}. Vous pouvez le faire en cliquant sur le lien ci-dessous.</p>
+        <p>%{reset_password_link}</p>
+        <p>Si vous n'avez pas demandé ce changement, veuillez ignorer ce message.</p>
+        <p>Votre mot de passe ne sera pas changé tant que vous n'aurez pas accédé au lien ci-dessus pour en créer un nouveau.</p>"
+      unlock_instructions:
+        subject: "Directives de déverrouillage"
+        link: "Déverrouiller mon compte"
+        email: "<p>Bonjour %{resource_email}!</p>
+        <p>Votre compte %{app_link} a été verrouillé à la suite d'un trop grand nombre de tentatives d'authentification.</p>
+        <p>Cliquez sur le lien ci-dessous pour déverrouiller votre compte :</p>
+        <p>%{unlock_link}</p>"
+    omniauth_callbacks:
+      failure: "Nous n'avons pas pu vous authentifier à partir de %{kind} parce que '%{reason}'."
+      success: "Authentification réussie à partir du compte %{kind}."
+    passwords:
+      no_token: "Vous ne pouvez pas accéder à cette page sans y avoir été dirigé par un courriel de réinitialisation du mot de passe. Si vous avez été dirigé vers cette page à partir d’un courriel de réinitialisation, assurez-vous d'utiliser l'adresse URL complète fournie."
+      send_instructions: "Vous recevrez dans quelques minutes un courriel contenant les directives pour réinitialiser le mot de passe."
+      send_paranoid_instructions: "Si votre adresse électronique existe dans notre base de données, vous recevrez dans quelques minutes un lien de récupération du mot de passe par courriel."
+      updated: "Votre mot de passe a bien été modifié. Vous êtes maintenant connecté."
+      updated_not_active: "Votre mot de passe a bien été modifié."
+    registrations:
+      destroyed: "Votre compte a bien été supprimé. Nous espérons vous revoir bientôt."
+      signed_up: "Bienvenu(e)! Vous êtes bien inscrit(e)."
+      signed_up_but_inactive: "Vous êtes bien inscrit(e). Cependant, vous ne pouvez pas vous connecter, car votre compte n'est pas encore activé."
+      signed_up_but_locked: "Vous êtes bien inscrit(e). Cependant, vous ne pouvez pas vous connecter, car votre compte est verrouillé."
+      signed_up_but_unconfirmed: "Un message contenant un lien de confirmation a été envoyé à votre adresse électronique. Ouvrez ce lien pour activer votre compte. Si vous n’avez pas reçu le courriel de confirmation, vérifiez votre filtre antipourriel."
+      update_needs_confirmation: "Votre compte a bien été mis à jour, mais nous devons vérifier votre nouvelle adresse électronique. Vérifiez vos courriels et cliquez sur le lien de confirmation pour finaliser la validation de votre nouvelle adresse électronique."
+      updated: "Votre compte a bien été modifié."
+    sessions:
+      signed_in: "Connecté"
+      signed_out: "Déconnecté"
+    unlocks:
+      send_instructions: "Vous recevrez dans quelques minutes un courriel contenant les directives pour déverrouiller votre compte."
+      send_paranoid_instructions: "Si votre compte existe, vous recevrez dans quelques minutes un courriel contenant les directives pour le déverrouiller."
+      resend_unlock_instructions: "Envoyer de nouveau les directives de déverouillage." 
+      unlocked: "Votre compte a bien été déverrouillé. Veuillez vous connecter pour continuer."
+  errors:
+    messages:
+      already_confirmed: "a déjà été validé, essayez de vous connecter."
+      confirmation_period_expired: "à confirmer dans les %{period}. Veuillez faire une nouvelle demande."
+      expired: "a expiré, veuillez faire une nouvelle demande."
+      not_found: "n'a pas été trouvé"
+      not_locked: "n'était pas verrouillé"
+      not_saved:
+        one: "Une erreur a empêché d’enregistrer ce(tte) %{resource} :"
+        other: "%{count} erreurs ont empêché d’enregistrer ce(tte) %{resource} :"
+      blank: "Ce champ ne peut être vide"
+  activerecord:
+    attributes:
+      user:
+        email: "Courriel: "


### PR DESCRIPTION
The gem locale files for devise, bootstrap and contact_us we still using the 'fr' locale id instead of 'fr_FR'