### PR TITLE
Fixed issues with Tinymce toolbar options

### DIFF
--- a/lib/assets/javascripts/views/org_admin/phases/new_edit.js
+++ b/lib/assets/javascripts/views/org_admin/phases/new_edit.js
@@ -22,7 +22,7 @@ $(() => {
       // For some reason the toolbar options are retained after the call to Tinymce.init() on
       // the views/notifications/edit.js file. Tried 'Object.assign' instead of '$.extend' but it
       // made no difference
-      Tinymce.init({ selector: `#${context} .question`, toolbar: 'bold italic | bullist numlist | link | table' });
+      Tinymce.init({ selector: `#${context} .question` });
       ariatiseForm({ selector: `#${context} .question_form` });
       initQuestionOption(context);
       // Swap in the question_formats when the user selects an option based question type
@@ -47,7 +47,7 @@ $(() => {
       // For some reason the toolbar options are retained after the call to Tinymce.init() on
       // the views/notifications/edit.js file. Tried 'Object.assign' instead of '$.extend' but it
       // made no difference
-      Tinymce.init({ selector: `${selector} .section`, toolbar: 'bold italic | bullist numlist | link | table' });
+      Tinymce.init({ selector: `${selector} .section` });
       ariatiseForm({ selector: `${selector} .edit_section` });
       const questionForm = $(selector).find('.question_form');
       if (questionForm.length > 0) {

--- a/lib/assets/javascripts/views/super_admin/notifications/edit.js
+++ b/lib/assets/javascripts/views/super_admin/notifications/edit.js
@@ -2,10 +2,6 @@ import ariatiseForm from '../../../utils/ariatiseForm';
 import { Tinymce } from '../../../utils/tinymce';
 
 $(() => {
-  Tinymce.init({
-    selector: '.notification-text',
-    forced_root_block: '',
-    toolbar: 'bold italic underline | link',
-  });
+  Tinymce.init({ selector: '.notification-text', forced_root_block: '' });
   ariatiseForm({ selector: 'form.notification' });
 });


### PR DESCRIPTION
For #1632 

Removed all occurrences of toolbar item specification from JS for views. It seems that Tinymce engine retains the last used options despite us reverting to the default options when instantiating a new editor. 

The only editor that does not use the defaults was the notifications page which removed the lists and tables. Since this page is limited to super admin use we have decided to remove that JS as an easy solution to the problem. It should become quickly apparent to an admin that their system message looks bad if they opt to use lists of tables. They have the ability to update the message afterward to correct any visual issues.

We will encounter this again at some point if we need to introduce an editor with additional or limited toolbar options. 