### PR TITLE
Add inviter name to sharing notification email

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -7,7 +7,7 @@ class RolesController < ApplicationController
     registered = true
     @role = Role.new(role_params)
     authorize @role
-    
+
     access_level = params[:role][:access_level].to_i
     @role.set_access_level(access_level)
     message = ''
@@ -30,7 +30,8 @@ class RolesController < ApplicationController
           if @role.save
             if registered
               deliver_if(recipients: user, key: 'users.added_as_coowner') do |r|
-                UserMailer.sharing_notification(@role, r).deliver_now
+                UserMailer.sharing_notification(@role, r, inviter: current_user)
+                          .deliver_now
               end
             end
             flash[:notice] = message
@@ -73,7 +74,7 @@ class RolesController < ApplicationController
     end
     redirect_to controller: 'plans', action: 'share', id: @role.plan.id
   end
-    
+
   # This function makes user's role on a plan inactive - i.e. "removes" this from their plans
   def deactivate
     role = Role.find(params[:id])

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,90 +2,94 @@ class UserMailer < ActionMailer::Base
   include MailerHelper
   helper MailerHelper
   default from: Rails.configuration.branding[:organisation][:email]
-  
+
   def welcome_notification(user)
     @user = user
     FastGettext.with_locale FastGettext.default_locale do
-      mail(to: @user.email, 
+      mail(to: @user.email,
            subject: _('Welcome to %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] })
     end
   end
-  
-  def sharing_notification(role, user)
-    @role = role
-    @user = user
+
+  def sharing_notification(role, user, inviter:)
+    @role    = role
+    @user    = user
+    @inviter = inviter
+    subject  = _("A Data Management Plan in %{tool_name} has been shared "\
+                   "with you") % {
+      tool_name: Rails.configuration.branding[:application][:name]
+    }
     FastGettext.with_locale FastGettext.default_locale do
-      mail(to: @role.user.email, 
-           subject: _('A Data Management Plan in %{tool_name} has been shared with you') %{ :tool_name => Rails.configuration.branding[:application][:name] })
+      mail(to: @role.user.email, subject: subject)
     end
   end
-  
+
   def permissions_change_notification(role, user)
     @role = role
     @user = user
     if user.active?
       FastGettext.with_locale FastGettext.default_locale do
-        mail(to: @role.user.email, 
+        mail(to: @role.user.email,
              subject: _('Changed permissions on a Data Management Plan in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] })
       end
     end
   end
-  
+
   def plan_access_removed(user, plan, current_user)
     @user = user
     @plan = plan
     @current_user = current_user
     if user.active?
       FastGettext.with_locale FastGettext.default_locale do
-        mail(to: @user.email, 
+        mail(to: @user.email,
              subject: "#{_('Permissions removed on a DMP in %{tool_name}') %{ :tool_name => Rails.configuration.branding[:application][:name] }}")
       end
     end
   end
-  
+
   def feedback_notification(recipient, plan, requestor)
     @user = requestor
-    
+
     if @user.org.present? && recipient.active?
       @org = @user.org
       @plan = plan
       @recipient = recipient
-      
+
       FastGettext.with_locale FastGettext.default_locale do
-        mail(to: recipient.email, 
+        mail(to: recipient.email,
              subject: _("%{application_name}: %{user_name} requested feedback on a plan") % {application_name: Rails.configuration.branding[:application][:name], user_name: @user.name(false)})
       end
     end
   end
-  
+
   def feedback_complete(recipient, plan, requestor)
     @requestor = requestor
     @user = recipient
     @plan = plan
-      
+
     if recipient.active?
       FastGettext.with_locale FastGettext.default_locale do
-        mail(to: recipient.email, 
+        mail(to: recipient.email,
              subject: _("%{application_name}: Expert feedback has been provided for %{plan_title}") % {application_name: Rails.configuration.branding[:application][:name], plan_title: @plan.title})
       end
     end
   end
-  
+
   def feedback_confirmation(recipient, plan, requestor)
     user = requestor
 
     if user.org.present? && recipient.active?
       org = user.org
       plan = plan
-        
+
       # Use the generic feedback confirmation message unless the Org has specified one
       subject = (org.feedback_email_subject.present? ? org.feedback_email_subject : feedback_confirmation_default_subject)
       message = (org.feedback_email_msg.present? ? org.feedback_email_msg : feedback_confirmation_default_message)
 
       @body = feedback_constant_to_text(message, user, plan, org)
-      
+
       FastGettext.with_locale FastGettext.default_locale do
-        mail(to: recipient.email, 
+        mail(to: recipient.email,
              subject: feedback_constant_to_text(subject, user, plan, org))
       end
     end
@@ -101,7 +105,7 @@ class UserMailer < ActionMailer::Base
       end
     end
   end
-  
+
   # @param commenter - User who wrote the comment
   # @param plan - Plan for which the comment is associated to
   def new_comment(commenter, plan)
@@ -119,7 +123,7 @@ class UserMailer < ActionMailer::Base
   end
 
   def admin_privileges(user)
-    @user = user 
+    @user = user
     if user.active?
       FastGettext.with_locale FastGettext.default_locale do
         mail(to: user.email, subject:

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -8,10 +8,14 @@
     <%= _('Hello %{user_email}') %{ :user_email => user_email } %>
   </p>
   <p>
-    <%= _('A colleague has invited you to contribute to their Data Management Plan in %{tool_name}') %{ :tool_name => tool_name }%>
+    <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
+            " their Data Management Plan in %{tool_name}") % {
+      tool_name: tool_name,
+      inviter_name: @inviter.name(false)
+    } %>
   </p>
   <p>
-    <%= raw(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') %{ :click_here => link_to(_('Click here'), link), :link => link }) %>
+    <%= raw(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % { click_here: link_to(_('Click here'), link), link: link }) %>
   </p>
   <%= render partial: 'email_signature' %>
 <% end %>

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -2,12 +2,12 @@ class UserMailerPreview < ActionMailer::Preview
   def initialize
     @org = Org.first
     @recipient = User.new(email: "recipient@example.org", firstname: "Test", surname: "Recipient",
-                              password: "password123", password_confirmation: "password123", org: @org, 
+                              password: "password123", password_confirmation: "password123", org: @org,
                               accept_terms: true, confirmed_at: Time.zone.now)
     @requestor = User.new(email: "requestor@example.org", firstname: "Test", surname: "Requestor",
-                              password: "password123", password_confirmation: "password123", org: @org, 
+                              password: "password123", password_confirmation: "password123", org: @org,
                               accept_terms: true, confirmed_at: Time.zone.now)
-    @template = Template.new(title: 'Test template', description: 'My test template', org: @org, 
+    @template = Template.new(title: 'Test template', description: 'My test template', org: @org,
                                  archived: false, family_id: "9999999")
     @plan = Plan.new(template: @template, title: 'Test Plan', grant_number: 'Grant-123',
                      principal_investigator: 'Researcher', principal_investigator_identifier: 'researcher-1234',
@@ -19,7 +19,7 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.welcome_notification(@requestor)
   end
   def sharing_notification
-    UserMailer.sharing_notification(@role, @recipient)
+    UserMailer.sharing_notification(@role, @recipient, inviter: @requestor)
   end
   def permissions_change_notification
     UserMailer.permissions_change_notification(@role, @recipient)


### PR DESCRIPTION
Fixes #1587 .

Changes proposed in this PR:
- Add inviter name to sharing notification email