### PR TITLE
Textual  changes made to Plan Edit Details Page:

### DIFF
--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -149,10 +149,10 @@
           </div>
         </div>
       </fieldset>
-      <%= f.button(_('Submit'), class: "btn btn-default", type: "submit") %>
+      <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
     </div>
     <div class="col-md-4">
-      <h2><%= _('Plan Guidance Configuration') %></h2>
+      <h2><%= _('Select Guidance') %></h2>
       <p><%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations.') %
           {application_name: Rails.configuration.branding[:application][:name]} %>
           </p>
@@ -168,7 +168,7 @@
       <%= link_to _('See the full list'), '#', 'data-toggle' =>  'modal', 'data-target' => '#modal-full-guidances', class: 'modal-guidances-window' %>
 
       <br>
-      <%= f.button(_('Submit'), class: "btn btn-default", type: "submit") %>
+      <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
     </div>
 
     <div id="modal-full-guidances" class="modal fade" tabindex="-1" role="dialog">
@@ -179,7 +179,7 @@
               <button type="button" class="close pull-right" data-dismiss="modal" aria-label="<%= _('Cancel') %>">
                 <span class="fa fa-times" aria-hidden="true">&nbsp;</span>
               </button>
-              <h2><%= _('Plan Guidance Configuration') %></h2>
+              <h2><%= _('Select Guidance') %></h2>
               <p>
                 <%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations. Please choose up to 6 organisations of the following organisations who offer guidance relevant to your plan.') %
                 {application_name: Rails.configuration.branding[:application][:name]} %>

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Plans", type: :feature do
       fill_in "ID", with: "ABCDEF"
       fill_in "ORCID iD", with: "My ORCID"
       fill_in "Phone", with: "07787 000 0000"
-      click_button "Submit"
+      click_button "Save"
     end
 
     # Reload the plan to get the latest from memory


### PR DESCRIPTION
Fixes # 1781.

Changes proposed in this PR:
 
Textual  changes made to Plan Edit Details Page:
    
    - 'Submit' buttons renamed 'Save'
    - 'Plan Guidance Configuration' chanded to 'Select Guidance'

