### PR TITLE
Fix issue with validation of Tinymce on Guidances page

### DIFF
--- a/lib/assets/javascripts/views/guidances/new_edit.js
+++ b/lib/assets/javascripts/views/guidances/new_edit.js
@@ -2,6 +2,6 @@ import ariatiseForm from '../../utils/ariatiseForm';
 import { Tinymce } from '../../utils/tinymce';
 
 $(() => {
-  ariatiseForm({ selector: '#new_edit_guidance' });
   Tinymce.init({ selector: '#guidance-text' });
+  ariatiseForm({ selector: '#new_edit_guidance' });
 });


### PR DESCRIPTION
Fixes #1629 

The Tinymce editor was being wired up after the ariatiseForm was called, so its validation wasn't firing properly. Switched order of the calls.