### PR TITLE
Update default locale

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 # When Travis runs this, the DB isn't always built yet.
 if Language.table_exists?
   def default_locale
-    Language.default.try(:abbreviation) || 'en-GB'
+    Language.default.try(:abbreviation) || "en-GB"
   end
 
   def available_locales
@@ -11,25 +13,27 @@ if Language.table_exists?
   end
 else
   def default_locale
-    Rails.application.config.i18n.available_locales.first || 'en-GB'
+    Rails.application.config.i18n.available_locales.first || "en-GB"
   end
 
   def available_locales
-    Rails.application.config.i18n.available_locales = LocaleSet.new(['en-GB', 'en'])
+    Rails.application.config.i18n.available_locales = LocaleSet.new(["en-GB", "en"])
   end
 end
 
-FastGettext.add_text_domain('app', {
-  path: 'config/locale',
+FastGettext.add_text_domain("app",
+  path: "config/locale",
   type: :po,
   ignore_fuzzy: true,
   report_warning: false,
-})
+)
 
 I18n.available_locales += available_locales.for(:i18n)
 FastGettext.default_available_locales = available_locales.for(:fast_gettext)
 
-FastGettext.default_text_domain       = 'app'
+FastGettext.default_text_domain       = "app"
 
-I18n.default_locale        = available_locales.for(:i18n).first
-FastGettext.default_locale = available_locales.for(:fast_gettext).first
+I18n.default_locale        = LocaleFormatter.new(default_locale,
+                                                 format: :i18n).to_s
+FastGettext.default_locale = LocaleFormatter.new(default_locale,
+                                                 format: :fast_gettext).to_s


### PR DESCRIPTION
Fixes #1890 .

Updated the FastGettext initializer to use the `default_locale` logic when setting the default locales for both I18n and FastGettext. Included logic to swap out '-' and '_' in the locale names for the appropriate localization plugin
