### PR TITLE
Issue 1173

### DIFF
--- a/app/actions/stat_created_plan/generate.rb
+++ b/app/actions/stat_created_plan/generate.rb
@@ -1,0 +1,48 @@
+module Actions
+  module StatCreatedPlan
+    class Generate
+      class << self
+        def full(org)
+          OrgDateRangeable.split_months_from_creation(org) do |start_date, end_date|
+            create_count_for_date(start_date: start_date, end_date: end_date, org: org)  
+          end
+        end
+
+        def last_month(org)
+          months = OrgDateRangeable.split_months_from_creation(org)
+          last = months.last
+          if last.present?
+            create_count_for_date(start_date: last[:start_date], end_date: last[:end_date], org: org)
+          end
+        end
+        
+        def full_all_orgs
+          Org.all.each do |org|
+            full(org)
+          end
+        end
+
+        def last_month_all_orgs
+          Org.all.each do |org|
+            last_month(org)
+          end
+        end
+
+        private
+
+        def count_plans(start_date: , end_date: , org:)
+          users = User.where('users.org_id = ?', org.id)
+          plans = Plan.where('plans.created_at >= ? AND plans.created_at <= ?', start_date, end_date)
+          owner_coowner = Role.where(access: Role.access_values_for(:creator).concat(Role.access_values_for(:administrator)).uniq)
+          
+          Role.joins([:plan, :user]).merge(owner_coowner).merge(users).merge(plans).select(:plan_id).distinct.count
+        end
+
+        def create_count_for_date(start_date:, end_date:, org:)
+          count = count_plans(start_date: start_date, end_date: end_date, org: org)
+          ::StatCreatedPlan.create(date: end_date.to_date, count: count, org_id: org.id)
+        end
+      end
+    end
+  end
+end

--- a/app/actions/stat_joined_user/generate.rb
+++ b/app/actions/stat_joined_user/generate.rb
@@ -1,0 +1,43 @@
+module Actions
+  module StatJoinedUser
+    class Generate
+      class << self
+        def full(org)
+          OrgDateRangeable.split_months_from_creation(org) do |start_date, end_date|
+            create_count_for_date(start_date: start_date, end_date: end_date, org: org)
+          end
+        end
+
+        def last_month(org)
+          months = OrgDateRangeable.split_months_from_creation(org)
+          last = months.last
+          if last.present?
+            create_count_for_date(start_date: last[:start_date], end_date: last[:end_date], org: org)
+          end
+        end
+        
+        def full_all_orgs
+          Org.all.each do |org|
+            full(org)
+          end
+        end
+
+        def last_month_all_orgs
+          Org.all.each do |org|
+            last_month(org)
+          end
+        end
+
+        private
+          def count_users(start_date: , end_date: , org_id: )
+            User.where('created_at >= ? AND created_at <= ? AND org_id = ?', start_date, end_date, org_id).count
+          end
+
+          def create_count_for_date(start_date:, end_date:, org:)
+            count = count_users(start_date: start_date, end_date: end_date, org_id: org.id)
+            ::StatJoinedUser.create(date: end_date.to_date, count: count, org_id: org.id)
+          end
+      end
+    end
+  end
+end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -1,0 +1,13 @@
+class Stat < ActiveRecord::Base
+  belongs_to :org
+
+  class << self
+    def to_csv(stats)
+      data = stats.reduce([]) do |acc, stat|
+        acc << { date: stat.date, count: stat.count }
+        acc
+      end
+      Csvable.from_array_of_hashes(data)
+    end
+  end
+end

--- a/app/models/stat_created_plan.rb
+++ b/app/models/stat_created_plan.rb
@@ -1,0 +1,9 @@
+class StatCreatedPlan < Stat
+  extend OrgDateRangeable
+
+  class << self
+    def to_csv(created_plans)
+      Stat.to_csv(created_plans)
+    end
+  end
+end

--- a/app/models/stat_joined_user.rb
+++ b/app/models/stat_joined_user.rb
@@ -1,0 +1,9 @@
+class StatJoinedUser < Stat 
+  extend OrgDateRangeable
+
+  class << self
+    def to_csv(joined_users)
+      Stat.to_csv(joined_users)
+    end
+  end
+end

--- a/db/migrate/20180812095920_create_stats.rb
+++ b/db/migrate/20180812095920_create_stats.rb
@@ -1,0 +1,11 @@
+class CreateStats < ActiveRecord::Migration
+  def change
+    create_table :stats do |t|
+      t.integer :count, default: 0
+      t.date :date, null: false
+      t.string :type, null: false
+      t.belongs_to :org
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180508151824) do
+ActiveRecord::Schema.define(version: 20180812095920) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "annotations", force: :cascade do |t|
     t.integer  "question_id"
@@ -22,7 +25,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.datetime "updated_at"
   end
 
-  add_index "annotations", ["question_id"], name: "index_annotations_on_question_id"
+  add_index "annotations", ["question_id"], name: "index_annotations_on_question_id", using: :btree
 
   create_table "answers", force: :cascade do |t|
     t.text     "text"
@@ -34,15 +37,15 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.integer  "lock_version", default: 0
   end
 
-  add_index "answers", ["plan_id"], name: "index_answers_on_plan_id"
-  add_index "answers", ["question_id"], name: "index_answers_on_question_id"
+  add_index "answers", ["plan_id"], name: "index_answers_on_plan_id", using: :btree
+  add_index "answers", ["question_id"], name: "index_answers_on_question_id", using: :btree
 
   create_table "answers_question_options", id: false, force: :cascade do |t|
     t.integer "answer_id",          null: false
     t.integer "question_option_id", null: false
   end
 
-  add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id"
+  add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id", using: :btree
 
   create_table "exported_plans", force: :cascade do |t|
     t.integer  "plan_id"
@@ -83,7 +86,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "published"
   end
 
-  add_index "guidance_groups", ["org_id"], name: "index_guidance_groups_on_org_id"
+  add_index "guidance_groups", ["org_id"], name: "index_guidance_groups_on_org_id", using: :btree
 
   create_table "guidances", force: :cascade do |t|
     t.text     "text"
@@ -94,7 +97,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "published"
   end
 
-  add_index "guidances", ["guidance_group_id"], name: "index_guidances_on_guidance_group_id"
+  add_index "guidances", ["guidance_group_id"], name: "index_guidances_on_guidance_group_id", using: :btree
 
   create_table "identifier_schemes", force: :cascade do |t|
     t.string   "name"
@@ -123,7 +126,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.datetime "updated_at"
   end
 
-  add_index "notes", ["answer_id"], name: "index_notes_on_answer_id"
+  add_index "notes", ["answer_id"], name: "index_notes_on_answer_id", using: :btree
 
   create_table "notification_acknowledgements", force: :cascade do |t|
     t.integer  "user_id"
@@ -132,8 +135,8 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.datetime "updated_at"
   end
 
-  add_index "notification_acknowledgements", ["notification_id"], name: "index_notification_acknowledgements_on_notification_id"
-  add_index "notification_acknowledgements", ["user_id"], name: "index_notification_acknowledgements_on_user_id"
+  add_index "notification_acknowledgements", ["notification_id"], name: "index_notification_acknowledgements_on_notification_id", using: :btree
+  add_index "notification_acknowledgements", ["user_id"], name: "index_notification_acknowledgements_on_user_id", using: :btree
 
   create_table "notifications", force: :cascade do |t|
     t.integer  "notification_type"
@@ -163,15 +166,15 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.datetime "updated_at"
   end
 
-  add_index "org_token_permissions", ["org_id"], name: "index_org_token_permissions_on_org_id"
+  add_index "org_token_permissions", ["org_id"], name: "index_org_token_permissions_on_org_id", using: :btree
 
   create_table "orgs", force: :cascade do |t|
     t.string   "name"
     t.string   "abbreviation"
     t.string   "target_url"
     t.string   "wayfless_entity"
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.integer  "parent_id"
     t.boolean  "is_other"
     t.string   "sort_name"
@@ -182,7 +185,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.string   "logo_uid"
     t.string   "logo_name"
     t.string   "contact_email"
-    t.integer  "org_type",               default: 0,              null: false
+    t.integer  "org_type",               default: 0,     null: false
     t.text     "links"
     t.string   "contact_name"
     t.boolean  "feedback_enabled",       default: false
@@ -207,7 +210,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "modifiable"
   end
 
-  add_index "phases", ["template_id"], name: "index_phases_on_template_id"
+  add_index "phases", ["template_id"], name: "index_phases_on_template_id", using: :btree
 
   create_table "plans", force: :cascade do |t|
     t.string   "title"
@@ -231,14 +234,14 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "complete",                          default: false
   end
 
-  add_index "plans", ["template_id"], name: "index_plans_on_template_id"
+  add_index "plans", ["template_id"], name: "index_plans_on_template_id", using: :btree
 
   create_table "plans_guidance_groups", force: :cascade do |t|
     t.integer "guidance_group_id"
     t.integer "plan_id"
   end
 
-  add_index "plans_guidance_groups", ["guidance_group_id", "plan_id"], name: "index_plans_guidance_groups_on_guidance_group_id_and_plan_id"
+  add_index "plans_guidance_groups", ["guidance_group_id", "plan_id"], name: "index_plans_guidance_groups_on_guidance_group_id_and_plan_id", using: :btree
 
   create_table "prefs", force: :cascade do |t|
     t.text    "settings"
@@ -263,7 +266,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.datetime "updated_at"
   end
 
-  add_index "question_options", ["question_id"], name: "index_question_options_on_question_id"
+  add_index "question_options", ["question_id"], name: "index_question_options_on_question_id", using: :btree
 
   create_table "questions", force: :cascade do |t|
     t.text     "text"
@@ -277,14 +280,14 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "modifiable"
   end
 
-  add_index "questions", ["section_id"], name: "index_questions_on_section_id"
+  add_index "questions", ["section_id"], name: "index_questions_on_section_id", using: :btree
 
   create_table "questions_themes", id: false, force: :cascade do |t|
     t.integer "question_id", null: false
     t.integer "theme_id",    null: false
   end
 
-  add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id"
+  add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id", using: :btree
 
   create_table "regions", force: :cascade do |t|
     t.string  "abbreviation"
@@ -302,8 +305,8 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "active",     default: true
   end
 
-  add_index "roles", ["plan_id"], name: "index_roles_on_plan_id"
-  add_index "roles", ["user_id"], name: "index_roles_on_user_id"
+  add_index "roles", ["plan_id"], name: "index_roles_on_plan_id", using: :btree
+  add_index "roles", ["user_id"], name: "index_roles_on_user_id", using: :btree
 
   create_table "sections", force: :cascade do |t|
     t.string   "title"
@@ -316,7 +319,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "modifiable"
   end
 
-  add_index "sections", ["phase_id"], name: "index_sections_on_phase_id"
+  add_index "sections", ["phase_id"], name: "index_sections_on_phase_id", using: :btree
 
   create_table "settings", force: :cascade do |t|
     t.string   "var",         null: false
@@ -327,12 +330,21 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.datetime "updated_at",  null: false
   end
 
-  add_index "settings", ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true
+  add_index "settings", ["target_type", "target_id", "var"], name: "index_settings_on_target_type_and_target_id_and_var", unique: true, using: :btree
 
   create_table "splash_logs", force: :cascade do |t|
     t.string   "destination"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+  end
+
+  create_table "stats", force: :cascade do |t|
+    t.integer  "count",      default: 0
+    t.date     "date",                   null: false
+    t.string   "type",                   null: false
+    t.integer  "org_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "templates", force: :cascade do |t|
@@ -352,11 +364,11 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.text     "links"
   end
 
-  add_index "templates", ["customization_of", "version", "org_id"], name: "index_templates_on_customization_of_and_version_and_org_id", unique: true
-  add_index "templates", ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true
-  add_index "templates", ["family_id"], name: "index_templates_on_family_id"
-  add_index "templates", ["org_id", "family_id"], name: "template_organisation_dmptemplate_index"
-  add_index "templates", ["org_id"], name: "index_templates_on_org_id"
+  add_index "templates", ["customization_of", "version", "org_id"], name: "index_templates_on_customization_of_and_version_and_org_id", unique: true, using: :btree
+  add_index "templates", ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true, using: :btree
+  add_index "templates", ["family_id"], name: "index_templates_on_family_id", using: :btree
+  add_index "templates", ["org_id", "family_id"], name: "template_organisation_dmptemplate_index", using: :btree
+  add_index "templates", ["org_id"], name: "index_templates_on_org_id", using: :btree
 
   create_table "themes", force: :cascade do |t|
     t.string   "title"
@@ -371,8 +383,8 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.integer "guidance_id"
   end
 
-  add_index "themes_in_guidance", ["guidance_id"], name: "index_themes_in_guidance_on_guidance_id"
-  add_index "themes_in_guidance", ["theme_id"], name: "index_themes_in_guidance_on_theme_id"
+  add_index "themes_in_guidance", ["guidance_id"], name: "index_themes_in_guidance_on_guidance_id", using: :btree
+  add_index "themes_in_guidance", ["theme_id"], name: "index_themes_in_guidance_on_theme_id", using: :btree
 
   create_table "token_permission_types", force: :cascade do |t|
     t.string   "token_type"
@@ -389,7 +401,7 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.integer  "identifier_scheme_id"
   end
 
-  add_index "user_identifiers", ["user_id"], name: "index_user_identifiers_on_user_id"
+  add_index "user_identifiers", ["user_id"], name: "index_user_identifiers_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "firstname"
@@ -426,8 +438,8 @@ ActiveRecord::Schema.define(version: 20180508151824) do
     t.boolean  "active",                 default: true
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["org_id"], name: "index_users_on_org_id"
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["org_id"], name: "index_users_on_org_id", using: :btree
 
   create_table "users_perms", id: false, force: :cascade do |t|
     t.integer "user_id"

--- a/lib/csvable.rb
+++ b/lib/csvable.rb
@@ -1,0 +1,16 @@
+module Csvable
+  class << self
+    def from_array_of_hashes(data = [])
+      headers = data.first && data.first.keys
+      if headers
+        return CSV.generate do |csv|
+          csv << headers
+          data.each do |row|
+            csv << row.values
+          end
+        end
+      end
+      ''
+    end
+  end
+end

--- a/lib/org_date_rangeable.rb
+++ b/lib/org_date_rangeable.rb
@@ -1,0 +1,27 @@
+module OrgDateRangeable
+  def monthly_range(org:, start_date: Date.today.end_of_month, end_date: Date.today.end_of_month)
+    raise ArgumentError.new('missing org') unless org.present?
+    raise ArgumentError.new('missing start_date') unless start_date.respond_to?(:end_of_month)
+    raise ArgumentError.new('missing end_date') unless end_date.respond_to?(:end_of_month)
+
+    where(["org_id = ? and date >= ? and date <= ?", org.id, start_date, end_date]) 
+  end
+
+  class << self
+    def split_months_from_creation(org, &block)
+      starts_at = org.created_at
+      ends_at = starts_at.end_of_month
+      callable = block.nil? ? lambda{ |start_date, end_date| } : lambda{ | start_date, end_date| block.call(start_date, end_date) }
+      enumerable = []
+
+      while !(starts_at.future? || ends_at.future?) do
+        callable.call(starts_at, ends_at)
+        enumerable << { start_date: starts_at, end_date: ends_at }
+        starts_at = starts_at.next_month.beginning_of_month
+        ends_at = starts_at.end_of_month
+      end
+
+      enumerable
+    end
+  end
+end

--- a/lib/tasks/stat.rake
+++ b/lib/tasks/stat.rake
@@ -1,0 +1,32 @@
+require_relative '../../app/actions/stat_created_plan/generate'
+require_relative '../../app/actions/stat_joined_user/generate'
+
+namespace :stat do
+  namespace :created_plan do
+    namespace :generate do
+      desc "Generate created plan stats for every org since they joined"
+      task full_all_orgs: :environment do
+        Actions::StatCreatedPlan::Generate.full_all_orgs
+      end
+
+      desc "Generate created plan stats for today's last month for every org"
+      task last_month_all_orgs: :environment do
+        Actions::StatCreatedPlan::Generate.last_month_all_orgs
+      end
+    end
+  end
+  
+  namespace :joined_user do
+    namespace :generate do
+      desc "Generate joined user stats for every org since they joined"
+      task full_all_orgs: :environment do
+        Actions::StatJoinedUser::Generate.full_all_orgs
+      end
+
+      desc "Generate joined user stats for today's last month for every org"
+      task last_month_all_orgs: :environment do
+        Actions::StatJoinedUser::Generate.last_month_all_orgs
+      end
+    end
+  end
+end

--- a/test/actions/stat_created_plan/generate_test.rb
+++ b/test/actions/stat_created_plan/generate_test.rb
@@ -1,0 +1,144 @@
+require 'minitest/mock'
+require_relative '../../../app/actions/stat_created_plan/generate'
+
+class Actions::StatCreatedPlan::GenerateTest < ActiveSupport::TestCase
+  test "full returns monthly aggregates since org's creation" do
+    org = create_org(created_at: DateTime.new(2018,04,01))
+    template = create_template(org)
+    user1 = create_user(org: org)
+    user2 = create_user(org: org)
+    plan = create_plan(template: template, created_at: DateTime.new(2018, 04, 01))
+    plan2 = create_plan(template: template, created_at: DateTime.new(2018, 04, 03))
+    plan3 = create_plan(template: template, created_at: DateTime.new(2018, 05, 02))
+    plan4 = create_plan(template: template, created_at: DateTime.new(2018, 06, 02))
+    plan5 = create_plan(template: template, created_at: DateTime.new(2018, 06, 03))
+    assign_owner(plan: plan, user: user1)
+    assign_coowner(plan: plan, user: user2)
+    assign_owner(plan: plan2, user: user1)
+    assign_owner(plan: plan3, user: user1)
+    assign_coowner(plan: plan4, user: user2)
+    assign_coowner(plan: plan5, user: user2)
+
+    Actions::StatCreatedPlan::Generate.full(org)
+
+    april_count = StatCreatedPlan.find_by(date: '2018-04-30', org_id: org.id).count
+    may_count = StatCreatedPlan.find_by(date: '2018-05-31', org_id: org.id).count
+    june_count = StatCreatedPlan.find_by(date: '2018-06-30', org_id: org.id).count
+    july_count = StatCreatedPlan.find_by(date: '2018-07-31', org_id: org.id).count
+
+    assert_equal(2, april_count)
+    assert_equal(1, may_count)
+    assert_equal(2, june_count)
+    assert_equal(0, july_count)
+  end
+
+  test "last_month returns aggregates from today's last month" do
+    org = create_org(created_at: DateTime.new(2018,04,01))
+    template = create_template(org)
+    user1 = create_user(org: org)
+    user2 = create_user(org: org)
+    plan = create_plan(template: template, created_at: Date.today.last_month.end_of_month)
+    plan2 = create_plan(template: template, created_at: Date.today.last_month.end_of_month)
+    plan3 = create_plan(template: template, created_at: Date.today.last_month.end_of_month)
+    assign_owner(plan: plan, user: user1)
+    assign_coowner(plan: plan, user: user2)
+    assign_owner(plan: plan2, user: user1)
+    assign_owner(plan: plan3, user: user2)
+
+    Actions::StatCreatedPlan::Generate.last_month(org)
+
+    last_month_count = StatCreatedPlan.find_by(date: Date.today.last_month.end_of_month, org_id: org.id).count
+    assert_equal(3, last_month_count)
+  end
+
+  test "full_all_orgs returns monthly aggregates for each org since their creation" do
+    org = create_org(created_at: DateTime.new(2018,04,01))
+    template = create_template(org)
+    user1 = create_user(org: org)
+    user2 = create_user(org: org)
+    plan = create_plan(template: template, created_at: DateTime.new(2018, 04, 01))
+    plan2 = create_plan(template: template, created_at: DateTime.new(2018, 04, 03))
+    plan3 = create_plan(template: template, created_at: DateTime.new(2018, 05, 02))
+    plan4 = create_plan(template: template, created_at: DateTime.new(2018, 06, 02))
+    plan5 = create_plan(template: template, created_at: DateTime.new(2018, 06, 03))
+    assign_owner(plan: plan, user: user1)
+    assign_coowner(plan: plan, user: user2)
+    assign_owner(plan: plan2, user: user1)
+    assign_owner(plan: plan3, user: user1)
+    assign_coowner(plan: plan4, user: user2)
+    assign_coowner(plan: plan5, user: user2)
+
+    Org.stub :all, [org] do
+      Actions::StatCreatedPlan::Generate.full_all_orgs
+
+      april_count = StatCreatedPlan.find_by(date: '2018-04-30', org_id: org.id).count
+      may_count = StatCreatedPlan.find_by(date: '2018-05-31', org_id: org.id).count
+      june_count = StatCreatedPlan.find_by(date: '2018-06-30', org_id: org.id).count
+      july_count = StatCreatedPlan.find_by(date: '2018-07-31', org_id: org.id).count
+
+      assert_equal(2, april_count)
+      assert_equal(1, may_count)
+      assert_equal(2, june_count)
+      assert_equal(0, july_count)
+    end
+  end
+
+  test "last_month_all_orgs returns aggregates from today's last month" do
+    org = create_org(created_at: DateTime.new(2018,04,01))
+    template = create_template(org)
+    user1 = create_user(org: org)
+    user2 = create_user(org: org)
+    plan = create_plan(template: template, created_at: Date.today.last_month.end_of_month)
+    plan2 = create_plan(template: template, created_at: Date.today.last_month.end_of_month)
+    plan3 = create_plan(template: template, created_at: Date.today.last_month.end_of_month)
+    assign_owner(plan: plan, user: user1)
+    assign_coowner(plan: plan, user: user2)
+    assign_owner(plan: plan2, user: user1)
+    assign_owner(plan: plan3, user: user2)
+
+    Org.stub :all, [org] do
+      Actions::StatCreatedPlan::Generate.last_month_all_orgs
+
+      last_month_count = StatCreatedPlan.find_by(date: Date.today.last_month.end_of_month, org_id: org.id).count
+      assert_equal(3, last_month_count)
+    end
+  end
+
+  def create_user(org: , created_at: DateTime.current)
+    user = User.new(user_seed.merge({ org: org, email: "user#{Random.new.rand(100000)}@example.com" }))
+    user.save!
+    user.created_at = created_at
+    user.save!
+    user
+  end
+
+  def create_org(created_at: DateTime.current)
+    org = Org.create!(org_seed.merge({ name: "org#{Random.new.rand(100000)}" }))
+    org.created_at = created_at
+    org.save!
+    org
+  end
+
+  def create_template(org)
+    template = Template.create!(template_seed.merge({ org: org }))
+  end
+
+  def create_plan(template:, created_at: DateTime.current)
+    plan = Plan.create!(plan_seed.merge({ template: template }))
+    plan.created_at = created_at
+    plan.save!
+    plan
+  end
+
+  def assign_owner(plan:, user: )
+    creator = Role.access_values_for(:creator)
+    role = Role.create!(plan: plan, user: user, access: creator.first) 
+    role
+  end
+
+  def assign_coowner(plan:, user: )
+    administrator = Role.access_values_for(:administrator)
+    role = Role.create!(plan: plan, user: user, access: administrator.first)
+    role
+  end
+end

--- a/test/actions/stat_joined_user/generate_test.rb
+++ b/test/actions/stat_joined_user/generate_test.rb
@@ -1,0 +1,80 @@
+require 'minitest/mock'
+require_relative '../../../app/actions/stat_joined_user/generate'
+
+class Actions::StatJoinedUser::GenerateTest < ActiveSupport::TestCase
+  setup do
+    @org = Org.create!(org_seed.merge({ name: "org#{Random.new.rand(100000)}" }))
+    @org.created_at = DateTime.new(2018,04,02,0,0,0)
+    @org.save!
+  end
+
+  test "full returns monthly aggregates since org's creation" do
+    april = [create_user(org: @org, created_at: DateTime.new(2018,04,03,0,0,0)), create_user(org: @org, created_at: DateTime.new(2018,04,04,0,0,0))]
+    may = [create_user(org: @org, created_at: DateTime.new(2018,05,01,0,0,0))]
+    june = [create_user(org: @org, created_at: DateTime.new(2018,06,01,0,0,0)), create_user(org: @org, created_at: DateTime.new(2018,06,02,0,0,0))]
+
+    Actions::StatJoinedUser::Generate.full(@org)
+
+    april_count = StatJoinedUser.find_by(date: '2018-04-30', org_id: @org.id).count
+    may_count = StatJoinedUser.find_by(date: '2018-05-31', org_id: @org.id).count
+    june_count = StatJoinedUser.find_by(date: '2018-06-30', org_id: @org.id).count
+    july_count = StatJoinedUser.find_by(date: '2018-07-31', org_id: @org.id).count
+
+    assert_equal(2, april_count)
+    assert_equal(1, may_count)
+    assert_equal(2, june_count)
+    assert_equal(0, july_count)
+  end
+
+  test "last_month returns aggregates from today's last month" do
+    3.times do
+      create_user(org: @org, created_at: Date.today.last_month)
+    end
+
+    Actions::StatJoinedUser::Generate.last_month(@org)
+    
+    last_month_count = StatJoinedUser.find_by(date: Date.today.last_month.end_of_month, org_id: @org.id).count
+    assert_equal(3, last_month_count)
+  end
+
+  test "full_all_orgs returns monthly aggregates for each org since their creation" do
+    april = [create_user(org: @org, created_at: DateTime.new(2018,04,03,0,0,0)), create_user(org: @org, created_at: DateTime.new(2018,04,04,0,0,0))]
+    may = [create_user(org: @org, created_at: DateTime.new(2018,05,01,0,0,0))]
+    june = [create_user(org: @org, created_at: DateTime.new(2018,06,01,0,0,0)), create_user(org: @org, created_at: DateTime.new(2018,06,02,0,0,0))]
+
+    Org.stub :all, [@org] do
+      Actions::StatJoinedUser::Generate.full_all_orgs
+
+      april_count = StatJoinedUser.find_by(date: '2018-04-30', org_id: @org.id).count
+      may_count = StatJoinedUser.find_by(date: '2018-05-31', org_id: @org.id).count
+      june_count = StatJoinedUser.find_by(date: '2018-06-30', org_id: @org.id).count
+      july_count = StatJoinedUser.find_by(date: '2018-07-31', org_id: @org.id).count
+
+      assert_equal(2, april_count)
+      assert_equal(1, may_count)
+      assert_equal(2, june_count)
+      assert_equal(0, july_count)
+    end
+  end
+
+  test "last_month_all_orgs returns aggregates from today's last month" do
+    3.times do
+      create_user(org: @org, created_at: Date.today.last_month)
+    end
+
+    Org.stub :all, [@org] do
+      Actions::StatJoinedUser::Generate.last_month_all_orgs
+    
+      last_month_count = StatJoinedUser.find_by(date: Date.today.last_month.end_of_month, org_id: @org.id).count
+      assert_equal(3, last_month_count)
+    end
+  end
+
+  def create_user(org: , created_at: DateTime.current)
+    user = User.new(user_seed.merge({ org: org, email: "user#{Random.new.rand(100000)}@example.com" }))
+    user.save!
+    user.created_at = created_at
+    user.save!
+    user
+  end
+end

--- a/test/lib/csvable_test.rb
+++ b/test/lib/csvable_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class CsvableTest < ActiveSupport::TestCase
+  test '.from_array_of_hashes return empty string' do
+    data = []
+
+    stringified_csv = Csvable.from_array_of_hashes(data)
+
+    assert_empty(stringified_csv)
+  end
+
+  test '.from_array_of_hashes return first row with columns for each hash key' do
+    data = [{ column1: 'value row1.1', column2: 'value row1.2' }]
+
+    stringified_csv = Csvable.from_array_of_hashes(data)
+    header = /[^\n]*/.match(stringified_csv)[0]
+
+    assert_equal("column1,column2", header)
+  end
+
+  test '.from_array_of_hashes returns a row for each hash within the array' do
+    data = [
+      { column1: 'value row1.1', column2: 'value row1.2' },
+      { column1: 'value row2.1', column2: 'value row2.2' },
+      { column1: 'value row3.1', column2: 'value row3.2' },
+    ]
+
+    stringified_csv = Csvable.from_array_of_hashes(data)
+    expected_data = <<~HERE
+      column1,column2
+      value row1.1,value row1.2
+      value row2.1,value row2.2
+      value row3.1,value row3.2
+    HERE
+
+    assert_equal(expected_data, stringified_csv)
+  end
+end

--- a/test/lib/org_date_rangeable_test.rb
+++ b/test/lib/org_date_rangeable_test.rb
@@ -1,0 +1,48 @@
+class OrgDateRangeableTest < ActiveSupport::TestCase
+
+  setup do
+    @org = Org.create!(org_seed)
+    @org.created_at = DateTime.new(2018,05,27, 0,0,0)
+    @org.save!
+  end
+
+  test 'classes which include respond to monthly_range' do
+    included = [StatJoinedUser, StatCreatedPlan]
+
+    included.each do |klass|
+      assert_respond_to(klass, :monthly_range)
+    end
+  end
+
+  test ".split_months_from_creation starts at org's created_at" do
+    expected_start_date = @org.created_at.to_i
+
+    OrgDateRangeable.split_months_from_creation(@org) do |start_date|
+      assert_equal(start_date.to_i, expected_start_date)
+      break
+    end
+  end
+
+  test ".split_months_from_creation finishes at today's last month" do
+    expected_end_date = DateTime.current.last_month.end_of_month.to_i
+    actual_end_date = nil
+
+    OrgDateRangeable.split_months_from_creation(@org) do |start_date, end_date|
+      actual_end_date = end_date
+    end
+
+    assert_equal(actual_end_date.to_i, expected_end_date)
+  end
+
+  test '.split_months_from_creation returns Enumerable' do
+    enumerable = OrgDateRangeable.split_months_from_creation(@org)
+
+    assert_respond_to(enumerable, :each)
+    start_date = @org.created_at.to_i
+    end_date = DateTime.new(2018,05,31,23,59,59).to_i
+    first_start_date = enumerable.first[:start_date].to_i
+    first_end_date = enumerable.first[:end_date].to_i
+    assert_equal(first_start_date, start_date)
+    assert_equal(first_end_date, end_date)
+  end
+end

--- a/test/unit/stat_created_plan_test.rb
+++ b/test/unit/stat_created_plan_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class StatCreatedPlanTest < ActiveSupport::TestCase
+
+  setup do
+    @org = Org.create!(org_seed)
+  end
+
+  test '.to_csv returns each StatCreatedPlan object in a comma-separated row' do
+    june = StatCreatedPlan.create!(date: Date.new(2018, 06, 30), org: @org, count: 10)
+    may = StatCreatedPlan.create!(date: Date.new(2018, 05, 31), org: @org, count: 20)
+    data = [june, may]
+
+    csv = StatCreatedPlan.to_csv(data)
+
+    expected_csv = <<~HERE
+      date,count
+      2018-06-30,10
+      2018-05-31,20
+    HERE
+
+    assert_equal(csv, expected_csv)
+  end
+end

--- a/test/unit/stat_joined_user_test.rb
+++ b/test/unit/stat_joined_user_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class StatJoinedUserTest < ActiveSupport::TestCase
+
+  setup do
+    @org = Org.create!(org_seed.merge({ name: "org#{Random.new.rand(100000)}" }))
+  end
+
+  test '.monthly_range raises ArgumentError when org is missing' do
+    assert_raises(ArgumentError) do
+      StatJoinedUser.monthly_range
+    end
+  end
+
+  test 'monthly_range raises ArgumentError when start_date is missing' do
+    assert_raises(ArgumentError) do
+      StatJoinedUser.monthly_range(org: @org, start_date: nil)
+    end
+  end
+
+  test '.monthly_range raises ArgumentError when end_date is missing' do
+    assert_raises(ArgumentError) do
+      StatJoinedUser.monthly_range(org: @org, end_date: nil)
+    end
+  end
+
+  test '.monthly_range returns matching records' do
+    start_date = Date.new(2018, 04, 30)
+    end_date = Date.new(2018, 05, 31)
+    june = StatJoinedUser.create!(date: Date.new(2018, 06, 30), org: @org)
+    may = StatJoinedUser.create!(date: end_date, org: @org)
+    april = StatJoinedUser.create!(date: start_date, org: @org)
+    
+    actual = StatJoinedUser.monthly_range(org: @org, start_date: start_date, end_date: end_date).to_a
+
+    assert_includes(actual, april)
+    assert_includes(actual, may)
+    refute_includes(actual, june)
+  end
+
+  test '.to_csv returns each StatJoinedUser object in a comma-separated row' do
+    june = StatJoinedUser.create!(date: Date.new(2018, 06, 30), org: @org, count: 5)
+    may = StatJoinedUser.create!(date: Date.new(2018, 05, 31), org: @org, count: 6)
+    data = [june, may]
+
+    csv = StatJoinedUser.to_csv(data)
+
+    expected_csv = <<~HERE
+      date,count
+      2018-06-30,5
+      2018-05-31,6
+    HERE
+
+    assert_equal(csv, expected_csv)
+  end
+end


### PR DESCRIPTION
- History tables that are updated through rake tasks:
  - initially (e.g. stat:joined_user:generate:full_all_orgs)
  - monthly (e.g. stat:joined_user:generate:last_month_all_orgs)
- Models capturing monthly aggregates for created plans and joined
users:
  - Use of Single Table Inheritance from rails through Stat model
  - class method for generating CSV data according to a set of instances
  (e.g. StatCreatedPlan or StatJoinedUser)
  - class method to retrieve data for a monthly range through
  StatCreatedPlan.monthly_range or StatJoinedUser.monthly_range
- Introduction of actions to avoid polluting models
- Unit test for each newly model created
