### PR TITLE
Add <fieldset> markup to radio buttons and check boxes #1448

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -20,7 +20,7 @@
         <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true) %>
       </div>
       <div class="checkbox">
-        <label for="passwords_toggle">
+        <label>
           <input type="checkbox" id="passwords_toggle" class="passwords_toggle"/><%= _('Show passwords') %>
         </label>
       </div>

--- a/app/views/devise/registrations/_password_confirmation.html.erb
+++ b/app/views/devise/registrations/_password_confirmation.html.erb
@@ -22,7 +22,7 @@
             <label class="control-label"><%= _('Organisation') %></label>
           </div>
           <div class="checkbox">
-            <label for="confirm_org_change">
+            <label>
               <input type="checkbox" id="confirm_org_change" />
               <%= _('Yes, I understand that I will lose my administrative privileges') %>
             </label>

--- a/app/views/guidance_groups/_guidance_group_form.html.erb
+++ b/app/views/guidance_groups/_guidance_group_form.html.erb
@@ -2,13 +2,13 @@
   <%= f.label _('Name'), for: :name, class: "control-label" %>
   <%= f.text_field :name, as: :string, class: "form-control", 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will be used to tell the end user where the guidance has come from. It will be appended to text identifying the theme e.g. "[guidance group name]: guidance on data sharing" so we suggest you just use the organisation or department name.'), 'aria-required': true %>
 </div>
+<fieldset>
+	<div class="checkbox">
+	  <%= f.label :published, raw("#{f.check_box :published, 'data-toggle': 'tooltip', title: _('Check this box when you are ready for guidance associated with this group to appear on user\'s plans.')} #{_('Published')}") %>
+	</div>
 
-<div class="checkbox">
-  <%= f.label :published, raw("#{f.check_box :published, 'data-toggle': 'tooltip', title: _('Check this box when you are ready for guidance associated with this group to appear on user\'s plans.')} #{_('Published')}") %>
-</div>
-
-<div class="checkbox">
-  <%= f.label :optional_subset, raw("#{f.check_box :optional_subset, 'data-toggle': 'tooltip', title: _('If the guidance is only meant for a subset of users e.g. those in a specific college or institute, check this box.  Users will be able to select to display this subset guidance when answering questions in the \'create plan\' wizard.')} #{_('Optional Subset (e.g. School/Department)')}") %>
-</div>
-
+	<div class="checkbox">
+	  <%= f.label :optional_subset, raw("#{f.check_box :optional_subset, 'data-toggle': 'tooltip', title: _('If the guidance is only meant for a subset of users e.g. those in a specific college or institute, check this box.  Users will be able to select to display this subset guidance when answering questions in the \'create plan\' wizard.')} #{_('Optional Subset (e.g. School/Department)')}") %>
+	</div>
+</fieldset>
 <%= f.submit _('Save'), class: 'btn btn-primary' %>

--- a/app/views/guidance_groups/admin_new.html.erb
+++ b/app/views/guidance_groups/admin_new.html.erb
@@ -13,17 +13,17 @@
           <%= f.label _('Name'), for: :name, class: "control-label" %>
           <%= f.text_field :name, as: :string, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
         </div>
-
-        <div class='form-input col-xs-8'> 
-          <%= f.check_box :published, 'data-toggle': 'tooltip', title: _("Check this box when you are ready for guidance associated with this group to appear on user's plans.") %>
-          <%= f.label _('Published'), for: :published, class: "control-label" %>
-        </div>
-        
-        <div class='form-input col-xs-8'>
-          <%= f.check_box :optional_subset, 'data-toggle': 'tooltip', title: _("If the guidance is only meant for a subset of users e.g. those in a specific college or institute, check this box.  Users will be able to select to display this subset guidance when answering questions in the 'create plan' wizard.") %>
-          <%= f.label _('Optional Subset'), for: :optional_subset, class: "control-label" %><%= _(' (e.g. School/ Department) ') %>
-        </div>
-      
+        <fieldset class='col-xs-12'>
+          <div class='form-input'> 
+            <%= f.check_box :published, 'data-toggle': 'tooltip', title: _("Check this box when you are ready for guidance associated with this group to appear on user's plans.") %>
+            <%= f.label _('Published'), class: "control-label" %>
+          </div>
+          
+          <div class='form-input'>
+            <%= f.check_box :optional_subset, 'data-toggle': 'tooltip', title: _("If the guidance is only meant for a subset of users e.g. those in a specific college or institute, check this box.  Users will be able to select to display this subset guidance when answering questions in the 'create plan' wizard.") %>
+            <%= f.label _('Optional Subset'), class: "control-label" %><%= _(' (e.g. School/ Department) ') %>
+          </div>
+        </fieldset>
         <!-- submit buttons -->
         <div class="form-group col-xs-8">
           <%= f.submit _('Save'), name: "draft", class: "btn btn-primary" %>

--- a/app/views/org_admin/shared/_theme_selector.html.erb
+++ b/app/views/org_admin/shared/_theme_selector.html.erb
@@ -25,6 +25,7 @@
             <div class="col-md-<%= col_size %>">
             <% cntr = 0 %>
           <% end %>
+        <fieldset>
           <div class="checkbox">
             <% namespace = f.object.class.name.downcase %>
             <% id = f.object.id.present? ? f.object.id : 'new' %>
@@ -35,6 +36,7 @@
                    value="<%= theme.id %>"<%= f.object.themes.include?(theme) ? ' checked="checked"' : '' %>>
             <%= theme.title %>
           </div>
+        </fieldset>
           <% cntr += 1 %>
         <% end %>
       </div>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -80,19 +80,19 @@
         </div>
       <% end %>  
       <div class="row">
-        <div class="form-group col-xs-8">
-          <%= f.label _('Organisation Types'), for: :funder, class: 'control-label' %>
-          <div class="checkbox">
-            <%= f.label :funder, raw("#{check_box_tag :funder, 2, org.funder?, class: 'org_types'} #{_('Funder')}") %>
-          </div>
-          <div class="checkbox">
-            <%= f.label :institution, raw("#{check_box_tag :institution, 1, org.institution?, class: 'org_types'} #{_('Institution')}") %>
-          </div>
-          <div class="checkbox">
-            <%= f.label :organisation, raw("#{check_box_tag :organisation, 4, org.organisation?, class: 'org_types'} #{_('Organisation')}") %>
-          </div>
-          <%= f.hidden_field :org_type, 'data-validation': 'text', 'data-validation-error': _('You must select at least one organisation type') %>
-        </div>
+        <fieldset class="col-xs-8">
+          <legend><%= _('Organisation Types') %></legend>
+            <div class="checkbox">
+              <%= f.label :funder, raw("#{check_box_tag :funder, 2, org.funder?, class: 'org_types'} #{_('Funder')}") %>
+            </div>
+            <div class="checkbox">
+              <%= f.label :institution, raw("#{check_box_tag :institution, 1, org.institution?, class: 'org_types'} #{_('Institution')}") %>
+            </div>
+            <div class="checkbox">
+              <%= f.label :organisation, raw("#{check_box_tag :organisation, 4, org.organisation?, class: 'org_types'} #{_('Organisation')}") %>
+            </div>
+            <%= f.hidden_field :org_type, 'data-validation': 'text', 'data-validation-error': _('You must select at least one organisation type') %>
+        </fieldset>
       </div>
     <% else %>
       <dl>

--- a/app/views/plans/_download_form.html.erb
+++ b/app/views/plans/_download_form.html.erb
@@ -9,23 +9,24 @@
   <% else %>
     <%= hidden_field_tag(:phase_id, @phase_options[0][1]) %>
   <% end %>
-
-  <h3><%= _("Optional plan components") %></h3>
-  <div class="checkbox">
-    <%= label_tag 'export[project_details]', raw("#{check_box_tag 'export[project_details]', true, false} #{_('project details coversheet')}") %>
-  </div>
-  <div class="checkbox">
-    <%= label_tag 'export[question_headings]', raw("#{check_box_tag 'export[question_headings]', true, true} #{_('question text and section headings')}") %>
-  </div>
-  <div class="checkbox">
-    <%= label_tag 'export[unanswered_questions]', raw("#{check_box_tag 'export[unanswered_questions]', true, true} #{_('unanswered questions')}") %>
-  </div>
-  <% if @plan.template.customization_of.present? %>
+  <fieldset>
+    <legend><%= _("Optional plan components") %></legend>
     <div class="checkbox">
-      <%= label_tag 'export[custom_sections]', raw("#{check_box_tag 'export[custom_sections]', true, false} #{_('supplementary section(s) not requested by funding organisation')}") %>
+      <%= label_tag 'export[project_details]', raw("#{check_box_tag 'export[project_details]', true, false} #{_('project details coversheet')}") %>
     </div>
-  <% end %>
-
+    <div class="checkbox">
+      <%= label_tag 'export[question_headings]', raw("#{check_box_tag 'export[question_headings]', true, true} #{_('question text and section headings')}") %>
+    </div>
+    <div class="checkbox">
+      <%= label_tag 'export[unanswered_questions]', raw("#{check_box_tag 'export[unanswered_questions]', true, true} #{_('unanswered questions')}") %>
+    </div>
+    <% if @plan.template.customization_of.present? %>
+      <div class="checkbox">
+        <%= label_tag 'export[custom_sections]', raw("#{check_box_tag 'export[custom_sections]', true, false} #{_('supplementary section(s) not requested by funding organisation')}") %>
+      </div>
+    <% end %>
+  </fieldset>
+  
   <h2><%= _('Format') %></h2>
   <div class="row">
     <div class="form-group col-xs-2">

--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -148,15 +148,16 @@
     <div class="col-md-4">
       <h2><%= _('Plan Guidance Configuration') %></h2>
       <p><%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations.') %
-        {application_name: Rails.configuration.branding[:application][:name]} %>
-      </p>
-      <p><%= _('Select up to 6 organisations to see their guidance.') %></p>
-      <ul id="priority-guidance-orgs">
-        <%= render partial: "guidance_choices", 
-                      locals: {choices: @important_ggs, form: f,
-                               current_selections: @selected_guidance_groups} %>
-      </ul>
-
+          {application_name: Rails.configuration.branding[:application][:name]} %>
+          </p>
+      <fieldset>
+        <p><%= _('Select up to 6 organisations to see their guidance.') %></p>
+        <ul id="priority-guidance-orgs">
+          <%= render partial: "guidance_choices", 
+                        locals: {choices: @important_ggs, form: f,
+                                 current_selections: @selected_guidance_groups} %>
+        </ul>
+      </fieldset>
       <p><%= _('Find guidance from additional organisations below') %></p>
       <%= link_to _('See the full list'), '#', 'data-toggle' =>  'modal', 'data-target' => '#modal-full-guidances', class: 'modal-guidances-window' %>
 

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -78,33 +78,37 @@
       <%= user.email_field :email, for: :user, name: "user", class: "form-control", "aria-required": true %>
     <% end %>
   </div>
+  
+  <fieldset class="col-xs-12">
+    <legend><%= _('Permissions') %></legend>
+    <div class="form-group">
+      <div class="radio">
+        <%= f.label :access_level, raw("#{f.radio_button :access_level, 3, "aria-required": true} #{_('Co-owner: can edit project details, change visibility, and add collaborators')}") %>
+      </div>
+      <div class="radio">
+        <%= f.label :access_level, raw("#{f.radio_button :access_level, 2} #{_('Editor: can comment and make changes')}") %>
+      </div>
+      <div class="radio">
+        <%= f.label :access_level, raw("#{f.radio_button :access_level, 1} #{_('Read only: can view and comment, but not make changes')}") %>
+      </div>
 
-  <div class="form-group col-xs-8">
-    <label class="control-label"><%= _('Permissions') %></label>
-    <div class="radio">
-      <%= f.label :access_level, raw("#{f.radio_button :access_level, 3, "aria-required": true} #{_('Co-owner: can edit project details, change visibility, and add collaborators')}") %>
+      <%= f.button(_('Submit'), class: "btn btn-primary", type: "submit") %>
     </div>
-    <div class="radio">
-      <%= f.label :access_level, raw("#{f.radio_button :access_level, 2} #{_('Editor: can comment and make changes')}") %>
-    </div>
-    <div class="radio">
-      <%= f.label :access_level, raw("#{f.radio_button :access_level, 1} #{_('Read only: can view and comment, but not make changes')}") %>
-    </div>
+    <div class="clearfix"></div>
+  <% end %>
+  </fieldset>
 
-    <%= f.button(_('Submit'), class: "btn btn-primary", type: "submit") %>
-  </div>
-  <div class="clearfix"></div>
-<% end %>
+  <div class="col-xs-12">
+    <% if plan.owner_and_coowners.include?(current_user) && current_user.org.present? && current_user.org.feedback_enabled? %>
+      <h2><%= _('Request expert feedback') %></h2>
+      <p><%= _('Click below to give data management staff at your organisation access to read and comment on your plan.') %></p>
+      <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
 
-<% if plan.owner_and_coowners.include?(current_user) && current_user.org.present? && current_user.org.feedback_enabled? %>
-  <h2><%= _('Request expert feedback') %></h2>
-  <p><%= _('Click below to give data management staff at your organisation access to read and comment on your plan.') %></p>
-  <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
-
-  <div class="form-group col-xs-8">
-    <button type="button" class="btn btn-default"> 
-      <%= link_to _('Request feedback'), request_feedback_plan_path, class: "link_as_button#{' disabled' if @plan.feedback_requested?}" %>
-    </button>
-    <span><%= _("Feedback has been requested.") if @plan.feedback_requested? %></span>
+      <div class="form-group">
+        <button type="button" class="btn btn-default"> 
+          <%= link_to _('Request feedback'), request_feedback_plan_path, class: "link_as_button#{' disabled' if @plan.feedback_requested?}" %>
+        </button>
+        <span><%= _("Feedback has been requested.") if @plan.feedback_requested? %></span>
+      </div>
   </div>
 <% end %>

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -24,7 +24,7 @@
     <%= f.password_field(:password, class: "form-control", "aria-required": true) %>
   </div>
   <div class="checkbox">
-    <label for="passwords_toggle_sign_up">
+    <label>
       <input type="checkbox" id="passwords_toggle_sign_up" class="passwords_toggle" /><%= _('Show password') %>
     </label>
   </div>

--- a/app/views/users/_notification_preferences.html.erb
+++ b/app/views/users/_notification_preferences.html.erb
@@ -9,28 +9,28 @@
 
     <p class="form-control-static"><strong>All Users</strong></p>
     <div class="checkbox">
-      <label for="prefs[users][new_comment]">
+      <label>
         <%= check_box_tag 'prefs[users][new_comment]', true, @prefs[:users][:new_comment] %><%= _('A new comment has been added to my DMP')  %>
       </label>
     </div>
     <div class="checkbox">
-      <label for="prefs[users][added_as_coowner]">
+      <label>
         <%= check_box_tag 'prefs[users][added_as_coowner]', true, @prefs[:users][:added_as_coowner] %><%= _('A plan has been shared with me')  %>
       </label>
     </div>
     <div class="checkbox">
-      <label for="prefs[users][admin_privileges]">
+      <label>
         <%= check_box_tag 'prefs[users][admin_privileges]', true, @prefs[:users][:admin_privileges] %><%= _('Admin privileges granted to me')  %>
       </label>
     </div>
     <% if @user.org.present? && @user.org.feedback_enabled %>
       <div class="checkbox">
-        <label for="prefs[users][feedback_requested]">
+        <label>
           <%= check_box_tag 'prefs[users][feedback_requested]', true, @prefs[:users][:feedback_requested] %><%= _('Feedback has been requested for my DMP') %>
         </label>
       </div>
       <div class="checkbox">
-        <label for="prefs[users][feedback_provided]">
+        <label>
           <%= check_box_tag 'prefs[users][feedback_provided]', true, @prefs[:users][:feedback_provided] %><%= _('Feedback has been provided for my DMP')  %>
         </label>
       </div>
@@ -39,7 +39,7 @@
     <p class="form-control-static"><strong>DMP owners and co-owners</strong></p>
 
     <div class="checkbox">
-      <label for="prefs[owners_and_coowners][visibility_changed]">
+      <label>
         <%= check_box_tag 'prefs[owners_and_coowners][visibility_changed]', true, @prefs[:owners_and_coowners][:visibility_changed] %><%= _("My DMP's visibility has changed")  %>
       </label>
     </div>

--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -548,6 +548,18 @@ $tooltip-background: $grey;
 }
 
 /* Fieldset styling */
+
+/* generic styling */
+fieldset {
+  border: none;
+}
+legend {
+  border: none;
+  margin-bottom: 5px;
+  text-transform: capitalize;
+}
+
+/* Specific to project details page */
 fieldset.project-details {
   border: 0.5px groove #ddd;
   padding: 0 5px;


### PR DESCRIPTION
remove the 'for' attribute for any check boxes or radio buttons that are embedded within the <label> tag

Fixes # .

Changes proposed in this PR:
-
Adding Fieldset markup for grouped radio buttons/checkboxes across the application.
Remove 'for' attribute in labels for checkboxes which are embedded within labels.