### PR TITLE
Fixed issues with Template

### DIFF
--- a/app/controllers/org_admin/phases_controller.rb
+++ b/app/controllers/org_admin/phases_controller.rb
@@ -38,7 +38,9 @@ module OrgAdmin
             partial_path: 'edit',
             template: phase.template,
             phase: phase,
+            prefix_section: phase.prefix_section,
             sections: phase.sections.order(:number).select(:id, :title, :modifiable),
+            suffix_sections: phase.suffix_sections.order(:number),
             current_section: section.present? ? Section.find_by(id: section, phase_id: phase.id) : nil
           })
       end

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -50,8 +50,8 @@ class Phase < ActiveRecord::Base
   has_many :suffix_sections, -> (phase) {
     modifiable.where(<<~SQL, phase_id: phase.id, modifiable: false)
       sections.number > (SELECT MAX(number) FROM sections
-                           WHERE sections.modifiable = :modifiable)
-                           AND sections.phase_id = :phase_id
+                           WHERE sections.modifiable = :modifiable
+                           AND sections.phase_id = :phase_id)
     SQL
   }, class_name: "Section"
 

--- a/app/views/org_admin/sections/_index.html.erb
+++ b/app/views/org_admin/sections/_index.html.erb
@@ -11,20 +11,36 @@
                            phase: phase,
                            template: template,
                            current_section: current_section,
+                           panel_id: "section-#{prefix_section.id}",
                            modifiable: true } if prefix_section %>
 
-      <%= render partial: "org_admin/sections/section_group",
-                locals: { sections: sections,
-                          phase: phase,
-                          template: template,
-                          current_section: current_section,
-                          modifiable: modifiable } %>
+      <%# If we are working with a modifiable phase then allow the core sections to be reordered %>
+      <% if phase.modifiable? %>
+        <% sections.each do |s| %>
+          <%= render partial: "org_admin/sections/section_group",
+                     locals: { sections: Array(s),
+                               phase: phase,
+                               template: template,
+                               current_section: current_section,
+                               panel_id: "section-#{s.id}",
+                               modifiable: s.modifiable } %>
+        <% end %>
+      <% else %>
+          <%= render partial: "org_admin/sections/section_group",
+                     locals: { sections: sections,
+                               phase: phase,
+                               template: template,
+                               current_section: current_section,
+                               panel_id: "baseline-sections",
+                               modifiable: modifiable } %>
+      <% end %>
 
       <% suffix_sections.each do |s| %>
         <%= render partial: "org_admin/sections/section_group",
                    locals: { sections: Array(s),
                              phase: phase,
                              template: template,
+                             panel_id: "section-#{s.id}",
                              current_section: current_section,
                              modifiable: true } %>
       <% end %>
@@ -45,7 +61,6 @@
             </div>
             <div class="pull-right">
               <i class="fa fa-plus pull-right" aria-hidden="true"></i>
-              <i class="fa fa-edit pull-right" aria-hidden="true"></i>
             </div>
             <div class="clearfix"></div>
           </div>

--- a/app/views/org_admin/sections/_section.html.erb
+++ b/app/views/org_admin/sections/_section.html.erb
@@ -5,7 +5,7 @@
     data-remote="true"
     class="heading-button ajaxified-section"
     data-toggle="collapse"
-    data-parent="sections-accordion"
+    data-parent="<%= data_parent %>"
     data-target="#collapseSection<%= section.id%>"
     aria-expanded="false"
     aria-controls="#collapseSection<%= section.id%>">
@@ -17,8 +17,9 @@
       <div class="pull-right">
         <i class="fa fa-plus pull-right" aria-hidden="true" title="Click to expand"></i>
         <% if local_assigns[:draggable] %>
-          <i class="fa fa-bars pull-right" aria-hidden="true"
-             title="Drag to reposition"></i>
+          <!-- commenting out until this is working properly -->
+          <!-- <i class="fa fa-bars pull-right" aria-hidden="true"
+             title="Drag to reposition"></i> -->
         <% end %>
       </div>
       <div class="clearfix"></div>

--- a/app/views/org_admin/sections/_section_group.html.erb
+++ b/app/views/org_admin/sections/_section_group.html.erb
@@ -1,7 +1,7 @@
 <!-- TODO: Move this away from using ID attr -->
 <div class="panel-group section-group"
      data-modifiable="<%= modifiable %>"
-     id="sections_accordion"
+     id="<%= panel_id %>"
      role="tablist">
   <% sections.each do |section| %>
     <%= render partial: "org_admin/sections/section",
@@ -9,6 +9,7 @@
                locals: { phase: phase,
                          template: template,
                          current_section: current_section,
+                         data_parent: panel_id,
                          draggable: section == sections.first } %>
   <% end%>
 </div>

--- a/lib/assets/javascripts/views/org_admin/phases/new_edit.js
+++ b/lib/assets/javascripts/views/org_admin/phases/new_edit.js
@@ -14,7 +14,7 @@ $(() => {
 
   Tinymce.init({ selector: '.phase' });
   ariatiseForm({ selector: '.phase_form' });
-  const parentSelector = '#sections_accordion';
+  const parentSelector = '.section-group';
 
   const initQuestion = (context) => {
     const target = $(context);
@@ -117,7 +117,7 @@ $(() => {
   });
 
   // Handle the section that has focus on initial page load
-  const currentSection = $('#sections_accordion .in');
+  const currentSection = $('.sectiongroup .in');
   if (currentSection.length > 0) {
     initSection(`#${currentSection.attr('id')}`);
   }


### PR DESCRIPTION
Fixed a few issues with viewing and saving the template stack (template, phase, section, question).

Commented out the draggable icon for now until we discuss implementation in the team meeting tomorrow. You cannot currently reorder sections for a template that you own. Its working ok when the user is customizing a template. The UX is a bit weird. The section shakes when you drag it to an invalid position but it will not likely be clear to a user why the position is invalid (e.g. only one prefix section)