### PR TITLE
Fix Travis CI to work properly with headless chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 # Main test script
 script:
   # Precompile the assets
-  - cd lib/assets && npm install && npm run bundle --no-watch && cd -
+  - rake assets:precompile
   # Copy over config files needed for setup, and create DB
   - bin/setup
   # Default test stage: Run all specs, listing the 10 slowest.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $HOME/.npm
 
 addons:
-  chrome: beta
+  chrome: stable
   apt:
     packages:
       - nodejs
@@ -24,6 +24,7 @@ addons:
 
 matrix:
   fast_finish: true
+  include:
 
 rvm:
   # Use 2.4.1, since this is installed by default on Travis (1st Aug, 2018)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ addons:
   apt:
     packages:
       - nodejs
-      - google-chrome-stable
-      - chromium-chromedriver
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
 # Main test script
 script:
   # Precompile the assets
-  - rake assets:precompile
+  - bundle exec rake assets:precompile
   # Copy over config files needed for setup, and create DB
   - bin/setup
   # Default test stage: Run all specs, listing the 10 slowest.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ addons:
     packages:
       - nodejs
       - google-chrome-stable
-      - google-chrome-stable
       - chromium-chromedriver
 
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -175,10 +175,10 @@ group :test do
   gem "capybara-screenshot"
 
   # The next generation developer focused tool for automated testing of webapps (https://github.com/SeleniumHQ/selenium)
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '>= 3.13.1'
 
   # Easy installation and use of chromedriver. (https://github.com/flavorjones/chromedriver-helper)
-  gem 'chromedriver-helper'
+  gem 'chromedriver-helper', ">= 1.2.0"
 end
 
 group :ci do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
-  chromedriver-helper
+  chromedriver-helper (>= 1.2.0)
   contact_us
   database_cleaner
   devise
@@ -426,7 +426,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   ruby_dig
-  selenium-webdriver
+  selenium-webdriver (>= 3.13.1)
   shoulda
   simplecov
   spring

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -8,7 +8,7 @@ namespace :assets do
   task :precompile do
     FileUtils.cd("lib/assets") do
       system("npm install")
-      system("npm run bundle --no-watch -- -p")
+      system("npm run bundle -- --no-watch -p")
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,6 +9,20 @@ DIMENSION   = Selenium::WebDriver::Dimension.new(*SCREEN_SIZE)
 
 Capybara.default_driver = :rack_test
 
+# This is a customisation of the default :selenium_chrome_headless config in:
+# https://github.com/teamcapybara/capybara/blob/master/lib/capybara.rb
+#
+# This adds the --no-sandbox flag to fix TravisCI as described here:
+# https://docs.travis-ci.com/user/chrome#sandboxing
+Capybara.register_driver :custom_chrome_headless do |app|
+  Capybara::Selenium::Driver.load_selenium
+  browser_options = ::Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--no-sandbox'
+  browser_options.args << '--disable-gpu' if Gem.win_platform?
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+end
+
 RSpec.configure do |config|
 
   config.before(:each, type: :feature, js: false) do
@@ -16,7 +30,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :feature, js: true) do
-    Capybara.current_driver = :selenium_chrome_headless
+    Capybara.current_driver = :custom_chrome_headless
     Capybara.page.driver.browser.manage.window.size = DIMENSION
   end
 


### PR DESCRIPTION
Changes proposed in this PR:
- Update selenium chrome driver to use Headless Chrome without sandbox. See [this documentation for a description of the issue](https://docs.travis-ci.com/user/chrome#sandboxing)
