### PR TITLE
Fixed issues with Feedback settings on Org page

### DIFF
--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -31,6 +31,7 @@
 class Org < ActiveRecord::Base
   include ValidationMessages
   include ValidationValues
+  include FeedbacksHelper
   include GlobalHelpers
   include FlagShihTzu
   extend Dragonfly::Model::Validations
@@ -126,6 +127,7 @@ class Org < ActiveRecord::Base
     where("orgs.name LIKE ? OR orgs.contact_email LIKE ?", search_pattern, search_pattern)
   }
 
+  before_validation :set_default_feedback_email_subject
   after_create :create_guidance_group
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW
@@ -219,6 +221,12 @@ class Org < ActiveRecord::Base
       if logo.height != 100
         self.logo = logo.thumb('x100')  # resize height and maintain aspect ratio
       end
+    end
+  end
+
+  def set_default_feedback_email_subject
+    if self.feedback_enabled? && !self.feedback_email_subject.present?
+      self.feedback_email_subject = feedback_confirmation_default_subject
     end
   end
 

--- a/lib/assets/javascripts/views/orgs/admin_edit.js
+++ b/lib/assets/javascripts/views/orgs/admin_edit.js
@@ -1,14 +1,18 @@
 // TODO: we need to be able to swap in the appropriate locale here
 import 'number-to-text/converters/en-us';
+import { isObject } from '../../utils/isType';
 import { Tinymce } from '../../utils/tinymce';
 import { eachLinks } from '../../utils/links';
 
 $(() => {
   const toggleFeedback = () => {
-    if ($('#org_feedback_enabled_true').is(':checked')) {
-      $('#feeback-email input, #feeback-email textarea').removeAttr('disabled');
-    } else {
-      $('#feeback-email input, #feeback-email textarea').attr('disabled', true);
+    const editor = Tinymce.findEditorById('org_feedback_email_msg');
+    if (isObject(editor)) {
+      if ($('#org_feedback_enabled_true').is(':checked')) {
+        editor.setMode('code');
+      } else {
+        editor.setMode('readonly');
+      }
     }
   };
 
@@ -19,6 +23,7 @@ $(() => {
   // Initialises tinymce for any target element with class tinymce_answer
   Tinymce.init({ selector: '#org_feedback_email_msg' });
   toggleFeedback();
+
 
   // update the hidden org_type field based on the checkboxes selected
   const calculateOrgType = () => {


### PR DESCRIPTION
Fixes #1877 .
- Updated JS so that the Feedback message is enabled/disabled appropriately based on the status of the feedback_enabled radio buttons
- Added a `before_validation` callback that will set the feedback subject to the default subject defined in the FeedbacksHelper.rb. There is a rake task that sets this value for existing records but nothing sets it for new Orgs.

A better long term solution might be to remove this DB field completely since we no longer allow users to define their own email subject. We should discuss and create a new ticket if that sounds like a good solution. 