### PR TITLE
fixed issue with autosave

### DIFF
--- a/lib/assets/javascripts/views/answers/edit.js
+++ b/lib/assets/javascripts/views/answers/edit.js
@@ -12,7 +12,7 @@ $(() => {
   const hideSavingMessage = jQuery => jQuery.closest('.question-form').find('[data-status="saving"]').hide();
   const closestErrorSavingMessage = jQuery => jQuery.closest('.question-form').find('[data-status="error-saving"]');
   const questionId = jQuery => jQuery.closest('.form-answer').attr('data-autosave');
-  const isStale = jQuery => jQuery.closest('.question-form').find('.answer-locking').html().length !== 0;
+  const isStale = jQuery => jQuery.closest('.question-form').find('.answer-locking').text().length !== 0;
   const isReadOnly = () => $('.form-answer fieldset:disabled').length > 0;
   /*
    * A map of debounced functions, one for each input, textarea or select change at any


### PR DESCRIPTION
Fixes #1878  .

JS was checking length of the html within the `answer-locking` element. Recent reformatting of the HTML for Rubocop/readability added some blank space to the element which was causing the length to always be greater than zero.

Updated to check the length of the element's text instead.