### PR TITLE
Remove accessibility link from the footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<% 
+<%
   # Override the default Rails route helper for the contact_us page IF an alternate contact_us url was defined
   # in the branding config file
   contact_us = Rails.application.config.branding[:organisation][:contact_us_url] || contact_us_path
@@ -10,11 +10,10 @@
     <ul class="nav navbar-nav">
       <li><%= link_to "&copy; 2004 - #{Time.now.year} #{Rails.configuration.branding[:organisation][:name]}".sanitize, "#{Rails.configuration.branding[:organisation][:url]}"%></li>
       <li>•</li>
-      <li><a href="<%= about_us_path %>"><%= _('About') %></a></li>   
+      <li><a href="<%= about_us_path %>"><%= _('About') %></a></li>
       <li><a href="<%= contact_us %>"><%= _('Contact us') %></a></li>
       <li><a href="<%= terms_path %>"><%= _('Terms of use') %></a></li>
       <li><a href="<%= privacy_path %>"><%= _('Privacy statement') %></a></li>
-      <li><a href="#"><%= _('Accessibility') %></a></li>
       <li><a href="https://github.com/DMPRoadmap/roadmap"><%= _('Github') %></a></li>
     </ul>
     <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Fixes #1734

Changes proposed in this PR:
- Remove unused accessibility link from the footer of the layout