### PR TITLE
Fix  duplicates in guidance group options

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -84,7 +84,7 @@ class Plan < ActiveRecord::Base
 
   has_many :guidances, through: :themes
 
-  has_many :guidance_group_options, -> { GuidanceGroup.published },
+  has_many :guidance_group_options, -> { uniq.published.reorder('id') },
            through: :guidances,
            source: :guidance_group,
            class_name: "GuidanceGroup"


### PR DESCRIPTION
Fixes #1796  .

Changes proposed in this PR:
- Restructure the `has_many` association to use SQL's DISTINCT function