### PR TITLE
Add comments text to feedback completed email

### DIFF
--- a/app/views/user_mailer/feedback_complete.html.erb
+++ b/app/views/user_mailer/feedback_complete.html.erb
@@ -1,11 +1,18 @@
-<% 
+<%
   requestor = @requestor.name(false)
-  recipient_name = @user.name(false) 
+  recipient_name = @user.name(false)
   plan_name = @plan.title
   tool_name = Rails.configuration.branding[:application][:name]
 %>
 
 <p><%= _('Hello %{recipient_name}') % { recipient_name: recipient_name } %></p>
-<p><%= _('%{commenter} has finished providing feedback on the plan "%{plan_title}". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan.') % { commenter: requestor, plan_title: plan_name, tool_name: tool_name } %></p>
+
+<p>
+  <%= _("%{commenter} has finished providing feedback on the plan \"%{link_html}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan. Plan comments can be found adjacent to your answers in the tabbed panel next to guidance.").html_safe % {
+    commenter: requestor,
+    link_html: link_to(plan_name, plan_url(@plan)),
+    tool_name: tool_name
+  }%>
+</p>
 
 <%= render partial: 'email_signature' %>


### PR DESCRIPTION
Fixes #1492 

Changes proposed in this PR:
- Add additional text to feedback complete email template.
- Add plan name as clickable link to feedback complete (to match changes in #1431)
