### PR TITLE
Configurable plan access

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -350,15 +350,17 @@ class Plan < ActiveRecord::Base
   def readable_by?(user_id)
     user           = user_id.is_a?(User) ? user_id : User.find(user_id)
     owner_orgs     = owner_and_coowners.collect(&:org)
-    sys_permission = Branding.fetch(:service_configuration, :plans,
+    org_sys_permission = Branding.fetch(:service_configuration, :plans,
                                     :org_admins_read_all)
+    sup_sys_permission = Branding.fetch(:service_configuration, :plans,
+                                    :super_admins_read_all)
 
     # Super Admins can view plans read-only
-    return true if user.can_super_admin?
+    return true if user.can_super_admin? && sup_sys_permission
 
     # Org Admins can view their Org's plans if system permission allows
     return true if user.can_org_admin? && owner_orgs.include?(user.org) &&
-                                          sys_permission
+                                          org_sys_permission
 
     # ...otherwise the user must have the commenter role.
     return true if role?(user.id, :commenter)

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -14,7 +14,11 @@
       <% scope.each do |plan| %>
         <tr>
           <td>
-            <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
+            <% if plan.readable_by?(current_user) %>
+              <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
+            <% else %>
+              <%= plan.title.truncate(60) %>
+            <% end %>
           </td>
           <td><%= plan.template.title %></td>
           <td><%= plan.users.first.org.name %></td>

--- a/config/branding_example.yml
+++ b/config/branding_example.yml
@@ -55,6 +55,7 @@ defaults: &defaults
   service_configuration:
     plans:
       org_admins_read_all: true
+      super_admins_read_all: true
 
 
 development:

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -732,10 +732,13 @@ describe Plan do
 
     subject { plan }
 
-    context "when User has super admin permission" do
+    context "when User is Super admin & system permission" do
 
       before do
         user.perms << create(:perm, name: "add_organisations")
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
+                .returns(true)
       end
 
       it { is_expected.to be_readable_by(user) }

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -739,9 +739,28 @@ describe Plan do
         Branding.expects(:fetch)
                 .with(:service_configuration, :plans, :super_admins_read_all)
                 .returns(true)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :org_admins_read_all)
+                .returns(false)
       end
 
       it { is_expected.to be_readable_by(user) }
+
+    end
+
+    context "when User is Super admin & not system permission" do
+
+      before do
+        user.perms << create(:perm, name: "add_organisations")
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
+                .returns(false)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :org_admins_read_all)
+                .returns(false)
+      end
+
+      it { is_expected.not_to be_readable_by(user) }
 
     end
 
@@ -752,6 +771,9 @@ describe Plan do
         Branding.expects(:fetch)
                 .with(:service_configuration, :plans, :org_admins_read_all)
                 .returns(true)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
+                .returns(false)
       end
 
       it { is_expected.to be_readable_by(user) }
@@ -764,6 +786,9 @@ describe Plan do
         user.perms << create(:perm, name: "grant_permissions")
         Branding.expects(:fetch)
                 .with(:service_configuration, :plans, :org_admins_read_all)
+                .returns(false)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
                 .returns(false)
       end
 
@@ -780,6 +805,9 @@ describe Plan do
         Branding.expects(:fetch)
                 .with(:service_configuration, :plans, :org_admins_read_all)
                 .returns(true)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
+                .returns(false)
       end
 
       it { is_expected.not_to be_readable_by(user) }
@@ -795,6 +823,9 @@ describe Plan do
         Branding.expects(:fetch)
                 .with(:service_configuration, :plans, :org_admins_read_all)
                 .returns(false)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
+                .returns(false)
       end
 
       it { is_expected.not_to be_readable_by(user) }
@@ -808,6 +839,9 @@ describe Plan do
         Branding.expects(:fetch)
                 .with(:service_configuration, :plans, :org_admins_read_all)
                 .returns(true)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
+                .returns(false)
       end
 
       it { is_expected.not_to be_readable_by(user) }
@@ -820,6 +854,9 @@ describe Plan do
         user.update(org: create(:org))
         Branding.expects(:fetch)
                 .with(:service_configuration, :plans, :org_admins_read_all)
+                .returns(false)
+        Branding.expects(:fetch)
+                .with(:service_configuration, :plans, :super_admins_read_all)
                 .returns(false)
       end
 


### PR DESCRIPTION
- added configurable plan access for super as well as org-admins.
- conditionally render links if use can view them

updates branding_example.yml so update your branding.yml accordingly.
The new flag should be set to True for no change in behavior to the tool

Updated tests accordingly