### PR TITLE
Make 'Change notification prefs' optional in email signatures

### DIFF
--- a/app/views/user_mailer/_email_signature.html.erb
+++ b/app/views/user_mailer/_email_signature.html.erb
@@ -2,6 +2,7 @@
   tool_name = Rails.configuration.branding[:application][:name]
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
   email_subject = email_subject || _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
+  allow_change_prefs = allow_change_prefs || true
 
   # Override the default Rails route helper for the contact_us page IF an alternate contact_us url was defined
   # in the branding config file
@@ -13,5 +14,5 @@
   <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
 </p>
 <p>
-  <%= _('You may change your notification preferences on your profile page.') %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us => link_to(contact_us, contact_us) }) %>
+  <% if allow_change_prefs %><%= _('You may change your notification preferences on your profile page.') %><% end %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us => link_to(contact_us, contact_us) }) %>
 </p>

--- a/app/views/user_mailer/feedback_notification.html.erb
+++ b/app/views/user_mailer/feedback_notification.html.erb
@@ -7,6 +7,6 @@
   %>
 
   <p><%= _('Hello %{user_name},') % {user_name: recipient_name} %></p>
-  <p><%= _('%{requestor} has requested feedback on a plan "%{plan_name}." To add comments, please visit the \'Plans\' page under the Admin menu in %{application_name} and open the plan.') % {requestor: requestor_name, plan_name: plan_name, application_name: tool_name} %></p>
+  <p><%= _('%{requestor} has requested feedback on a plan "%{plan_name}." To add comments, please visit the \'Plans\' page under the Admin menu in %{application_name} and open the plan.') % {requestor: requestor_name, plan_name: plan_name, application_name: tool_name, allow_change_prefs: false} %></p>
   <%= render partial: 'email_signature' %>
 <% end %>


### PR DESCRIPTION
For #1631 

Added a flag to the email signature to hide the 'Change you notification prefs' portion of the signature for automated emails that cannot be disabled (e.g. feedback request notification to the org contact email)