### PR TITLE
The previous fix for the  long suggestion lists for the combobox woul…

### DIFF
--- a/lib/assets/stylesheets/overrides.scss
+++ b/lib/assets/stylesheets/overrides.scss
@@ -318,12 +318,12 @@ body{
 }
 
 /* footer */
-#footer-navbar {
+footer {
+  position: absolute;
   bottom: 0;
   margin-top: 20px;
   margin-bottom: -20px;
   width: 100%;
-  position: absolute;
 }
 
 
@@ -432,11 +432,11 @@ $tooltip-background: $grey;
 }
 
 .combobox-suggestions {
-  position: static;
+  position: absolute;
   left: 0;
   width: 100%;
   background: $white;
-  z-index: 99;
+  z-index: 1100;
 }
 .combobox-suggestion {
   color: $grey;


### PR DESCRIPTION
Issue #1300

The previous fix for the  long suggestion lists for the combobox would be overlapped by the footer had the following issue:
- long lists pushed everything down below it on the page rather than covering over items.

Changes proposed in this PR:

  This fix makes the following changes:
      - the css selector ".combobox-suggestions" has position reverted back to "position:absolute"
        (as the change "position:static" caused the issue)
        and z-index increased to 1100 (as z-index for footer is 1030) to appear above footer;
      - replaced css selector "#footer-navbar" with "footer" for sticky footer to work correctly with above changes.

Fixes # 1300.
