### PR TITLE
Remove Rails 3 attr_accessible from models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ lib/assets/node_modules
 lib/assets/npm-debug.log
 lib/assets/.eslintcache
 !.keep
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,6 @@ gem 'rails', '~> 4.2.10'
 gem 'railties'
 
 
-#    GEMS ADDED TO HELP HANDLE RAILS MIGRATION FROM 3.x to 4.2
-#    THESE GEMS HELP SUPPORT DEPRACATED FUNCTIONALITY AND WILL LOSE SUPPORT IN FUTURE VERSIONS
-#    WE SHOULD CONSIDER BRINGING THE CODE UP TO DATE INSTEAD
-gem 'protected_attributes', '~> 1.1.3'  # Provides attr_accessor functions
 gem 'responders', '~> 2.0'  # Allows use of respond_with and respond_to in controllers
 
 # ------------------------------------------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,8 +164,6 @@ GEM
     pg (0.19.0)
     po_to_json (1.0.1)
       json (>= 1.6.0)
-    protected_attributes (1.1.3)
-      activemodel (>= 4.0.1, < 5.0)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (1.6.10)
@@ -268,7 +266,6 @@ DEPENDENCIES
   omniauth-orcid
   omniauth-shibboleth
   pg (~> 0.19.0)
-  protected_attributes (~> 1.1.3)
   pundit
   rack-mini-profiler
   rack-test

--- a/app/controllers/guidance_groups_controller.rb
+++ b/app/controllers/guidance_groups_controller.rb
@@ -19,7 +19,7 @@ class GuidanceGroupsController < ApplicationController
   # POST /guidance_groups
   # POST /guidance_groups.json
   def admin_create
-    @guidance_group = GuidanceGroup.new(params[:guidance_group])
+    @guidance_group = GuidanceGroup.new(guidance_group_params)
     authorize @guidance_group
     @guidance_group.org_id = current_user.org_id
     if params[:save_publish]
@@ -49,8 +49,8 @@ class GuidanceGroupsController < ApplicationController
     @guidance_group.org_id = current_user.org_id
     @guidance_group.published = true unless params[:save_publish].nil?
 
-    if @guidance_group.update_attributes(params[:guidance_group])
-      redirect_to admin_index_guidance_path(params[:guidance_group]), notice: success_message(_('guidance group'), _('saved'))
+    if @guidance_group.update(guidance_group_params)
+      redirect_to admin_index_guidance_path(guidance_group_params), notice: success_message(_('guidance group'), _('saved'))
     else
       flash[:alert] = failed_update_error(@guidance_group, _('guidance group'))
       render 'admin_edit'
@@ -93,4 +93,10 @@ class GuidanceGroupsController < ApplicationController
     end
   end
 
+  private
+
+  def guidance_group_params
+    params.require(:guidance_group)
+          .permit(:org_id, :name, :optional_subset, :published, :org, :guidances)
+  end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,31 +6,30 @@ class NotesController < ApplicationController
 
   def create
     @note = Note.new
-    @note.user_id = params[:note][:user_id]
-
-    # create answer if we don't have one already
-    @answer = nil # if defined within the transaction block, was not accessable afterward
+    @note.user_id = note_params[:user_id]
     # ensure user has access to plan BEFORE creating/finding answer
-    raise Pundit::NotAuthorizedError unless Plan.find(params[:note][:plan_id]).readable_by?(@note.user_id)
+    unless Plan.find_by(id: note_params[:plan_id]).readable_by?(@note.user_id)
+      raise Pundit::NotAuthorizedError
+    end
     Answer.transaction do
-      @answer = Answer.find_by(plan_id: params[:note][:plan_id], question_id: params[:note][:question_id])
+      @answer = Answer.find_by(plan_id: note_params[:plan_id], question_id: note_params[:question_id])
       if @answer.blank?
-        @answer = Answer.new
-        @answer.plan_id = params[:note][:plan_id]
-        @answer.question_id = params[:note][:question_id]
-        @answer.user_id = @note.user_id
+        @answer             = Answer.new
+        @answer.plan_id     = note_params[:plan_id]
+        @answer.question_id = note_params[:question_id]
+        @answer.user_id     = @note.user_id
         @answer.save!
       end
     end
 
     @note.answer = @answer
-    @note.text = params[:note][:text]
+    @note.text = note_params[:text]
 
     authorize @note
 
     @plan = @answer.plan
 
-    @question = Question.find(params[:note][:question_id])
+    @question = Question.find(note_params[:question_id])
 
     if @note.save
       @status = true
@@ -43,11 +42,11 @@ class NotesController < ApplicationController
       @notice = success_message(_('comment'), _('created'))
       render(json: {
         "notes" => {
-          "id" => params[:note][:question_id],
+          "id" => note_params[:question_id],
           "html" => render_to_string(partial: 'layout', locals: {plan: @plan, question: @question, answer: @answer }, formats: [:html])
         },
         "title" => {
-          "id" => params[:note][:question_id],
+          "id" => note_params[:question_id],
           "html" => render_to_string(partial: 'title', locals: { answer: @answer}, formats: [:html])
         }
       }.to_json, status: :created)
@@ -63,7 +62,7 @@ class NotesController < ApplicationController
   def update
     @note = Note.find(params[:id])
     authorize @note
-    @note.text = params[:note][:text]
+    @note.text = note_params[:text]
 
     @answer = @note.answer
     @question = @answer.question
@@ -71,7 +70,7 @@ class NotesController < ApplicationController
 
     question_id = @note.answer.question_id.to_s
 
-    if @note.update_attributes(params[:note])
+    if @note.update(note_params)
       @notice = success_message(_('comment'), _('saved'))
       render(json: {
         "notes" => {
@@ -103,7 +102,7 @@ class NotesController < ApplicationController
 
     question_id = @note.answer.question_id.to_s
 
-    if @note.update_attributes(params[:note])
+    if @note.update(note_params)
       @notice = success_message(_('comment'), _('removed'))
       render(json: {
         "notes" => {
@@ -121,5 +120,13 @@ class NotesController < ApplicationController
         "msg" => @notice
       }.to_json, status: :bad_request
     end
+  end
+
+  private
+
+  def note_params
+    params.require(:note)
+          .permit(:text, :archived_by, :user_id, :answer_id, :plan_id,
+                  :question_id)
   end
 end

--- a/app/controllers/org_admin/questions_controller.rb
+++ b/app/controllers/org_admin/questions_controller.rb
@@ -122,32 +122,33 @@ module OrgAdmin
     end
 
     private
-      def question_params
-        params.require(:question).permit(:number, :text, :question_format_id, :option_comment_display, :default_value, question_options_attributes: [:id, :number, :text, :is_default, :_destroy], annotations_attributes: [:id, :text, :org_id, :org, :type], theme_ids: [])
-      end
 
-      # When a template gets versioned by changes to one of its questions we need to loop
-      # through the incoming params and ensure that the annotations and question_options
-      # get attached to the new question
-      def transfer_associations(question)
-        attrs = question_params
-        if attrs[:annotations_attributes].present?
-          attrs[:annotations_attributes].each_key do |key|
-            old_annotation = question.annotations.select do |a|
-              a.org_id.to_s == attrs[:annotations_attributes][key][:org_id] && a.type.to_s == attrs[:annotations_attributes][key][:type]
-            end
-            attrs[:annotations_attributes][key][:id] = old_annotation.first.id unless old_annotation.empty?
+    def question_params
+      params.require(:question).permit(:number, :text, :question_format_id, :option_comment_display, :default_value, question_options_attributes: [:id, :number, :text, :is_default, :_destroy], annotations_attributes: [:id, :text, :org_id, :org, :type], theme_ids: [])
+    end
+
+    # When a template gets versioned by changes to one of its questions we need to loop
+    # through the incoming params and ensure that the annotations and question_options
+    # get attached to the new question
+    def transfer_associations(question)
+      attrs = question_params
+      if attrs[:annotations_attributes].present?
+        attrs[:annotations_attributes].each_key do |key|
+          old_annotation = question.annotations.select do |a|
+            a.org_id.to_s == attrs[:annotations_attributes][key][:org_id] && a.type.to_s == attrs[:annotations_attributes][key][:type]
           end
+          attrs[:annotations_attributes][key][:id] = old_annotation.first.id unless old_annotation.empty?
         end
-        # TODO: This question_options id swap feel fragile. We cannot really match on any of the
-        #       data elements because the user may have changed them so we rely on its position
-        #       within the array/query since they should be equivalent.
-        if attrs[:question_options_attributes].present?
-          attrs[:question_options_attributes].each_key do |key|
-            attrs[:question_options_attributes][key][:id] = question.question_options[key.to_i].id.to_s if question.question_options[key.to_i].present?
-          end
-        end
-        attrs
       end
+      # TODO: This question_options id swap feel fragile. We cannot really match on any of the
+      #       data elements because the user may have changed them so we rely on its position
+      #       within the array/query since they should be equivalent.
+      if attrs[:question_options_attributes].present?
+        attrs[:question_options_attributes].each_key do |key|
+          attrs[:question_options_attributes][key][:id] = question.question_options[key.to_i].id.to_s if question.question_options[key.to_i].present?
+        end
+      end
+      attrs
+    end
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -23,12 +23,6 @@ class Answer < ActiveRecord::Base
 
   has_many :notes
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :text, :plan_id, :lock_version, :question_id, :user_id, :question_option_ids,
-                  :question, :user, :plan, :question_options, :notes, :note_ids, :id,
-                  :as => [:default, :admin]
 
   ##
   # Validations

--- a/app/models/exported_plan.rb
+++ b/app/models/exported_plan.rb
@@ -2,8 +2,6 @@ class ExportedPlan < ActiveRecord::Base
   include GlobalHelpers
   include SettingsTemplateHelper
 
-# TODO: REMOVE AND HANDLE ATTRIBUTE SECURITY IN THE CONTROLLER!
-  attr_accessible :plan_id, :user_id, :format, :user, :plan, :as => [:default, :admin]
 
   #associations between tables
   belongs_to :plan

--- a/app/models/guidance_group.rb
+++ b/app/models/guidance_group.rb
@@ -9,11 +9,6 @@ class GuidanceGroup < ActiveRecord::Base
   # has_and_belongs_to_many :guidances, join_table: "guidance_in_group"
 
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :org_id, :name, :optional_subset, :published, :org, :guidances,
-                  :as => [:default, :admin]
 
   validates :name, :org, presence: {message: _("can't be blank")}
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -4,11 +4,7 @@ class Note < ActiveRecord::Base
   belongs_to :answer
   belongs_to :user
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :text, :user_id, :answer_id, :archived, :archived_by, 
-                  :answer, :user, :as => [:default, :admin]
-                  
+
   validates :text, :answer, :user, presence: {message: _("can't be blank")}
+
 end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -23,16 +23,6 @@ class Org < ActiveRecord::Base
   has_many :identifier_schemes, through: :org_identifiers
 
   ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-	attr_accessible :abbreviation, :logo, :remove_logo,
-                  :logo_file_name, :name, :links,
-                  :organisation_type_id, :wayfless_entity, :parent_id, :sort_name,
-                  :token_permission_type_ids, :language_id, :contact_email, :contact_name,
-                  :language, :org_type, :region, :token_permission_types,
-                  :guidance_group_ids, :is_other, :region_id, :logo_uid, :logo_name,
-                  :feedback_enabled, :feedback_email_subject, :feedback_email_msg
-  ##
   # Validators
   validates :name, presence: {message: _("can't be blank")}, uniqueness: {message: _("must be unique")}
   # allow validations for logo upload

--- a/app/models/perm.rb
+++ b/app/models/perm.rb
@@ -3,13 +3,8 @@ class Perm < ActiveRecord::Base
   # Associations
   has_and_belongs_to_many :users, :join_table => :users_perms
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  #attr_accessible :name, :as => [:default, :admin]
-
   validates :name, presence: {message: _("can't be blank")}, uniqueness: {message: _("must be unique")}
-  
+
   scope :add_orgs, -> {Perm.find_by(name: 'add_organisations')}
   scope :change_affiliation, -> {Perm.find_by(name: 'change_org_affiliation')}
   scope :grant_permissions, -> {Perm.find_by(name: 'grant_permissions')}

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -13,22 +13,17 @@ class Phase < ActiveRecord::Base
   belongs_to :template
   has_many :sections, -> { order(:number => :asc) }, dependent: :destroy
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :description, :number, :title, :template_id, 
-                  :template, :sections, :modifiable, :as => [:default, :admin]
 
   validates :title, :number, :template, presence: {message: _("can't be blank")}
 
   scope :titles, -> (template_id) {
     Phase.where(template_id: template_id).select(:id, :title)
   }
-  
+
 # TODO: Remove after implementing new template versioning logic
   # Callbacks
   after_save do |phase|
-    # Updates the template.updated_at attribute whenever a phase has been created/updated 
+    # Updates the template.updated_at attribute whenever a phase has been created/updated
     phase.template.touch if template.present?
   end
 
@@ -37,7 +32,7 @@ class Phase < ActiveRecord::Base
     copy.modifiable = options.fetch(:modifiable, self.modifiable)
     copy.template_id = options.fetch(:template_id, nil)
     copy.save!(validate:false)  if options.fetch(:save, false)
-    options[:phase_id] = id
+    options[:phase_id] = copy.id
     self.sections.each{ |section| copy.sections << section.deep_copy(options) }
     return copy
   end
@@ -47,7 +42,7 @@ class Phase < ActiveRecord::Base
   def num_answered_questions(plan)
     return 0 if plan.nil?
     return sections.reduce(0) do |m, s|
-      m + s.num_answered_questions(plan) 
+      m + s.num_answered_questions(plan)
     end
   end
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -25,15 +25,6 @@ class Plan < ActiveRecord::Base
 #  has_many :users, through: :roles
 
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :locked, :project_id, :version_id, :version, :plan_sections,
-                  :exported_plans, :project, :title, :template, :grant_number,
-                  :identifier, :principal_investigator, :principal_investigator_identifier,
-                  :description, :data_contact, :funder_name, :visibility, :exported_plans,
-                  :roles, :users, :org, :data_contact_email, :data_contact_phone, :feedback_requested,
-                  :principal_investigator_email, :as => [:default, :admin]
   accepts_nested_attributes_for :roles
 
   # public is a Ruby keyword so using publicly

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -22,18 +22,9 @@ class Question < ActiveRecord::Base
   accepts_nested_attributes_for :question_options, :reject_if => lambda {|a| a[:text].blank? },  :allow_destroy => true
   accepts_nested_attributes_for :annotations, :allow_destroy => true
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :default_value, :dependency_id, :dependency_text, :guidance,:number,
-                  :annotation, :text, :section_id, :question_format_id,
-                  :question_options_attributes, :annotations_attributes,
-                  :option_comment_display, :theme_ids, :section, :question_format,
-                  :question_options, :annotations, :answers, :themes,
-                  :modifiable, :option_comment_display, :as => [:default, :admin]
 
   validates :text, :section, :number, presence: {message: _("can't be blank")}
-  
+
   ##
   # returns the text from the question
   #
@@ -58,7 +49,7 @@ class Question < ActiveRecord::Base
     self.themes.each{ |theme| copy.themes << theme }
     return copy
   end
-  
+
 # TODO: consider moving this to a view helper instead and use the built in scopes for guidance. May need to add
 #       a new one for 'thematic_guidance'. This method doesn't even make reference to this class and its returning
 #       a hash that is specific to a view

--- a/app/models/question_format.rb
+++ b/app/models/question_format.rb
@@ -5,14 +5,9 @@ class QuestionFormat < ActiveRecord::Base
   has_many :questions
 
   enum formattype: [ :textarea, :textfield, :radiobuttons, :checkbox, :dropdown, :multiselectbox, :date, :rda_metadata ]
-  attr_accessible :formattype
 
   validates :title, presence: {message: _("can't be blank")}, uniqueness: {message: _("must be unique")}
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :title, :description, :option_based, :questions, :as => [:default, :admin]
 
   # Retrieves the id for a given formattype passed
   scope :id_for, -> (formattype) { where(formattype: formattype).pluck(:id).first }

--- a/app/models/question_option.rb
+++ b/app/models/question_option.rb
@@ -4,11 +4,6 @@ class QuestionOption < ActiveRecord::Base
   belongs_to :question
   has_and_belongs_to_many :answers, join_table: :answers_question_options
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :text, :question_id, :is_default, :number, :question, 
-                  :as => [:default, :admin]
 
   validates :text, :question, :number, presence: {message: _("can't be blank")}
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -9,10 +9,6 @@ class Section < ActiveRecord::Base
   #Link the data
   accepts_nested_attributes_for :questions, :reject_if => lambda {|a| a[:text].blank? },  :allow_destroy => true
 
-  attr_accessible :phase_id, :description, :number, :title, :published,
-                  :questions_attributes, :organisation, :phase, :modifiable,
-                  :as => [:default, :admin]
-
   validates :phase, :title, :number, presence: {message: _("can't be blank")}
 
   before_validation :set_defaults
@@ -42,7 +38,7 @@ class Section < ActiveRecord::Base
     copy.modifiable = options.fetch(:modifiable, self.modifiable)
     copy.phase_id = options.fetch(:phase_id, nil)
     copy.save!(validate: false)  if options.fetch(:save, false)
-    options[:section_id] = id
+    options[:section_id] = copy.id
     self.questions.map{ |question| copy.questions << question.deep_copy(options) }
     return copy
   end

--- a/app/models/settings/template.rb
+++ b/app/models/settings/template.rb
@@ -1,8 +1,6 @@
 module Settings
   class Template < RailsSettings::SettingObject
 
-  #attr_accessible :var, :target, :target_id, :target_type
-
     VALID_FONT_FACES = [
       '"Times New Roman", Times, Serif',
       'Arial, Helvetica, Sans-Serif'

--- a/app/models/splash_log.rb
+++ b/app/models/splash_log.rb
@@ -1,3 +1,2 @@
 class SplashLog < ActiveRecord::Base
-	#attr_accessible :destination
 end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -5,13 +5,6 @@ class Theme < ActiveRecord::Base
   has_and_belongs_to_many :questions, join_table: "questions_themes"
   has_and_belongs_to_many :guidances, join_table: "themes_in_guidance"
 
-  ##
-  # Possibly needed for active_admin
-  #   -relies on protected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :guidance_ids , :as => [:default, :admin]
-  attr_accessible :question_ids, :as => [:default, :admin]
-  attr_accessible :description, :title, :locale , :as => [:default, :admin]
-
 
   validates :title, presence: {message: _("can't be blank")}
 

--- a/app/models/token_permission_type.rb
+++ b/app/models/token_permission_type.rb
@@ -6,11 +6,6 @@ class TokenPermissionType < ActiveRecord::Base
   has_and_belongs_to_many :orgs, join_table: 'org_token_permissions', unique: true
 
   ##
-  # Possibly needed for active_admin
-  #  - relies on proetected_attributes gem as syntax depricated in rails 4.2
-  attr_accessible :token_type, :text_description, :as => [:default, :admin]
-
-  ##
   # Validators
   validates :token_type, presence: {message: _("can't be blank")}, uniqueness: {message: _("must be unique")}
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module DMPRoadmap
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-	
+
 	# Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
 
@@ -39,7 +39,7 @@ module DMPRoadmap
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
-    
+
     config.eager_load_paths << "app/models/scopes"
     config.eager_load_paths << "app/services"
 
@@ -47,12 +47,6 @@ module DMPRoadmap
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
-
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    #config.active_record.whitelist_attributes = true	
 
     config.autoload_paths += %W(#{config.root}/lib)
     config.action_controller.include_all_helpers = true
@@ -83,7 +77,7 @@ module DMPRoadmap
 
     # Load Branded terminology (e.g. organization name, application name, etc.)
     config.branding = config_for(:branding).deep_symbolize_keys
-    
+
     # The default visibility setting for new plans
     #   organisationally_visible  - Any member of the user's org can view, export and duplicate the plan
     #   publicly_visibile         - (NOT advisable because plans will show up in Public DMPs page by default)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,9 +31,6 @@ Rails.application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   config.action_mailer.perform_deliveries = false
 
   BetterErrors::Midleware.allow_ip! "10.0.2.2" if defined?(BetterErrors) && Rails.env == :development

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -354,8 +354,6 @@ templates = [
    org: Org.find_by(abbreviation: Rails.configuration.branding[:organisation][:abbreviation]),
    is_default: true,
    version: 0,
-   migrated: false,
-   dmptemplate_id: 1,
    visibility: Template.visibilities[:publicly_visible],
    links: {"funder":[],"sample_plan":[]}},
 
@@ -364,9 +362,7 @@ templates = [
    org: Org.find_by(abbreviation: 'GA'),
    is_default: false,
    version: 0,
-   migrated: false,
    visibility: Template.visibilities[:organisationally_visible],
-   dmptemplate_id: 2,
    links: {"funder":[],"sample_plan":[]}},
 
   {title: "Department of Testing Award",
@@ -374,9 +370,7 @@ templates = [
    org: Org.find_by(abbreviation: 'GA'),
    is_default: false,
    version: 0,
-   migrated: false,
    visibility: Template.visibilities[:organisationally_visible],
-   dmptemplate_id: 3,
    links: {"funder":[],"sample_plan":[]}}
 ]
 # Template creation calls defaults handler which sets is_default and

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -12,14 +12,13 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
     @plan.assign_reader(@user.id)
     @plan.save!
 
-    @question = Question.create(text: 'Answer Testing', number: 9,
+    @question = Question.create!(text: 'Answer Testing', number: 9,
                                 section: @plan.template.phases.first.sections.first,
                                 question_format: QuestionFormat.find_by(option_based: false))
 
-    @answer = Answer.create(user: @user, plan: @plan, question: @question, text: 'Testing')
+    @answer = Answer.create!(user: @user, plan: @plan, question: @question, text: 'Testing')
 
-    @note = Note.create(user: @user, plan: @plan, answer: @answer, question: @question, archived: false,
-                        text: 'Test Note')
+    @note = Note.create!(user: @user, answer: @answer, archived: false, text: 'Test Note')
   end
 
 # TODO: The following methods SHOULD probably be restful
@@ -45,10 +44,16 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
   # POST /notes (notes_path)
   # ----------------------------------------------------------
   test "create a new note" do
-    params = {user_id: @user.id, answer_id: @answer.id, plan_id: @plan.id, question_id: @question.id, text: 'Test Note'}
+    params = {
+      user_id: @user.id,
+      answer_id: @answer.id,
+      plan_id: @plan.id,
+      question_id: @question.id,
+      text: 'Test Note'
+    }
 
     # Should redirect user to the root path if they are not logged in!
-    post notes_path, {note: params}
+    post notes_path, { note: params }
     assert_unauthorized_redirect_to_root_path
 
     sign_in @user

--- a/test/functional/org_admin/plans_controller_test.rb
+++ b/test/functional/org_admin/plans_controller_test.rb
@@ -7,21 +7,21 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
   setup do
     # Get the first Org Admin
     @org = Org.funder.first
-    @admin = User.create!(email: "org-admin-plans-tester@example.com", 
+    @admin = User.create!(email: "org-admin-plans-tester@example.com",
                          firstname: "Org", surname: "Admin",
                          password: "password123", password_confirmation: "password123",
                          org: @org, accept_terms: true, confirmed_at: Time.zone.now)
-                         
+
     # Make sure the user is an org admin
-    @admin.perms << Perm.where(name: ['grant_permissions', 'modify_guidance', 
+    @admin.perms << Perm.where(name: ['grant_permissions', 'modify_guidance',
                                       'modify_templates', 'change_org_details'])
     @admin.save!
-    
+
     @regular_user = User.create!(email: 'org_admin_plans_tester@example.com', firstname: "Tester", surname: "Testing",
                                  password: "password123", password_confirmation: "password123",
-                                 org: @org, accept_terms: true, confirmed_at: Time.zone.now, ) 
-    @plan = Plan.create!(template: Template.first, title: 'Test Plan', visibility: :privately_visible, feedback_requested: true,
-                         roles: [Role.new(user: @regular_user, creator: true)])
+                                 org: @org, accept_terms: true, confirmed_at: Time.zone.now, )
+    @plan = Plan.create!(template: Template.first, title: 'Test Plan', visibility: :privately_visible, feedback_requested: true)
+    @plan.roles.create!(user: @regular_user, creator: true)
     Role.create!(user: @admin, plan: @plan, access: Role.access_values_for(:reviewer).min)
   end
 
@@ -34,7 +34,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     get org_admin_plans_path
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test "org admin can access the plans page" do
     sign_in @admin
     get org_admin_plans_path
@@ -53,18 +53,18 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     get feedback_complete_org_admin_plan_path(@plan)
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test "org admin can complete feedback" do
     sign_in @admin
     get feedback_complete_org_admin_plan_path(@plan)
     assert_response :redirect
-    
+
     # TODO: This one is failing on Travis but not on any other machine
     #       seems to be due to the seeds.rb not loading properly on the
     #       latest instance of Travis
     #assert_redirected_to org_admin_plans_path
   end
-  
+
   test "unauthorized user cannot download the plans as CSV" do
     # Should redirect user to the root path if they are not logged in!
     get org_admin_download_plans_path(format: :csv)
@@ -74,7 +74,7 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     get org_admin_download_plans_path(format: :csv)
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test "org admin can download plans as CSV" do
     sign_in @admin
     get org_admin_download_plans_path(format: :csv)

--- a/test/functional/org_admin/questions_controller_test.rb
+++ b/test/functional/org_admin/questions_controller_test.rb
@@ -1,16 +1,16 @@
 require 'test_helper'
 
 class QuestionsControllerTest < ActionDispatch::IntegrationTest
-  
+
   include Devise::Test::IntegrationHelpers
-  
+
   setup do
     @institution = init_institution
     @researcher = init_researcher(@institution)
     @org_admin = init_org_admin(@institution)
     @template = init_template(@institution, {
-      title: 'Test Template', 
-      published: true, 
+      title: 'Test Template',
+      published: true,
       visibility: Template.visibilities[:publicly_visible]
     })
     @phase = init_phase(@template)
@@ -18,7 +18,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     @text_area = init_question_format({ title: 'Test question format' })
     @question = init_question(@section)
   end
-  
+
   test 'unauthorized user cannot call question_controller#create' do
     params = { question: { text: 'New question test', number: 2, question_format_id: @text_area.id } }
     post org_admin_template_phase_section_questions_path(@template, @phase, @section), params
@@ -27,7 +27,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     post org_admin_template_phase_section_questions_path(@template, @phase, @section), params
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test 'unauthorized user cannot call question_controller#create for another org\'s template' do
     params = { question: { text: 'New question test', number: 2, question_format_id: @text_area.id } }
     funder = init_funder
@@ -38,7 +38,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     post org_admin_template_phase_section_questions_path(funder_template, funder_phase, funder_section), params
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test 'authorized user can call question_controller#create for an unpublished template' do
     @template.update!(published: false)
     params = { question: { text: 'New question test', number: 2, question_format_id: @text_area.id } }
@@ -47,7 +47,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to edit_org_admin_template_phase_path(template_id: @template.id, id: @phase.id, section: @section.id)
   end
-  
+
   test 'authorized user can call question_controller#create for a published template' do
     params = { question: { text: 'New question test', number: 2, question_format_id: @text_area.id } }
     sign_in @org_admin
@@ -56,7 +56,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     template = Template.latest_version(@template.family_id).first
     assert_redirected_to edit_org_admin_template_phase_path(template_id: template.id, id: template.phases.first.id, section: template.phases.first.sections.first.id)
   end
-  
+
   test 'unauthorized user cannot call question_controller#edit' do
     params = { section: { text: 'Edited question' } }
     put org_admin_template_phase_section_question_path(@template, @phase, @section, @question), params
@@ -77,7 +77,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     put org_admin_template_phase_section_question_path(funder_template, funder_phase, funder_section, funder_question), params
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test 'authorized user can call question_controller#edit for an unpublished template' do
     @template.update!(published: false)
     params = { section: { text: 'Edited question' } }
@@ -86,7 +86,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to edit_org_admin_template_phase_path(template_id: @template.id, id: @phase.id, section: @section.id)
   end
-  
+
   test 'authorized user can call question_controller#edit for a published template' do
     params = { section: { text: 'Edited question' } }
     sign_in @org_admin
@@ -103,7 +103,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     delete org_admin_template_phase_section_question_path(@template, @phase, @section, @question)
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test 'unauthorized user cannot call question_controller#destroy for another org\'s template' do
     funder = init_funder
     funder_template = init_template(funder)
@@ -114,7 +114,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     delete org_admin_template_phase_section_question_path(funder_template, funder_phase, funder_section, funder_question)
     assert_authorized_redirect_to_plans_page
   end
-  
+
   test 'authorized user can call question_controller#destroy for an unpublished template' do
     @template.update!(published: false)
     sign_in @org_admin
@@ -122,12 +122,16 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to edit_org_admin_template_phase_path(template_id: @template.id, id: @phase.id, section: @section.id)
   end
-  
+
   test 'authorized user can call question_controller#destroy for a published template' do
     sign_in @org_admin
     delete org_admin_template_phase_section_question_path(@template, @phase, @section, @question)
     assert_response :redirect
     template = Template.latest_version(@template.family_id).first
-    assert_redirected_to edit_org_admin_template_phase_path(template_id: template.id, id: template.phases.first.id, section: template.phases.first.sections.first.id)
+    assert_redirected_to edit_org_admin_template_phase_path({
+      id: template.phases.first.id,
+      template_id: template.id,
+      section: template.phases.first.sections.first.id
+    })
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -392,15 +392,18 @@ class ActiveSupport::TestCase
   # ----------------------------------------------------------------------
   def scaffold_plan
     scaffold_template if @template.nil?
-
-    @plan = Plan.new(template: @template, title: 'Test Plan', grant_number: 'Grant-123',
-                        principal_investigator: 'me', principal_investigator_identifier: 'me-1234',
-                        description: "this is my plan's informative description",
-                        identifier: '1234567890', data_contact: 'me@example.com', visibility: :privately_visible,
-                        roles: [Role.new(user: User.last, creator: true)])
-
-    assert @plan.valid?, "unable to create new Plan: #{@plan.errors.map{|f, m| f.to_s + ' ' + m}.join(', ')}"
-    @plan.save!
+    @plan = Plan.create!(
+      template: @template,
+      title: 'Test Plan',
+      grant_number: 'Grant-123',
+      principal_investigator: 'me',
+      principal_investigator_identifier: 'me-1234',
+      description: "this is my plan's informative description",
+      identifier: '1234567890',
+      data_contact: 'me@example.com',
+      visibility: :privately_visible
+    )
+    @plan.roles.create(user: User.last, creator: true)
   end
 
 

--- a/test/unit/concerns/versionable_test.rb
+++ b/test/unit/concerns/versionable_test.rb
@@ -6,30 +6,35 @@ class VersionableTest < ActiveSupport::TestCase
   setup do
     @template = create_template
   end
+
   def create_template
-    funder = init_funder
+    funder   = init_funder
     template = init_template(funder)
-    phase = init_phase(template)
-    section = init_section(phase)
+    phase    = init_phase(template)
+    section  = init_section(phase)
     question = init_question(section)
     init_annotation(funder, question)
     return template
   end
+
   test "versionable concern is included" do
     assert(self.respond_to?(:get_modifiable))
   end
+
   test "#find_in_space raises ArgumentError when search_scape does not respond_to to each" do
     exception = assert_raises(ArgumentError) do
       find_in_space(nil, nil)
     end
     assert_equal(_('The search_space does not respond to each'), exception.message)
   end
+
   test "#find_in_space raises ArgumentError when search_scape does not have elements" do
     exception = assert_raises(ArgumentError) do
       find_in_space(nil, [])
     end
     assert_equal(_('The search space does not have elements associated'), exception.message)
   end
+
   test "#find_in_space looks for the object in the search_scape that has elements of its same class" do
     # Looking for phase
     phase = init_phase(@template)
@@ -59,6 +64,7 @@ class VersionableTest < ActiveSupport::TestCase
     # Looking for something else
     assert_not(find_in_space({}, [{}]))
   end
+
   test "#find_in_space looks for the object in the relation" do
     # Looking for section
     section = init_section(@template.phases.first)
@@ -75,6 +81,7 @@ class VersionableTest < ActiveSupport::TestCase
     # Looking for a question in a not known search_space
     assert_not(find_in_space(Question.new, [{}]))
   end
+
   test "#find_in_space looks for an object that does not belong to the hierarchy" do
     question = init_question(@template.phases.first.sections.first)
     question.phase.number = 2
@@ -175,7 +182,7 @@ class VersionableTest < ActiveSupport::TestCase
       @template.phases.first.sections.first.questions.first,
       @template.phases.first.sections.first.questions.first.annotations.first
     ]
-    
+
     hierarchy_objects.each do |obj|
       exception = assert_raises(RuntimeError) do
         get_modifiable(obj)
@@ -228,21 +235,22 @@ class VersionableTest < ActiveSupport::TestCase
   test "#get_modifiable returns new question when template is published" do
     @template.published = true
     @template.save!
-    question = @template.phases.first.sections.first.questions.first
+    question     = @template.phases.first.sections.first.questions.first
     new_question = get_modifiable(question)
-    assert_not_equal(question.id, new_question.id, 'returns different question id')
-    assert_not_equal(question.section.phase.template, new_question.section.phase.template, 'returns different template belonging')
+    refute_equal(question.id, new_question.id, 'returns different question id')
+    refute_equal(question.section.phase.template, new_question.section.phase.template, 'returns different template belonging')
   end
 
   test "#get_modifiable returns new annotation when template is published" do
     @template.published = true
     @template.save!
-    annotation = @template.phases.first.sections.first.questions.first.annotations.first
-    new_annotation = get_modifiable(annotation)
-    assert_not_equal(annotation.id, new_annotation.id, 'returns different annotation id')
-    assert_not_equal(annotation.question.section.phase.template, new_annotation.question.section.phase.template, 'returns different template belonging')
+    @annotation     = @template.phases.first.sections.first.questions.first.annotations.first
+    @new_annotation = get_modifiable(@annotation)
+    @new_template   = @new_annotation.question.section.phase.template
+    refute_equal(@annotation, @new_annotation, 'returns different annotation id')
+    refute_equal(@template, @new_template, 'returns different template belonging')
   end
-  
+
   test "#get_modifiable returns new question_option when template is published" do
     @template.published = true
     @template.save!

--- a/test/unit/plan_test.rb
+++ b/test/unit/plan_test.rb
@@ -313,8 +313,8 @@ class PlanTest < ActiveSupport::TestCase
 
   # ---------------------------------------------------
   test "can CRUD Plan" do
-    obj = Plan.create(title: 'Testing CRUD', template: Template.where.not(id: @template.id).first, visibility: :is_test,
-                      roles: [Role.new(user: User.last, creator: true)], description: "should change")
+    obj = Plan.create!(title: 'Testing CRUD', template: Template.where.not(id: @template.id).first, visibility: :is_test, description: "should change")
+    obj.roles.create!(user: User.last, creator: true)
     assert_not obj.id.nil?, "was expecting to be able to create a new Plan! - #{obj.errors.map{|f, m| f.to_s + ' ' + m}.join(', ')}"
 
     obj.description = 'changed'

--- a/test/unit/question_test.rb
+++ b/test/unit/question_test.rb
@@ -4,7 +4,7 @@ class QuestionTest < ActiveSupport::TestCase
 
   setup do
     # Need to clear the tables until we get seed.rb out of test_helper.rb
-    Template.delete_all    
+    Template.delete_all
     @funder = init_funder
     @institution = init_institution
     @template = init_template(@institution, published: true)
@@ -30,23 +30,23 @@ class QuestionTest < ActiveSupport::TestCase
 
   test "option_based? returns the correct boolean value" do
     assert_not @question.option_based?
-# TODO: replace with a call to the init_question_format factory method once seeds.rb is no longer being loaded 
+# TODO: replace with a call to the init_question_format factory method once seeds.rb is no longer being loaded
     @question.question_format = QuestionFormat.find_by(option_based: true)
     @question.save!
     assert @question.option_based?
   end
-  
+
   test "#deep_copy creates a new question object and attaches new annotations/question_options objects" do
     init_annotation(@institution, @question)
     init_question_option(@question)
     assert_deep_copy(@question, @question.deep_copy, relations: [:annotations, :question_options])
   end
-  
+
 # TODO: This method should get moved to a view helper instead
   test "returns the correct themed guidance for the org" do
     theme = init_theme
     guidance_group = init_guidance_group(@institution)
-    funder_guidance_group = init_guidance_group(@funder, { title: 'Test funder guidance group' } )
+    funder_guidance_group = init_guidance_group(@funder, { name: 'Test funder guidance group' } )
     guidance = init_guidance(guidance_group, { themes: [theme] })
     funder_guidance = init_guidance(funder_guidance_group, { themes: [theme] })
 
@@ -63,14 +63,14 @@ class QuestionTest < ActiveSupport::TestCase
     assert_equal 1, funder_guidances.length
     assert_equal funder_guidance, funder_guidances.first.last
   end
-    
+
   # ---------------------------------------------------
   test "returns the correct annotation for the org" do
     annotation = init_annotation(@institution, @question, { type: Annotation.types[:example_answer] })
     annotation2 = init_annotation(@institution, @question)
     funder_annotation = init_annotation(@funder, @question, { text: 'Test funder example answer', type: Annotation.types[:example_answer] } )
     funder_annotation2 = init_annotation(@funder, @question, { text: 'Test funder guidance'} )
-        
+
     institutional_annotations = @question.get_example_answers(@institution)
     assert_equal 1, institutional_annotations.length
     assert_equal annotation, institutional_annotations.first


### PR DESCRIPTION
Changes proposed in this PR:
- Removes deprecated `attr_accessible` from models
- Adds Rails 4 strong parameters to controllers
- Cleans up tests that broke after changing attr assignation in Plans
- Refactors some tests for readability
- Fixes bugs in `Section#deep_copy` and `Phase#deep_copy` where original record ID was being passed to children.