### PR TITLE
Update feedback email to link to write page

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -64,9 +64,9 @@ class UserMailer < ActionMailer::Base
 
   def feedback_complete(recipient, plan, requestor)
     @requestor = requestor
-    @user = recipient
-    @plan = plan
-
+    @user      = recipient
+    @plan      = plan
+    @phase     = plan.phases.first
     if recipient.active?
       FastGettext.with_locale FastGettext.default_locale do
         mail(to: recipient.email,

--- a/app/views/user_mailer/feedback_complete.html.erb
+++ b/app/views/user_mailer/feedback_complete.html.erb
@@ -8,9 +8,9 @@
 <p><%= _('Hello %{recipient_name}') % { recipient_name: recipient_name } %></p>
 
 <p>
-  <%= _("%{commenter} has finished providing feedback on the plan \"%{link_html}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan. Plan comments can be found adjacent to your answers in the tabbed panel next to guidance.").html_safe % {
+  <%= _("%{commenter} has finished providing feedback on the plan  \"%{link_html}\". Comments can be found in the 'Write plan' tab on the right side of the page (Guidance/Comments).").html_safe % {
     commenter: requestor,
-    link_html: link_to(plan_name, plan_url(@plan)),
+    link_html: link_to(plan_name, edit_plan_url(@plan, phase_id: @phase.id)),
     tool_name: tool_name
   }%>
 </p>


### PR DESCRIPTION
Updates work from issue #1654 to include requested changes on #1492.

Changes proposed in this PR:
- Updated text in feedback complete email
- Change link destination to use the 'edit' Plan path with latest Phase 