### PR TITLE
Update admin feedback tooltip

### DIFF
--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -9,9 +9,11 @@ module OrgsHelper
   # @return [String] The tooltip message
   def tooltip_for_org_feedback_form(org)
     email = org.contact_email.presence || DEFAULT_EMAIL
-    _("Someone will respond to your request within 48 hours. If you have \
-    questions pertaining to this action please contact us at %{email}") % {
-      email: email
+    _("A data librarian from %{org_name} will respond to your request within 48
+       hours. If you have questions pertaining to this action please contact us
+       at %{organisation_email}.") % {
+      organisation_email: email,
+      org_name: org.name
     }
   end
 end

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -103,7 +103,7 @@
       <h2><%= _('Request expert feedback') %></h2>
       <p><%= _('Click below to give data management staff at your organisation access to read and comment on your plan.') %></p>
       <div class="well well-sm">
-        <%= current_user.org.feedback_email_msg.html_safe %>
+        <%= current_user.org.feedback_email_msg %>
       </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
 


### PR DESCRIPTION
Fixes #1722 .

Changes proposed in this PR:
- Update the tooltip shown on the feedback message form
- Fix a bug that was caused when feedback_email_msg is nil
