### PR TITLE
Allow multiple themes per guidance

### DIFF
--- a/app/views/guidances/new_edit.html.erb
+++ b/app/views/guidances/new_edit.html.erb
@@ -14,8 +14,8 @@
         <%= text_area_tag("guidance-text", guidance.text, class: "form-control", 'aria-required': true, rows: 10) %>
       </div>
       <%= render partial: 'org_admin/shared/theme_selector',
-                 locals: { f: f, all_themes: themes, as_radio: true, required: true,
-                           popover_message: _('Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags.') } %>
+                 locals: { f: f, all_themes: themes, as_radio: false, required: true,
+                           popover_message: _('Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags.') } %>
       <div class="form-group">
         <%= f.label _('Guidance group'), for: :guidance_group_id, class: 'control-label' %>
         <%= f.collection_select(:guidance_group_id, guidance_groups,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -88,6 +88,7 @@
       VALIDATION_MESSAGE_PASSWORDS_MATCH: _('The passwords must match.'),
       VALIDATION_MESSAGE_RADIO: _('Please choose one of the options.'),
       VALIDATION_MESSAGE_CHECKBOX: _('Please check the box to continue.'),
+      VALIDATION_MESSAGE_MULTI_CHECKBOX: _('Please select at least one of the options to continue.'),
       VALIDATION_MESSAGE_SELECT: _('Please select a value from the list.'),
       VALIDATION_MESSAGE_TEXT: _('This field is required.'),
 

--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -23,15 +23,18 @@
     <%= f.label(:password, _('Password'), class: "control-label") %>
     <%= f.password_field(:password, class: "form-control", "aria-required": true) %>
   </div>
-  <div class="checkbox">
-    <label>
-      <input type="checkbox" id="passwords_toggle_sign_up" class="passwords_toggle" /><%= _('Show password') %>
-    </label>
+  <div class="form-group">
+    <div class="checkbox">
+      <label>
+        <input type="checkbox" id="passwords_toggle_sign_up" class="passwords_toggle" /><%= _('Show password') %>
+      </label>
+    </div>
   </div>
-  <div class="checkbox">
-    <%= f.label(:accept_terms,
-        raw("#{ f.check_box(:accept_terms, "aria-required": true, "data-validation-error": _('You must agree to the term and conditions.')) } #{_('I accept the')} <a href=\"#{terms_path}\">#{_('terms and conditions')}</a>")) %>
+  <div class="form-group">
+    <div class="checkbox">
+      <%= f.label(:accept_terms,
+          raw("#{ f.check_box(:accept_terms, "aria-required": true, "data-validation-error": _('You must agree to the term and conditions.')) } #{_('I accept the')} <a href=\"#{terms_path}\">#{_('terms and conditions')}</a>")) %>
+    </div>
   </div>
-  
   <%= f.button(_('Create account'), class: "btn btn-default", type: "submit") %>
 <% end %>

--- a/lib/assets/javascripts/utils/ariatiseForm.js
+++ b/lib/assets/javascripts/utils/ariatiseForm.js
@@ -50,7 +50,11 @@ const getValidationTypeForElement = (el) => {
   // Otherwise if the element is required validate based on its type
   } else if ($(el).attr('aria-required') === 'true') {
     if ($(el).is('input')) {
-      return $(el).attr('type'); // available types at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_<input>_types
+      const type = $(el).attr('type'); // available types at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_<input>_types
+      if (type === 'checkbox' && $(el).closest('fieldset').length > 0) {
+        return 'multi-checkbox';
+      }
+      return type;
     } else if ($(el).is('select')) {
       return 'select';
     } else if ($(el).is('.tinymce')) {
@@ -76,17 +80,13 @@ const ariaInvalid = (value) => {
 const addAsterisk = (el) => {
   const asterisk = '<span class="red" title="This field is required.">* </span>';
   if (isObject(el)) {
-    switch (getValidationTypeForElement(el)) {
-      case 'checkbox': {
-        el.after(asterisk);
-        break;
-      }
-      default: {
-        const label = el.closest('.form-group').find('label');
-        if (isObject(label)) {
-          $(label[0]).before(asterisk);
-        }
-        break;
+    const typ = getValidationTypeForElement(el);
+    if (typ === 'checkbox') {
+      el.after(asterisk);
+    } else {
+      const label = el.closest('.form-group').find('label');
+      if (isObject(label)) {
+        $(label[0]).before(asterisk);
       }
     }
   }
@@ -105,6 +105,7 @@ const getValue = (type, el) => {
     case 'tinymce':
       return Tinymce.findEditorById($(el).attr('id')).getContent();
     case 'checkbox':
+    case 'multi-checkbox':
       return ($(el).is(':checked') ? 'checked' : '');
     default:
       return $(el).val();
@@ -119,10 +120,13 @@ const isValid = (type, value) => {
   // See if a specific data-validation was specified
   switch (type) {
     case 'text':
-      return validator.isValidText(value);
     case 'textarea':
-      return validator.isValidText(value);
     case 'tinymce':
+    case 'radio':
+    case 'select':
+    case 'checkbox':
+    case 'multi-checkbox':
+    case 'js-combobox':
       return validator.isValidText(value);
     case 'number':
       return validator.isValidNumber(value);
@@ -130,13 +134,6 @@ const isValid = (type, value) => {
       return validator.isValidEmail(value);
     case 'password':
       return validator.isValidPassword(value);
-    case 'radio':
-      return validator.isValidText(value);
-    case 'select':
-    case 'checkbox':
-      return validator.isValidText(value);
-    case 'js-combobox':
-      return validator.isValidText(value);
     default:
       return false;
   }
@@ -145,7 +142,6 @@ const isValid = (type, value) => {
 const getDefaultValidationMessage = (type) => {
   switch (type) {
     case 'text':
-      return getConstant('VALIDATION_MESSAGE_TEXT');
     case 'textarea':
       return getConstant('VALIDATION_MESSAGE_TEXT');
     case 'number':
@@ -158,6 +154,8 @@ const getDefaultValidationMessage = (type) => {
       return getConstant('VALIDATION_MESSAGE_RADIO');
     case 'checkbox':
       return getConstant('VALIDATION_MESSAGE_CHECKBOX');
+    case 'multi-checkbox':
+      return getConstant('VALIDATION_MESSAGE_MULTI_CHECKBOX');
     case 'js-combobox':
       return getConstant('VALIDATION_MESSAGE_SELECT');
     default:
@@ -199,6 +197,8 @@ export default (options) => {
       const typ = getValidationTypeForElement(target);
       target.attr('validation-help-block', `help-${id}`);
       if (typ === 'radio' || typ === 'checkbox') {
+        target.closest('.form-group').after(blockHelp(`help-${id}`, getValidationMessage(el)));
+      } else if (typ === 'multi-checkbox') {
         target.closest('.form-group').before(blockHelp(`help-${id}`, getValidationMessage(el)));
       } else {
         target.after(blockHelp(`help-${id}`, getValidationMessage(el)));


### PR DESCRIPTION
Fixes #1742 
- Update flag to switch control from radio button to check boxes (DB already allows for 1-m relationship)
- Discovered that the 'accept terms' checkbox on create account form was not displaying an error message while testing. Fixed HTML structure 
- Added generic validation message for scenarios when user must select at least one of multiple checkboxes
- Updated ariatiseForm.js to distinguish between single checkboxes and mutiple checkboxes.
