### PR TITLE
Fix naming format of settings controller

### DIFF
--- a/app/controllers/settings/plans_controller.rb
+++ b/app/controllers/settings/plans_controller.rb
@@ -1,64 +1,67 @@
 # frozen_string_literal: true
 
-class Settings::PlansController < SettingsController
+module Settings
+  class PlansController < SettingsController
 
-  before_filter :get_settings
+    before_filter :get_settings
 
-  after_action :verify_authorized
+    after_action :verify_authorized
 
-  def show
-    authorize [:settings, @plan]
-    respond_to do |format|
-      format.html
-      format.partial
-      format.json { render json: settings_json }
-    end
-  end
-
-  def update
-    authorize @plan
-    export_params = params[:export].try(:deep_symbolize_keys)
-
-    settings = @plan.super_settings(:export).tap do |s|
-      if params[:commit] == "Reset"
-        s.formatting = nil
-        s.fields = nil
-        s.title = nil
-      else
-        s.formatting = export_params[:formatting]
-        s.fields = export_params[:fields]
-        s.title  = export_params[:title]
+    def show
+      authorize [:settings, @plan]
+      respond_to do |format|
+        format.html
+        format.partial
+        format.json { render json: settings_json }
       end
     end
 
-    if settings.save
-      flash[:notice] = _("Export settings updated successfully.")
-    else
-      # rubocop:disable LineLength
-      flash[:alert] = _("An error has occurred while saving/resetting your export settings.")
-      # rubocop:enable LineLength
+    def update
+      authorize @plan
+      export_params = params[:export].try(:deep_symbolize_keys)
+
+      settings = @plan.super_settings(:export).tap do |s|
+        if params[:commit] == "Reset"
+          s.formatting = nil
+          s.fields = nil
+          s.title = nil
+        else
+          s.formatting = export_params[:formatting]
+          s.fields = export_params[:fields]
+          s.title  = export_params[:title]
+        end
+      end
+
+      if settings.save
+        flash[:notice] = _("Export settings updated successfully.")
+      else
+        # rubocop:disable LineLength
+        flash[:alert] = _("An error has occurred while saving/resetting your export settings.")
+        # rubocop:enable LineLength
+      end
+      respond_to do |format|
+        @phase_options = @plan.phases.order(:number).pluck(:title, :id)
+        format.html { redirect_to(download_plan_path(@plan.id)) }
+        # format.json { render json: settings_json }
+      end
     end
-    respond_to do |format|
-      @phase_options = @plan.phases.order(:number).pluck(:title, :id)
-      format.html { redirect_to(download_plan_path(@plan.id)) }
-      # format.json { render json: settings_json }
+
+    private
+
+    def get_settings
+      @plan = Plan.find(params[:id])
+
+      @export_settings = plan.settings(:export)
     end
-  end
 
-  private
+    def settings_json
+      @settings_json ||= { export: @export_settings }.to_json
+    end
 
-  def get_settings
-    @plan = Plan.find(params[:id])
+    def plan
+      @plan ||= Plan.find(params[:id])
+    end
 
-    @export_settings = plan.settings(:export)
-  end
-
-  def settings_json
-    @settings_json ||= { export: @export_settings }.to_json
-  end
-
-  def plan
-    @plan ||= Plan.find(params[:id])
   end
 
 end


### PR DESCRIPTION
Changes proposed in this PR:
- Fix naming convention for settings controller. This was breaking in production mode
