### PR TITLE
Fix bug in paginable table sorting

### DIFF
--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -147,7 +147,7 @@ module Paginable
          style="float: right; font-size: 1.2em;">
 
         <span class="screen-reader-text">
-          #{_("Sort by %{sort_field}") % sort_field.split(".").first}
+          #{_("Sort by %{sort_field}") % { sort_field: sort_field.split(".").first }}
         </span>
       </i>
     HTML

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -8,6 +8,9 @@ module Paginable
   # Regex to validate sort_field param is safe
   SORT_COLUMN_FORMAT = /[\w\_]+\.[\w\_]/
 
+  PAGINATION_QUERY_PARAMS = [:page, :sort_field, :sort_direction,
+                             :search, :controller, :action]
+
   private
 
   # Renders paginable layout with the partial view passed
@@ -75,24 +78,12 @@ module Paginable
 
   # Returns the base url of the paginable route for a given page passed
   def paginable_base_url(page = 1)
-    url_for(
-      @paginable_path_params.merge(
-        controller: @paginable_params[:controller],
-        action: @paginable_params[:action], page: page
-      )
+    url_params = @paginable_path_params.merge(
+      controller: @paginable_params[:controller],
+      action: @paginable_params[:action],
+      page: page
     )
-  end
-
-  # Returns the base url of the paginable router for a given page passed together with
-  # its query_params. It is used to retain context, i.e. search, sort_field,
-  # sort_direction, etc
-  def paginable_base_url_with_query_params(page: 1, **stringify_query_params_options)
-    base_url = paginable_base_url(page)
-    stringified_query_params = stringify_query_params(stringify_query_params_options)
-    if stringified_query_params.present?
-      return "#{base_url}?#{stringified_query_params}"
-    end
-    base_url
+    url_for(url_params)
   end
 
   # Generates an HTML link to sort given a sort field.
@@ -101,8 +92,9 @@ module Paginable
     link_to(
       sort_link_name(sort_field),
       sort_link_url(sort_field),
-      "data-remote": true,
-      class: "paginable-action", "aria-label": "#{sort_field}"
+      class: "paginable-action",
+      data: { remote: true },
+      aria: { label: sort_field }
     )
   end
 
@@ -114,20 +106,6 @@ module Paginable
   # Determines whether or not the scoped query is paginated or not
   def paginable?
     @refined_scope.respond_to?(:total_pages)
-  end
-
-  # Returns the upcase string (e.g ASC or DESC) if sort_direction param is present in any
-  # of the forms 'asc', 'desc', 'ASC', 'DESC' otherwise returns ASC
-  def upcasing_sort_direction(direction = @paginable_params[:sort_direction])
-    directions = ["asc", "desc", "ASC", "DESC"]
-    directions.include?(direction) ? direction.upcase : "ASC"
-  end
-
-  # Returns DESC when ASC is passed and vice versa, otherwise nil
-  def swap_sort_direction(direction = @paginable_params[:sort_direction])
-    direction_upcased = upcasing_sort_direction(direction)
-    "DESC" if direction_upcased == "ASC"
-    "ASC" if direction_upcased == "DESC"
   end
 
   # Refine a scope passed to this concern if any of the params (search,
@@ -143,7 +121,7 @@ module Paginable
       end
       # Can raise ActiveRecord::StatementInvalid (e.g. column does not
       # exist, ambiguity on column, etc)
-      scope = scope.order("#{@paginable_params[:sort_field]} #{upcasing_sort_direction}")
+      scope = scope.order("#{@paginable_params[:sort_field]} #{sort_direction}")
     end
     if @paginable_params[:page] != "ALL"
       # Can raise error if page is not a number
@@ -152,12 +130,16 @@ module Paginable
     scope
   end
 
+  def sort_direction
+    @sort_direction ||= SortDirection.new(@paginable_params[:sort_direction])
+  end
+
   # Returns the sort link name for a given sort_field. The link name includes
   # html prevented of being escaped
   def sort_link_name(sort_field)
     class_name = "fa-sort"
     if @paginable_params[:sort_field] == sort_field
-      class_name = upcasing_sort_direction == "ASC" ? "fa-sort-asc" : "fa-sort-desc"
+      class_name = "fa-sort-#{sort_direction.downcase}"
     end
     <<~HTML.html_safe
       <i class="fa #{class_name}"
@@ -165,54 +147,45 @@ module Paginable
          style="float: right; font-size: 1.2em;">
 
         <span class="screen-reader-text">
-
-        Sort by #{sort_field.split(".").first}
+          Sort by #{sort_field.split(".").first}
+        </span>
       </i>
     HTML
   end
 
   # Returns the sort url for a given sort_field.
   def sort_link_url(sort_field)
-    page = @paginable_params[:page] == "ALL" ? "ALL" : 1
+    query_params = {}
+    query_params[:page] = @paginable_params[:page] == "ALL" ? "ALL" : 1
+    query_params[:sort_field] = sort_field
     if @paginable_params[:sort_field] == sort_field
-      sort_url = paginable_base_url_with_query_params(
-        page: page,
-        sort_field: sort_field,
-        sort_direction: swap_sort_direction)
+      query_params[:sort_direction] = sort_direction.opposite
     else
-      sort_url = paginable_base_url_with_query_params(
-        page: page,
-        sort_field: sort_field)
+      query_params[:sort_direction] = sort_direction
     end
-    "#{sort_url}#{stringify_nonpagination_query_params}"
+    base_url = paginable_base_url(query_params[:page])
+    sort_url = URI(base_url)
+    sort_url.query = stringify_query_params(query_params)
+    sort_url.to_s
+    "#{sort_url}&#{stringify_nonpagination_query_params}"
   end
 
   # Retrieve any query params that are not a part of the paginable concern
   def stringify_nonpagination_query_params
-    other_params = @paginable_params.select do |param|
-      ![:page, :sort_field, :sort_direction,
-        :search, :controller, :action].include?(param)
-    end
-    if other_params.empty?
-      ""
-    else
-      "&#{other_params.collect { |k, v| "#{k}=#{v}" }.join('&')}"
-    end
+    @paginable_params.except(*PAGINATION_QUERY_PARAMS).to_param
   end
 
-  def stringify_query_params(
-    search: @paginable_params[:search],
+  def stringify_query_params(page: 1, search: @paginable_params[:search],
     sort_field: @paginable_params[:sort_field],
     sort_direction: nil)
 
-    query_string = []
-    query_string << "search=#{search}" if search.present?
+    query_string = {}
+    query_string["search"] = search if search.present?
     if sort_field.present?
-      query_string << "sort_field=#{sort_field}"
-      direction = sort_direction || upcasing_sort_direction
-      query_string << "sort_direction=#{direction}"
+      query_string["sort_field"] = sort_field
+      query_string["sort_direction"] = SortDirection.new(sort_direction)
     end
-    query_string.join("&")
+    query_string.to_param
   end
 
 end

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -147,7 +147,7 @@ module Paginable
          style="float: right; font-size: 1.2em;">
 
         <span class="screen-reader-text">
-          Sort by #{sort_field.split(".").first}
+          #{_("Sort by %{sort_field}") % sort_field.split(".").first}
         </span>
       </i>
     HTML

--- a/lib/assets/javascripts/utils/paginable.js
+++ b/lib/assets/javascripts/utils/paginable.js
@@ -4,14 +4,16 @@ export const paginableSelector = '.paginable';
 
 $(() => {
   const onAjaxSuccessHandler = (e, data) => {
-    $(e.target).closest(paginableSelector).html($(data));
+    $(e.target).closest(paginableSelector).replaceWith($(data));
   };
   $('.paginable-search form[data-remote="true"]').on('ajax:before', e => isValidText($(e.target).find('input[name="search"]').val()));
   // Event listener for Ajax success event captured in response to a paginable link clicked or
   // search form submitted. Note the presence of a selector for on (e.g. a[data-remote="true"])
   // so that descendant elements from .paginable-results that are added in future are also
   // automatically handled.
-  $(paginableSelector).on('ajax:success', 'form.paginable-action[data-remote="true"], a.paginable-action[data-remote="true"]', onAjaxSuccessHandler);
+  $('body').on('ajax:success',
+    'form.paginable-action[data-remote="true"], a.paginable-action[data-remote="true"]',
+    onAjaxSuccessHandler);
 });
 
 export { paginableSelector as default };

--- a/lib/sort_direction.rb
+++ b/lib/sort_direction.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Helper class for column sorting in Pagination.
+#
+# Examples:
+#
+#   @direction = SortDirection.new(:asc)
+#   @direction.to_s # => "ASC"
+#   @direction.downcase # => 'asc'
+#   @direction.opposite # => 'DESC'
+#
+#   SortDirection.new(:wrong).to_s # => 'ASC'
+#
+class SortDirection
+
+  ##
+  # When given an unknown or nil direction, default to this value
+  DEFAULT_DIRECTION = "ASC"
+
+  ##
+  # Possible sort direction values
+  DIRECTIONS = %w[ASC DESC]
+
+  ##
+  # The direction represented as an uppercase, abbreviated String
+  attr_reader :direction
+
+  alias to_s direction
+
+  ##
+  # The direction as uppercase
+  #
+  # Returns String
+  delegate :uppercase, to: :direction
+
+  ##
+  # The direction as lowercase
+  #
+  # Returns String
+  delegate :downcase, to: :direction
+
+  # Initialize a new SortDirection
+  #
+  # direction - The direction (asc or desc) we want to sort results by
+  def initialize(direction = nil)
+    @direction = direction.to_s.upcase.presence_in(DIRECTIONS) || DEFAULT_DIRECTION
+  end
+
+  # The opposite direction to this one. Returns asc for desc, and desc for asc.
+  #
+  # Returns String
+  def opposite
+    @opposite ||= DIRECTIONS[DIRECTIONS.index(direction) - 1]
+  end
+
+end


### PR DESCRIPTION
Fixes #1861 .

Changes proposed in this PR:
- Fix bug preventing paginable links from updating when clicked
- Fix bug: JS was loading multiple nested duplicate .paginable objects
- Refactor Paginable for improved readability.