### PR TITLE
updated css so that fieldset legends are same font format as labels

### DIFF
--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -555,6 +555,8 @@ fieldset {
 }
 legend {
   border: none;
+  font-size: 14px;
+  font-weight: bold;
   margin-bottom: 5px;
   text-transform: capitalize;
 }
@@ -568,7 +570,6 @@ fieldset.project-details {
   -webkit-box-shadow:  0px 0px 0px 0px #000;
           box-shadow:  0px 0px 0px 0px #000;
 }
-
 legend.project-details {
     font-weight: bold;
     font-size: 100%;


### PR DESCRIPTION
For #1646 .

Updated CSS so that `<form><fieldset><legend>Text` appears the same as form labels.