### PR TITLE
Fix for funder being unable to create a new template

### DIFF
--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -56,7 +56,7 @@
     locals: { 
       context: 'funder',
       title: _('Funder Links'),
-      links: template.links['funder'],
+      links: Hash(template.links).fetch('funder', []),
       max_number_links: MAX_NUMBER_LINKS_FUNDER,
       tooltip: _('Add links to funder websites that provide additional information about the requirements for this template') }) %>
   </div>
@@ -65,7 +65,7 @@
     locals: { 
       context: 'sample_plan',
       title: _('Sample Plan Links'),
-      links: template.links['sample_plan'],
+      links: Hash(template.links).fetch('sample_plan', []),
       max_number_links: MAX_NUMBER_LINKS_SAMPLE_PLAN,
       tooltip: _('Add links to sample plans if provided by the funder.') }) %>
   </div>


### PR DESCRIPTION
Fixes #1710

Added nil check to the Template model's links getter. This way the hash will always be initialized correctly.

Might be a more elegant way by moving this into the model's getters/setters but this works for now