### PR TITLE
Disable caching in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Disable memory store cache set in application.rb
+  config.cache_store = :null_store
+
   # This is required for the Faker gem. See this issue here:
   # https://github.com/stympy/faker/issues/266
   config.i18n.available_locales = %w[en en_GB]

--- a/spec/features/locales_spec.rb
+++ b/spec/features/locales_spec.rb
@@ -4,14 +4,24 @@ RSpec.feature "Locales", type: :feature, js: true do
 
   let!(:languages) {
     [
-      Language.where(default_language: true, name: "English", abbreviation: "en_GB").first_or_create,
-      Language.where(default_language: false, name: "German", abbreviation: "de").first_or_create
+      Language.where(
+        default_language: true,
+        name: "English",
+        abbreviation: "en_GB"
+      ).first_or_create,
+
+      Language.where(
+        default_language: false,
+        name: "German",
+        abbreviation: "de"
+      ).first_or_create
     ]
   }
 
   let!(:user) { create(:user, language: languages.first) }
 
   before do
+    Rails.application.config.i18n.available_locales << languages.last.abbreviation
     FastGettext.default_available_locales << languages.last.abbreviation
     sign_in(user)
   end


### PR DESCRIPTION
Fixes bug breaking test suite in development.

Tests were failing with error `Unable to find link "Language"` since the languages were being cached at startup.
