### PR TITLE
Reduced vertical space between themes on Guidance and Templates pages.

### DIFF
--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -552,7 +552,20 @@ $tooltip-background: $grey;
 /* generic styling */
 fieldset {
   border: none;
+
+  input[type="radio"],
+  input[type="checkbox"] {
+      margin: 0px;
+      vertical-align: middle;
+  }
+
+  .checkbox,
+  .radio {
+    margin-top: 0px;
+    margin-bottom: 3px;
+  }
 }
+
 legend {
   border: none;
   margin-bottom: 5px;


### PR DESCRIPTION
Issue #1650

Fixes #1650.

Re-submitting PR as pointed out by @briri I created the previous PR DMPRoadmap#1708 (review) to be merged with master instead of development.

Changes proposed in this PR:

    Altered the CSS for the \<fieldset> tag children selectors:
    input[type="radio"], input[type="checkbox"], .checkbox and .radio.

