### PR TITLE
Fixed issue with feedback form deleting shib info for orgs

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -27,13 +27,13 @@ class OrgsController < ApplicationController
     
     begin
       # Only allow super admins to change the org types and shib info
-      if current_user.can_super_admin?    
+      if current_user.can_super_admin?
         # Handle Shibboleth identifiers if that is enabled
-        if Rails.application.config.shibboleth_use_filtered_discovery_service 
+        if Rails.application.config.shibboleth_use_filtered_discovery_service && params[:shib_id].present?
           shib = IdentifierScheme.find_by(name: 'shibboleth')
           shib_settings = @org.org_identifiers.select{ |ids| ids.identifier_scheme == shib}.first
 
-          if params[:shib_id].present? || params[:shib_domain].present?
+          if !params[:shib_id].blank?
             shib_settings = OrgIdentifier.new(org: @org, identifier_scheme: shib) unless shib_settings.present?
             shib_settings.identifier = params[:shib_id]
             shib_settings.attrs = {domain: params[:shib_domain]}


### PR DESCRIPTION
Fixes #1732 

Logic on the orgs controller was deleting shib info when the feedback form was submitted. Updated to first verify that the incoming params includes the shib info at all (if not skip the update of the `org_identifiers`) and if it is to check for blank instead of present.