### PR TITLE
Remove specs referencing `sections.published`

### DIFF
--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe Section, type: :model do
                           .scoped_to(:phase_id)
                           .with_message("must be unique") }
 
-    it { is_expected.to allow_values(true, false).for(:published) }
-
-    it { is_expected.not_to allow_value(nil).for(:published) }
-
     it { is_expected.to allow_values(true, false).for(:modifiable) }
 
   end


### PR DESCRIPTION
Broken specs still referencing sections.published.
