### PR TITLE
Add current version number to application layout

### DIFF
--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Helpers for displaying the current code version in the views.
+module VersionHelper
+
+  # The current release version for HEAD
+  VERSION = `git describe --tags --long`
+
+  # The current release version for HEAD
+  #
+  # Returns String
+  def version
+    VERSION
+  end
+
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Version: <%= version %> -->
     <title><%= content_for?(:title) ? yield(:title) : _('%{application_name}') % { :application_name => Rails.configuration.branding[:application][:name] } %>
     </title>
     <%= favicon_link_tag "favicon.ico" %>


### PR DESCRIPTION

Changes proposed in this PR:
- Adds an HTML comment with the current version number, so we can tell at a glance which version of the code is being run

Format is: `v2.0-40-gdc25d60` 

where "v2.0" is the version number, "40" is the number of commits since then, "gdc25d60" is the current commit.

