### PR TITLE
Change success message on permission change

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,7 @@ class UsersController < ApplicationController
       end
       render(json: {
         code: 1,
-        msg: success_message(perms.first, _("saved")),
+        msg: _("Successfully saved permissions"),
         current_privileges: render_to_string(partial: "users/current_privileges",
                                              locals: { user: @user }, formats: [:html])
         })


### PR DESCRIPTION
Fixes #1880  .

Changes proposed in this PR:
- Change success flash notice message when permissions are updated.

@xsrust I suggest we leave this one for @briri to review, since he's done work recently on generalising the flash notices and might want to have a say in this change.