### PR TITLE
The allowed QuestionFormats when adding a new question to a customisa…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     multipart-post (2.0.0)
     mysql2 (0.4.10)
     nenv (0.3.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -463,4 +463,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/app/controllers/concerns/allowed_question_formats.rb
+++ b/app/controllers/concerns/allowed_question_formats.rb
@@ -1,0 +1,9 @@
+module AllowedQuestionFormats
+  
+  private
+  
+  # The QuestionFormat "Multi select box" is no longer being used for new templates
+  def allowed_question_formats
+    QuestionFormat.where.not(title: "Multi select box").order(:title)
+  end
+end

--- a/app/controllers/org_admin/questions_controller.rb
+++ b/app/controllers/org_admin/questions_controller.rb
@@ -4,6 +4,7 @@ module OrgAdmin
 
   class QuestionsController < ApplicationController
 
+    include AllowedQuestionFormats
     include Versionable
 
     respond_to :html
@@ -42,6 +43,7 @@ module OrgAdmin
       question = Question.new(section_id: section.id,
                               question_format: question_format,
                               number: nbr.present? ? nbr + 1 : 1)
+      question_formats = allowed_question_formats
       authorize question
       render partial: "form", locals: {
         template: section.phase.template,
@@ -51,7 +53,8 @@ module OrgAdmin
         url: org_admin_template_phase_section_questions_path(
           template_id: section.phase.template.id,
           phase_id: section.phase.id,
-          id: section.id)
+          id: section.id),
+        question_formats: question_formats
       }
     end
 

--- a/app/views/org_admin/questions/_form.html.erb
+++ b/app/views/org_admin/questions/_form.html.erb
@@ -25,7 +25,7 @@
     <div class="form-group col-md-4">
       <%= f.label(:question_format_id, _('Answer format'), class: "control-label") %>
         <%= f.select :question_format_id,
-          options_from_collection_for_select(QuestionFormat.all.order("title"),
+          options_from_collection_for_select(question_formats,
           :id,
           :title,
           question.question_format_id),


### PR DESCRIPTION
Fixes # 1771

Changes proposed in this PR:
- Ensure that "Multi select box" question format is no longer visible when customising questions.
