### PR TITLE
Change tooltip on container page if all modifiable

### DIFF
--- a/app/views/org_admin/phases/container.html.erb
+++ b/app/views/org_admin/phases/container.html.erb
@@ -54,9 +54,10 @@
                   <div class="col-sm-6">
                     <div class='text-right text-muted'>
                       <i class="fa fa-info-circle small"></i>
-                        <%= _("Drag arrows to rearrange customized sections. You may place
-                           them before or after the main template sections.") %>
-
+                        <%= _("Drag arrows to rearrange customized sections.") %>
+                        <% unless phase.sections.all?(&:modifiable?) %>
+                          <%= _("You may place them before or after the main template sections.") %>
+                        <% end %>
                     </div>
                     <div class="clear">
                   </div>


### PR DESCRIPTION

Fixes #1371  .

Changes proposed in this PR:
- If all of the sections are modifiable, we don't need the second part of the tooltip that reads: "You may place them before or after the main template sections."
Only show this if some of the Sections are unmodifiable.

