### PR TITLE
Fix bug causing tooltips to display badly

### DIFF
--- a/lib/assets/javascripts/views/org_admin/phases/show.js
+++ b/lib/assets/javascripts/views/org_admin/phases/show.js
@@ -1,4 +1,4 @@
-import 'jquery-ui-dist/jquery-ui';
+import 'jquery-ui/ui/widgets/sortable';
 
 $(() => {
   // Is there already one prefix section on this Phase?

--- a/lib/assets/package-lock.json
+++ b/lib/assets/package-lock.json
@@ -5434,10 +5434,10 @@
         "jquery": "3.2.1"
       }
     },
-    "jquery-ui-dist": {
+    "jquery-ui": {
       "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.12.1.tgz",
-      "integrity": "sha1-XAgV08xvkP9fqvWyaKbiO0ypBPo="
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
     "jquery-ujs": {
       "version": "1.2.2",

--- a/lib/assets/package.json
+++ b/lib/assets/package.json
@@ -24,7 +24,7 @@
     "font-awesome": "^4.7.0",
     "jquery": "3.2.1",
     "jquery-accessible-autocomplete-list-aria": "1.5.5",
-    "jquery-ui-dist": "1.12.1",
+    "jquery-ui": "^1.12.1",
     "jquery-ujs": "1.2.2",
     "js-cookie": "2.1.4",
     "moment": "^2.20.1",


### PR DESCRIPTION
Changes proposed in this PR:
- Replace dist. build of jQuery-UI with original source (allows us to load only required modules)

Fixes #1722

NOTE: This bug was caused by loading jQuery-UI's tooltip module, which was clashing with Bootstrap's tooltip plugin.

NOTE: Extracted this commit from the `issue-1371` branch so it can be merged in sooner.