### PR TITLE
Remove bad migration

### DIFF
--- a/db/migrate/20180418115318_add_unique_index_customization_of_version_org_id_to_template.rb
+++ b/db/migrate/20180418115318_add_unique_index_customization_of_version_org_id_to_template.rb
@@ -1,5 +1,0 @@
-class AddUniqueIndexCustomizationOfVersionOrgIdToTemplate < ActiveRecord::Migration
-  def change
-    add_index(:templates, [:customization_of, :version, :org_id], unique: true)
-  end
-end

--- a/db/migrate/20180815180221_drop_unique_index_customization_of_version_org_id_from_templates.rb
+++ b/db/migrate/20180815180221_drop_unique_index_customization_of_version_org_id_from_templates.rb
@@ -1,0 +1,11 @@
+class DropUniqueIndexCustomizationOfVersionOrgIdFromTemplates < ActiveRecord::Migration
+  def up
+    if index_exists?(:templates, [:customization_of, :version, :org_id])
+      remove_index :templates, [:customization_of, :version, :org_id]
+    end
+  end
+
+  def down
+    add_index(:templates, [:customization_of, :version, :org_id], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180813114813) do
+ActiveRecord::Schema.define(version: 20180815180221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -318,7 +318,6 @@ ActiveRecord::Schema.define(version: 20180813114813) do
     t.text     "links"
   end
 
-  add_index "templates", ["customization_of", "version", "org_id"], name: "index_templates_on_customization_of_and_version_and_org_id", unique: true, using: :btree
   add_index "templates", ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true, using: :btree
   add_index "templates", ["family_id"], name: "index_templates_on_family_id", using: :btree
   add_index "templates", ["org_id", "family_id"], name: "template_organisation_dmptemplate_index", using: :btree


### PR DESCRIPTION
Removes a bad index from `templates` that was forcing `org_id, customization_of and version` to be unique. This was preventing an org from having multiple templates at version zero.


