### PR TITLE
Refactor Plan#readable_by? to check system settings

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -346,14 +346,23 @@ class Plan < ActiveRecord::Base
   # @param user_id [Integer] the id for a user
   # @return [Boolean] true if the user can read the plan
   def readable_by?(user_id)
-    user = user_id.is_a?(User) ? user_id : User.find(user_id)
-    owner_orgs = self.owner_and_coowners.collect(&:org)
+    user           = user_id.is_a?(User) ? user_id : User.find(user_id)
+    owner_orgs     = owner_and_coowners.collect(&:org)
+    sys_permission = Branding.fetch(:service_configuration, :plans,
+                                    :org_admins_read_all)
 
-    # Super Admins can view plans read-only, Org Admins can view their Org's plans
-    # otherwise the user must have the commenter role
-    (user.can_super_admin? ||
-     user.can_org_admin? && owner_orgs.include?(user.org) ||
-     has_role(user.id, :commenter))
+    # Super Admins can view plans read-only
+    if user.can_super_admin?
+      return true
+    # Org Admins can view their Org's plans if system permission allows
+    elsif user.can_org_admin? && owner_orgs.include?(user.org) && sys_permission
+      return true
+    # ...otherwise the user must have the commenter role.
+    elsif has_role(user.id, :commenter)
+      return true
+    else
+      return false
+    end
   end
 
   ##

--- a/config/branding_example.yml
+++ b/config/branding_example.yml
@@ -52,6 +52,10 @@ defaults: &defaults
       owners_and_coowners:
         visibility_changed: true
 
+  service_configuration:
+    plans:
+      org_admins_read_all: true
+
 
 development:
   <<: *defaults

--- a/lib/branding.rb
+++ b/lib/branding.rb
@@ -1,0 +1,19 @@
+# Provides a helper utility for loading branding configs.
+module Branding
+
+  module_function
+
+  # Loads branding config from YAML file.
+  #
+  # @param keys [Array<Object>] A list of the keys to return configs for.
+  #
+  # @example Return a value
+  #   Branding.fetch(:settings, :should_work) # => true
+  #   Branding.fetch(:settings, :email) # => 'user@example.com'
+  #   Branding.fetch(:settings, :missing) # => nil
+  # @return [Object] The value of the config
+  def fetch(*keys)
+    keys = keys.map(&:to_sym)
+    Rails.configuration.branding.dig(*keys)
+  end
+end

--- a/test/lib/branding_test.rb
+++ b/test/lib/branding_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+class BrandingTest < ActiveSupport::TestCase
+
+  test "Returns nested value from hash" do
+    Rails.configuration.stub(:branding, { test: { value: "foo" }}) do
+      assert_equal Branding.fetch(:test, :value), "foo"
+    end
+  end
+
+  test "It has indifferent access" do
+    Rails.configuration.stub(:branding, { test: { value: "foo" }}) do
+      assert_equal Branding.fetch(:test, 'value'), "foo"
+    end
+  end
+
+  test "Returns nil if key is missing" do
+    Rails.configuration.stub(:branding, { test: nil }) do
+      assert_nil Branding.fetch(:test, 'value')
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ SimpleCov.start 'rails'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'webmock/minitest'
+require 'minitest/mock'
 require 'active_support/inflector' # For pluralization utility
 
 class ActiveSupport::TestCase
@@ -28,7 +29,7 @@ class ActiveSupport::TestCase
   LANGUAGES = Language.all if LANGUAGES.empty?
 
   # Default attributes for model initialization
-  def org_seed  
+  def org_seed
     { name: 'Test Institution',
       abbreviation: 'TST',
       org_type: Org.org_type_values_for(:institution).min,
@@ -41,22 +42,22 @@ class ActiveSupport::TestCase
   end
   def user_seed
     {
-      email: 'test-user@testing-roadmap.org', 
-      firstname: 'Test', 
+      email: 'test-user@testing-roadmap.org',
+      firstname: 'Test',
       surname: 'User',
       language: Language.find_by(abbreviation: FastGettext.locale),
-      password: "password123", 
+      password: "password123",
       password_confirmation: "password123",
-      accept_terms: true, 
-      confirmed_at: Time.zone.now, 
+      accept_terms: true,
+      confirmed_at: Time.zone.now,
     }
   end
 
-  def template_seed 
+  def template_seed
     {
-      title: 'Test template', 
+      title: 'Test template',
       description: 'this is a test template',
-      org: Org.first, 
+      org: Org.first,
     }
   end
   def phase_seed
@@ -75,7 +76,7 @@ class ActiveSupport::TestCase
       modifiable: true,
     }
   end
-  def question_format_seed 
+  def question_format_seed
     {
       title: 'Text area',
       option_based: false,
@@ -104,7 +105,7 @@ class ActiveSupport::TestCase
       is_default: true,
     }
   end
-  def plan_seed 
+  def plan_seed
     {
       title: 'Test plan',
       funder_name: 'Organisation with a lot of funds',
@@ -141,7 +142,7 @@ class ActiveSupport::TestCase
       published: true,
     }
   end
-  
+
   def validate_and_create_obj(obj)
     obj.validate
     if obj.errors.present?
@@ -153,7 +154,7 @@ class ActiveSupport::TestCase
     assert obj.valid?
     obj
   end
-  
+
   # Org initializers
   def init_institution(**props)
     validate_and_create_obj(Org.new(org_seed.merge(props)))
@@ -173,33 +174,33 @@ class ActiveSupport::TestCase
 
   # User initializers
   def init_researcher(org, **props)
-    validate_and_create_obj(User.new(user_seed.merge({ 
-      org: org, 
+    validate_and_create_obj(User.new(user_seed.merge({
+      org: org,
       surname: 'Researcher',
       email: 'researcher@testing-roadmap.org',
      }.merge(props))))
   end
   def init_org_admin(org, **props)
-    perms = Perm.where.not(name: ['admin', 'add_organisations', 
-                                  'change_org_affiliation', 'grant_api_to_orgs', 
+    perms = Perm.where.not(name: ['admin', 'add_organisations',
+                                  'change_org_affiliation', 'grant_api_to_orgs',
                                   'change_org_details'])
-    validate_and_create_obj(User.new(user_seed.merge({ 
-      org: org, 
-      surname: 'OrgAdmin', 
+    validate_and_create_obj(User.new(user_seed.merge({
+      org: org,
+      surname: 'OrgAdmin',
       email: 'org.admin@testing-roadmap.org',
       perms: perms,
      }.merge(props))))
   end
   def init_super_admin(org, **props)
     perms = Perm.all
-    validate_and_create_obj(User.new(user_seed.merge({ 
-      org: org, 
-      surname: 'SuperAdmin', 
+    validate_and_create_obj(User.new(user_seed.merge({
+      org: org,
+      surname: 'SuperAdmin',
       email: 'super.admin@testing-roadmap.org',
-      perms: perms 
+      perms: perms
     }.merge(props))))
   end
-  
+
   # Template initializers
   def init_template(org, **props)
     if org.is_a? Org
@@ -279,7 +280,7 @@ class ActiveSupport::TestCase
       nil
     end
   end
-  
+
   # equality helpers for complex objects
   def assert_annotations_equal(annotation1, annotation2)
     assert_equal annotation1.text, annotation2.text, 'expected the annotations to have the same text'
@@ -347,7 +348,7 @@ class ActiveSupport::TestCase
   # ----------------------------------------------------------------------
   def scaffold_template
     template = Template.new(title: 'Test template',
-                            description: 'My test template', 
+                            description: 'My test template',
                             links: {"funder":[],"sample_plan":[]},
                             org: Org.first, archived: false, family_id: "0000009999")
 
@@ -465,7 +466,7 @@ class ActiveSupport::TestCase
             if relation_obj.respond_to?(:each)
               relation_obj.each do |obj|
                 assert_nil(obj.id, "id should be nil for the relation object from #{obj.class}") if copy.respond_to?(:id)
-              end 
+              end
             end
           end
         end

--- a/test/unit/plan_test.rb
+++ b/test/unit/plan_test.rb
@@ -25,6 +25,44 @@ class PlanTest < ActiveSupport::TestCase
     @plan.reload
   end
 
+  test "readable_by? false when organisation settings is false for org admin" do
+    @creator.update!(org: @org)
+    @org_admin = User.create!(email: "org-admin@example.com",
+                              password: "password",
+                              org: @org)
+
+    @org_admin.perms << Perm.grant_permissions
+    @org_admin.perms << Perm.modify_guidance
+    @org_admin.perms << Perm.modify_templates
+    @org_admin.perms << Perm.change_org_details
+
+    assert @org_admin.reload.can_org_admin?
+    Rails.configuration.stub(:branding, {
+      service_configuration: { plans: { org_admins_read_all: false } }
+    }) do
+      refute @plan.readable_by?(@org_admin)
+    end
+  end
+
+  test "readable_by? true when organisation settings is true for org admin" do
+    @creator.update!(org: @org)
+    @org_admin = User.create!(email: "org-admin@example.com",
+                              password: "password",
+                              org: @org)
+
+    @org_admin.perms << Perm.grant_permissions
+    @org_admin.perms << Perm.modify_guidance
+    @org_admin.perms << Perm.modify_templates
+    @org_admin.perms << Perm.change_org_details
+
+    assert @org_admin.reload.can_org_admin?
+    Rails.configuration.stub(:branding, {
+      service_configuration: { plans: { org_admins_read_all: true } }
+    }) do
+      assert @plan.readable_by?(@org_admin)
+    end
+  end
+
   # ---------------------------------------------------
   test "required fields are required" do
     # TODO: uncomment the validation on Plan and then retest this. The validations appear to be breaking the
@@ -100,10 +138,10 @@ class PlanTest < ActiveSupport::TestCase
     guidance_groups = GuidanceGroup.includes(guidances: :themes).where(published: true)
     @plan.guidance_groups << guidance_groups
     @plan.save!
-    
+
     phase = @template.phases.first
     hash = @plan.guidance_by_question_as_hash
-    
+
     phase.sections.includes(questions: :themes).each do |section|
       section.questions.each do |question|
         question.themes.each do |theme|
@@ -237,7 +275,7 @@ class PlanTest < ActiveSupport::TestCase
     assert @plan.reviewable_by?(usr), "expected the reviewer to be able to review"
     assert @plan.readable_by?(usr), "expected the reviewer to be able to comment"
   end
-  
+
   # ---------------------------------------------------
   test "name returns the title" do
     assert_equal @plan.title, @plan.name
@@ -310,7 +348,7 @@ class PlanTest < ActiveSupport::TestCase
     plan = Plan.new(title: 'Tester', visibility: :is_test)
     verify_belongs_to_relationship(plan, Template.first)
   end
-  
+
   # ---------------------------------------------------
   test "owner_and_coowners returns the correct users" do
     usrs = @plan.owner_and_coowners
@@ -319,14 +357,14 @@ class PlanTest < ActiveSupport::TestCase
       assert [@creator, @administrator].include?(usr), "expected only the creator and co-owner but found #{usr.email}"
     end
   end
-  
+
   # ---------------------------------------------------
   test "can request feedback" do
     scaffold_org_admin(@creator.org)
-    
+
     @plan.request_feedback(@creator)
     assert @plan.feedback_requested, "expected the feedback flag to be set to true"
-    assert @plan.reviewable_by?(@user), "expected the Org Admin to be a reviewer" 
+    assert @plan.reviewable_by?(@user), "expected the Org Admin to be a reviewer"
   end
 
   # ---------------------------------------------------
@@ -336,9 +374,9 @@ class PlanTest < ActiveSupport::TestCase
     @plan.feedback_requested = true
     @plan.roles << Role.new(user: @user, access: val)
     @plan.save!
-    
+
     @plan.complete_feedback(@user)
     assert_not @plan.feedback_requested, "expected the feedback flag to be set to false"
-    assert_not @plan.reviewable_by?(@user), "expected the Org Admin to no longer be a reviewer" 
+    assert_not @plan.reviewable_by?(@user), "expected the Org Admin to no longer be a reviewer"
   end
 end


### PR DESCRIPTION
Fixes #1661 .

Changes proposed in this PR:
- Add helper class for accessing system configs from `branding.yml`
- Refactor `Plan#readable_by?` to check system settings