### PR TITLE
Update feeback requests to provide more info

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -9,7 +9,7 @@ class OrgsController < ApplicationController
     authorize org
     languages = Language.all.order("name")
     org.links = {"org": []} unless org.links.present?
-    render 'admin_edit', locals: {org: org, languages: languages, method: 'PUT', 
+    render 'admin_edit', locals: {org: org, languages: languages, method: 'PUT',
                                   url: admin_update_org_path(org) }
   end
 
@@ -22,14 +22,14 @@ class OrgsController < ApplicationController
     @org.logo = attrs[:logo] if attrs[:logo]
     tab = (attrs[:feedback_enabled].present? ? 'feedback' : 'profile')
     if params[:org_links].present?
-      @org.links = JSON.parse(params[:org_links]) 
+      @org.links = JSON.parse(params[:org_links])
     end
-    
+
     begin
       # Only allow super admins to change the org types and shib info
-      if current_user.can_super_admin?    
+      if current_user.can_super_admin?
         # Handle Shibboleth identifiers if that is enabled
-        if Rails.application.config.shibboleth_use_filtered_discovery_service 
+        if Rails.application.config.shibboleth_use_filtered_discovery_service
           shib = IdentifierScheme.find_by(name: 'shibboleth')
           shib_settings = @org.org_identifiers.select{ |ids| ids.identifier_scheme == shib}.first
 
@@ -38,7 +38,7 @@ class OrgsController < ApplicationController
             shib_settings.identifier = params[:shib_id]
             shib_settings.attrs = {domain: params[:shib_domain]}
             shib_settings.save
-          else  
+          else
             if shib_settings.present?
               # The user cleared the shib values so delete the object
               shib_settings.destroy
@@ -46,7 +46,7 @@ class OrgsController < ApplicationController
           end
         end
       end
-      
+
       if @org.update_attributes(attrs)
         flash[:notice] = success_message(_('organisation'), _('saved'))
         redirect_to "#{admin_edit_org_path(@org)}\##{tab}"
@@ -63,14 +63,14 @@ class OrgsController < ApplicationController
   # ----------------------------------------------------------------
   def shibboleth_ds
     redirect_to root_path unless current_user.nil?
-  
+
     @user = User.new
-    # Display the custom Shibboleth discovery service page. 
+    # Display the custom Shibboleth discovery service page.
     @orgs = Org.joins(:identifier_schemes).where('identifier_schemes.name = ?', 'shibboleth').sort{|x,y| x.name <=> y.name }
-  
+
     if @orgs.empty?
       flash[:alert] = _('No organisations are currently registered.')
-      redirect_to user_shibboleth_omniauth_authorize_path 
+      redirect_to user_shibboleth_omniauth_authorize_path
     end
   end
 
@@ -82,12 +82,12 @@ class OrgsController < ApplicationController
 
       scheme = IdentifierScheme.find_by(name: 'shibboleth')
       shib_entity = OrgIdentifier.where(org_id: params['shib-ds'][:org_id], identifier_scheme: scheme)
-  
+
       if !shib_entity.empty?
         # Force SSL
         url = "#{request.base_url.gsub('http:', 'https:')}#{Rails.application.config.shibboleth_login}"
         target = "#{user_shibboleth_omniauth_callback_url.gsub('http:', 'https:')}"
-    
+
         #initiate shibboleth login sequence
         redirect_to "#{url}?target=#{target}&entityID=#{shib_entity.first.identifier}"
       else
@@ -104,6 +104,6 @@ class OrgsController < ApplicationController
   private
     def org_params
       params.require(:org).permit(:name, :abbreviation, :logo, :contact_email, :contact_name, :remove_logo, :org_type,
-                                  :feedback_enabled, :feedback_email_subject, :feedback_email_msg)
+                                  :feedback_enabled, :feedback_email_msg)
     end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -3,6 +3,8 @@ class PlansController < ApplicationController
   include ConditionalUserMailer
   helper PaginableHelper
   helper SettingsTemplateHelper
+  include FeedbacksHelper
+
   after_action :verify_authorized, except: [:overview]
 
   def index
@@ -153,16 +155,16 @@ class PlansController < ApplicationController
   def edit
     plan = Plan.find(params[:id])
     authorize plan
-    
+
     plan, phase = Plan.load_for_phase(params[:id], params[:phase_id])
-    
+
     readonly = !plan.editable_by?(current_user.id)
-    
+
     guidance_groups =  GuidanceGroup.where(published: true, id: plan.guidance_group_ids)
     # Since the answers have been pre-fetched through plan (see Plan.load_for_phase)
     # we create a hash whose keys are question id and value is the answer associated
     answers = plan.answers.reduce({}){ |m, a| m[a.question_id] = a; m }
-    
+
     render('/phases/edit', locals: {
       base_template_org: phase.template.base_org,
       plan: plan, phase: phase, readonly: readonly,
@@ -171,7 +173,7 @@ class PlansController < ApplicationController
       answers: answers,
       guidance_service: GuidanceService.new(plan) })
   end
-  
+
   # PUT /plans/1
   # PUT /plans/1.json
   def update
@@ -185,7 +187,7 @@ class PlansController < ApplicationController
         guidance_group_ids = params[:guidance_group_ids].blank? ? [] : params[:guidance_group_ids].map(&:to_i).uniq
         @plan.guidance_groups = GuidanceGroup.where(id: guidance_group_ids)
         @plan.save
-      
+
         if @plan.update_attributes(attrs)
           format.html { redirect_to overview_plan_path(@plan), notice: success_message(_('plan'), _('saved')) }
           format.json {render json: {code: 1, msg: success_message(_('plan'), _('saved'))}}
@@ -194,7 +196,7 @@ class PlansController < ApplicationController
           format.html { render action: "edit" }
           format.json {render json: {code: 0, msg: flash[:alert]}}
         end
-        
+
       rescue Exception
         flash[:alert] = failed_update_error(@plan, _('plan'))
         format.html { render action: "edit" }
@@ -348,18 +350,19 @@ class PlansController < ApplicationController
   end
 
   def request_feedback
-    plan = Plan.find(params[:id])
-    authorize plan
+    @plan = Plan.find(params[:id])
+    authorize @plan
     alert = _('Unable to submit your request for feedback at this time.')
 
     begin
-     if plan.request_feedback(current_user)
-       redirect_to share_plan_path(plan), notice: _('Your request for feedback has been submitted.')
+     if @plan.request_feedback(current_user)
+       redirect_to share_plan_path(@plan),
+                   notice: _(request_feedback_flash_notice)
      else
-       redirect_to share_plan_path(plan), alert: alert
+       redirect_to share_plan_path(@plan), alert: alert
      end
     rescue Exception
-      redirect_to share_plan_path(plan), alert: alert
+      redirect_to share_plan_path(@plan), alert: alert
     end
   end
 
@@ -444,5 +447,16 @@ class PlansController < ApplicationController
       end
     end
     plan.delete(src_plan_key)
+  end
+
+  # Flash notice for successful feedback requests
+  #
+  # @return [String]
+  def request_feedback_flash_notice
+    # Use the generic feedback confirmation message unless the Org has
+    # specified one
+    text = current_user.org.feedback_email_msg ||
+             feedback_confirmation_default_message
+    feedback_constant_to_text(text, current_user, @plan, current_user.org)
   end
 end

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -1,0 +1,18 @@
+module FeedbacksHelper
+  def feedback_confirmation_default_subject
+    _('%{application_name}: Your plan has been submitted for feedback')
+  end
+
+  def feedback_confirmation_default_message
+    _('<p>Hello %{user_name}.</p>'\
+            '<p>Your plan "%{plan_name}" has been submitted for feedback from an administrator at your organisation. '\
+            'If you have questions pertaining to this action, please contact us at %{organisation_email}.</p>')
+  end
+
+  def feedback_constant_to_text(text, user, plan, org)
+    _("#{text}") % {application_name: Rails.configuration.branding[:application][:name],
+                    user_name: user.name,
+                    plan_name: plan.title,
+                    organisation_email: org.contact_email}
+  end
+end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,21 +1,5 @@
 module MailerHelper
   include PermsHelper
-  def feedback_confirmation_default_subject
-    _('%{application_name}: Your plan has been submitted for feedback')
-  end
-
-  def feedback_confirmation_default_message
-    _('<p>Hello %{user_name}.</p>'\
-            '<p>Your plan "%{plan_name}" has been submitted for feedback from an administrator at your organisation. '\
-            'If you have questions pertaining to this action, please contact us at %{organisation_email}.</p>')
-  end
-  
-  def feedback_constant_to_text(text, user, plan, org)
-    _("#{text}") % {application_name: Rails.configuration.branding[:application][:name],
-                    user_name: user.name,
-                    plan_name: plan.title,
-                    organisation_email: org.contact_email}
-  end
 
   # Returns an unordered HTML list with the permissions associated to the user passed
   def privileges_list(user)
@@ -23,7 +7,7 @@ module MailerHelper
       names = name_and_text
       r= "<ul>"
       user.perms.each do |p|
-        r+="<li>#{names[p.name.to_sym]}</li>" if names.has_key?(p.name.to_sym) 
+        r+="<li>#{names[p.name.to_sym]}</li>" if names.has_key?(p.name.to_sym)
       end
       r+= "</ul>"
     end

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -1,19 +1,17 @@
 module OrgsHelper
+  # frozen_string_literal: true
 
-  DEFAULT_EMAIL = '%{organisation_email}'.freeze
+  DEFAULT_EMAIL = '%{organisation_email}'
 
   # Tooltip string for Org feedback form.
   #
   # @param org [Org] The current Org we're updating feedback form for.
   # @return [String] The tooltip message
   def tooltip_for_org_feedback_form(org)
-    output = <<~TEXT
-      Someone will respond to your request within 48 hours. If you have
-      questions pertaining to this action please contact us at
-      %{email}.
-    TEXT
-    email = org.contact_email.present? ? org.contact_email : DEFAULT_EMAIL
-    _(output % { email: email })
+    email = org.contact_email.presence || DEFAULT_EMAIL
+    _("Someone will respond to your request within 48 hours. If you have \
+    questions pertaining to this action please contact us at %{email}") % {
+      email: email
+    }
   end
-
 end

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -1,0 +1,19 @@
+module OrgsHelper
+
+  DEFAULT_EMAIL = '%{organisation_email}'.freeze
+
+  # Tooltip string for Org feedback form.
+  #
+  # @param org [Org] The current Org we're updating feedback form for.
+  # @return [String] The tooltip message
+  def tooltip_for_org_feedback_form(org)
+    output = <<~TEXT
+      Someone will respond to your request within 48 hours. If you have
+      questions pertaining to this action please contact us at
+      %{email}.
+    TEXT
+    email = org.contact_email.present? ? org.contact_email : DEFAULT_EMAIL
+    _(output % { email: email })
+  end
+
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,8 @@
 class UserMailer < ActionMailer::Base
   include MailerHelper
   helper MailerHelper
+  helper FeedbacksHelper
+
   default from: Rails.configuration.branding[:organisation][:email]
 
   def welcome_notification(user)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -194,11 +194,6 @@ class Plan < ActiveRecord::Base
         end
 
         if self.save!
-          # Send an email confirmation to the owners and co-owners
-          owners = User.joins(:roles).where('roles.plan_id =? AND roles.access IN (?)', self.id, Role.access_values_for(:administrator))
-          deliver_if(recipients: owners, key: 'users.feedback_requested') do |r|
-            UserMailer.feedback_confirmation(r, self, user).deliver_now
-          end
           # Send an email to the org-admin contact
           if user.org.contact_email.present?
             contact = User.new(email: user.org.contact_email, firstname: user.org.contact_name)

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -8,19 +8,14 @@
     </div>
   </div>
   <div id="feeback-email">
-    <h3><%= _('Request Expert Feedback - Automated Email:') %></h3>
+    <h3>
+      <%= _('Request Expert Feedback - Message Displayed on Share Plan Tab:') %>
+    </h3>
     <div class="row">
-      <div class="form-group col-xs-8">
-        <%= f.label :feedback_email_subject, _('Subject'), class: "control-label" %>
-
-        <%= f.text_field :feedback_email_subject, class: "form-control", placeholder: feedback_confirmation_default_subject.gsub('%{application_name}', Rails.configuration.branding[:application][:name]) %>
-      </div>
-    </div>
-    <div class="row">
-      <% tip = feedback_confirmation_default_message.gsub('%{organisation_email}',  org.contact_email.present? ? org.contact_email : '%{organisation_email}') %>
-      <div class="form-group col-xs-8" data-toggle="tooltip" data-html="true" title="<%= tip %>">
+      <div class="form-group col-xs-8" data-toggle="tooltip" data-html="true" title="<%= tooltip_for_org_feedback_form(org) %>">
         <%= f.label :feedback_email_msg, _('Message'), class: "control-label" %>
-        <%= f.text_area :feedback_email_msg, class: "form-control" %>
+        <%= f.text_area :feedback_email_msg, class: "form-control",
+                        "aria-required" => true %>
       </div>
     </div>
   </div>

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -41,7 +41,7 @@
           <td><%= role.user.name %></td>
           <td>
             <% if role.creator? %>
-                <span><%= _('Owner') %></span> 
+                <span><%= _('Owner') %></span>
             <% else %>
                 <% if administerable && role.user != current_user %>
                       <%= form_for role, url: { controller: :roles, action: :update, id: role.id }, remote: true, html: { method: :put } do |f| %>
@@ -78,7 +78,7 @@
       <%= user.email_field :email, for: :user, name: "user", class: "form-control", "aria-required": true %>
     <% end %>
   </div>
-  
+
   <fieldset class="col-xs-12">
     <legend><%= _('Permissions') %></legend>
     <div class="form-group">
@@ -102,6 +102,9 @@
     <% if plan.owner_and_coowners.include?(current_user) && current_user.org.present? && current_user.org.feedback_enabled? %>
       <h2><%= _('Request expert feedback') %></h2>
       <p><%= _('Click below to give data management staff at your organisation access to read and comment on your plan.') %></p>
+      <div class="well well-sm">
+        <%= current_user.org.feedback_email_msg.html_safe %>
+      </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
 
   <div class="form-group col-xs-8">

--- a/lib/assets/javascripts/views/orgs/admin_edit.js
+++ b/lib/assets/javascripts/views/orgs/admin_edit.js
@@ -22,6 +22,7 @@ $(() => {
   Tinymce.init({ selector: '#org_feedback_email_msg' });
   toggleFeedback();
   enableValidations($('#edit_org_profile_form .form-group:not(.link-input)'));
+  enableValidations($('#edit_org_feedback_form .form-group'));
   // Only enable validations on the links section if it has values initially
   $('.link').each((idx, el) => {
     const linkVal = $(el).find('input[name="link_link"]').val();


### PR DESCRIPTION
Fixes #1163 .

Changes proposed in this PR:
- Revise heading above editor to "Request Expert Feedback - Message Displayed on Share Plan Tab"
- Remove "Subject" field from organisation feedback form
- Make Message a mandatory field (related issue #1197 ) in organisation feedback form
- Revise tooltip text: "Someone will respond to your request within 48 hours. If you have questions pertaining to this action please contact us at [insert email address]."
- Display the feedback message on the page instead of sending the email to the owner(s)
- Display the Message created by admins on the Share plan tab 