### PR TITLE
Remove number field from Section form

### DIFF
--- a/app/controllers/org_admin/sections_controller.rb
+++ b/app/controllers/org_admin/sections_controller.rb
@@ -118,8 +118,9 @@ module OrgAdmin
     end
 
     private
-      def section_params
-        params.require(:section).permit(:title, :description, :number)
-      end
+
+    def section_params
+      params.require(:section).permit(:title, :description)
+    end
   end
 end

--- a/app/views/org_admin/sections/_form.html.erb
+++ b/app/views/org_admin/sections/_form.html.erb
@@ -4,15 +4,6 @@
     <%= f.text_field(:title, { class: "form-control", placeholder: _('Enter a title for the section'), 'data-toggle': 'tooltip', title: _('Enter a title for the section'), 'aria-required': true} ) %>
   </div>
 
-  <div class="form-group">
-    <div class="col-md-10">
-      <%= f.label(:number, _('Order of display'), class: "control-label") %>
-    </div>
-    <div class="col-md-4">
-      <%= f.number_field(:number, in: 1..15, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('This allows you to order sections.')) %>
-    </div>
-  </div>
-
   <div class="form-group col-md-10" data-toggle="tooltip" title="<%= _("Enter a basic description. This could be a summary of what is covered in the section or instructions on how to answer. This text will be displayed in the coloured banner once a section is opened to edit.") %>">
     <%= f.label(:description, _('Description'), class: "control-label") %>
     <%= f.text_area(:description, class: "section") %>


### PR DESCRIPTION
This should no longer be necessary, since the number is set automatically by ordering the sections

Related to issue #1371 .

Changes proposed in this PR:
- Removed the number field from the sections form.