### PR TITLE
fixed issue with notification pref messaging on email signatures

### DIFF
--- a/app/views/user_mailer/_email_signature.html.erb
+++ b/app/views/user_mailer/_email_signature.html.erb
@@ -1,8 +1,8 @@
-<% 
+<%
   tool_name = Rails.configuration.branding[:application][:name]
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
   email_subject = email_subject || _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
-  allow_change_prefs = allow_change_prefs || true
+  allow_change_prefs = allow_change_prefs.nil? ? true : allow_change_prefs
 
   # Override the default Rails route helper for the contact_us page IF an alternate contact_us url was defined
   # in the branding config file
@@ -14,5 +14,5 @@
   <%= _('The %{tool_name} team') %{:tool_name => tool_name} %>
 </p>
 <p>
-  <% if allow_change_prefs %><%= _('You may change your notification preferences on your profile page.') %><% end %>&nbsp;<%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us => link_to(contact_us, contact_us) }) %>
+  <% if allow_change_prefs %><%= _('You may change your notification preferences on your profile page. ') %><% end %><%= _('Please do not reply to this email.') %>&nbsp;<%= raw(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') %{ :helpdesk_email => mail_to(helpdesk_email, helpdesk_email, subject: email_subject), :contact_us => link_to(contact_us, contact_us) }) %>
 </p>

--- a/app/views/user_mailer/feedback_notification.html.erb
+++ b/app/views/user_mailer/feedback_notification.html.erb
@@ -22,7 +22,6 @@
     Alternatively, you can click the link below:<br>
     <%= link_to plan_url(@plan), plan_url(@plan) %>
   </p>
-
-  <%= render partial: 'email_signature' %>
-
+  
+  <%= render partial: 'email_signature', locals: { allow_change_prefs: false } %>
 <% end %>


### PR DESCRIPTION
Fixes #1631 

Original code was resolving to `allow_change_prefs = false || true` which always set the variable to true
