### PR TITLE
added text to default feedback message

### DIFF
--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -9,7 +9,7 @@ module OrgsHelper
   # @return [String] The tooltip message
   def tooltip_for_org_feedback_form(org)
     email = org.contact_email.presence || DEFAULT_EMAIL
-    _("A data librarian from %{org_name} will respond to your request within 48
+    _("SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48
        hours. If you have questions pertaining to this action please contact us
        at %{organisation_email}.") % {
       organisation_email: email,


### PR DESCRIPTION
Fixes #1722 

Added missing 'SAMPLE MESSAGE: ' text to feedback message tooltip.

