### PR TITLE
Add RAILS_ENV check in assets precompile task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
 # Main test script
 script:
   # Precompile the assets
-  - cd lib/assets && npm install && npm run bundle --no-watch && cd -
+  - bundle exec rake assets:precompile
   # Copy over config files needed for setup, and create DB
   - bin/setup
   # Default test stage: Run all specs, listing the 10 slowest.

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -7,8 +7,15 @@ namespace :assets do
   desc "Pre-compile assets for production. Overwrite the Rails assets:precompile"
   task :precompile do
     FileUtils.cd("lib/assets") do
+      webpack_options = []
+      # Don't watch asset files for further changes
+      webpack_options << "--no-watch"
+      # Add the production flag, if env is production
+      webpack_options << "-p" if ENV["RAILS_ENV"] == "production"
+      # Ensure all dependencies are installed
       system("npm install")
-      system("npm run bundle --no-watch -- -p")
+      # Run the webpack command via npm
+      system("npm run bundle -- #{webpack_options.join(" ")}")
     end
   end
 end


### PR DESCRIPTION
Changes proposed in this PR:
- Update the `rake assets:precompile` to check the Rails env. This is required to fix the test suite.