### PR TITLE
Fix bug preventing orgs loading on register page

### DIFF
--- a/app/views/shared/_create_account_form.html.erb
+++ b/app/views/shared/_create_account_form.html.erb
@@ -15,7 +15,7 @@
   <div class="form-group">
     <%= render partial: "shared/my_org",
                locals: {f: f, default_org: @default_org,
-                        orgs: Org.where("is_other IS NULL").order("sort_name ASC, name ASC"),
+                        orgs: Org.where(is_other: false).order("sort_name ASC, name ASC"),
                         allow_other_orgs: true, required: false} %>
   </div>
 

--- a/lib/assets/javascripts/views/shared/create_account_form.js
+++ b/lib/assets/javascripts/views/shared/create_account_form.js
@@ -1,7 +1,6 @@
 import ariatiseForm from '../../utils/ariatiseForm';
 import { togglisePasswords } from '../../utils/passwordHelper';
-import validateOrgSelection from '../shared/my_org';
-import { isValidText } from '../../utils/isValidInputType';
+import { validateOrgSelection } from '../shared/my_org';
 
 $(() => {
   const options = { selector: '#create-account-form' };

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -15,7 +15,7 @@ namespace :assets do
       # Ensure all dependencies are installed
       system("npm install")
       # Run the webpack command via npm
-      system("npm run bundle -- #{webpack_options.join(" ")}")
+      system("npm run bundle -- #{webpack_options.join(" ")}") or exit()
     end
   end
 end


### PR DESCRIPTION
Recent updates to the DB have made the `is_other` field on the Orgs table mandatory.
Previously, it was loading null values. This PR updates this to load false values instead.

Fixes #1809

Changes proposed in this PR:
- Load orgs where `is_other` is false, instead of null
