### PR TITLE
updated section/question export logic in helper

### DIFF
--- a/app/helpers/plans_helper.rb
+++ b/app/helpers/plans_helper.rb
@@ -48,9 +48,13 @@ module PlansHelper
     return hash[:phases].many? ? "#{plan.title} - #{phase[:title]}" : plan.title
   end
 
-  def display_questions_and_section_headings(section, show_sections_questions, show_custom_sections)
-    # Return true if show_sections_questions is true and either section not customised, or section is customised
-    # and show_custom_sections is true
-    return show_sections_questions && (!section[:modifiable] || (show_custom_sections && section[:modifiable]))
+  def display_questions_and_section_headings(customization, section, show_sections_questions, show_custom_sections)
+    display = false
+    if show_sections_questions
+      display = !customization
+      display ||= customization && !section[:modifiable]
+      display ||= customization && section[:modifiable] && show_custom_sections
+    end
+    return display
   end
 end

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -75,7 +75,7 @@ module ExportablePlan
                        .joins(phases: { sections: { questions: :question_format } })
                        .where(id: self.template_id)
                        .order('sections.number', 'questions.number').first
-
+    hash[:customization] = template.customization_of.present?
     hash[:title] = self.title
     hash[:answers] = self.answers
 

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -24,7 +24,7 @@
         <h1><%= download_plan_page_title(@plan, phase, @hash) %></h1>
         <hr />
         <% phase[:sections].each do |section| %>
-          <% if display_questions_and_section_headings(section, @show_sections_questions, @show_custom_sections) %>
+          <% if display_questions_and_section_headings(@hash[:customization], section, @show_sections_questions, @show_custom_sections) %>
             <h3><%= section[:title] %></h3>
 
             <% section[:questions].each do |question| %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -26,7 +26,7 @@
 <% if phase[:title] == @selected_phase.title %>
 <%= (@hash[:phases].many? ? "#{phase[:title]}" : "") %>
   <% phase[:sections].each do |section| %>
-    <% if display_questions_and_section_headings(section, @show_sections_questions, @show_custom_sections) %>
+    <% if display_questions_and_section_headings(@hash[:customization], section, @show_sections_questions, @show_custom_sections) %>
 <%= "#{section[:title]}\n" %>
 
       <% section[:questions].each do |question| %>


### PR DESCRIPTION
Fixes #1844 

Updated logic in helper
Previously modifiable sections would only export if the 'show supplementary' option was selected.
