### PR TITLE
added trim to check for optimistic lock text

### DIFF
--- a/lib/assets/javascripts/views/answers/edit.js
+++ b/lib/assets/javascripts/views/answers/edit.js
@@ -12,7 +12,7 @@ $(() => {
   const hideSavingMessage = jQuery => jQuery.closest('.question-form').find('[data-status="saving"]').hide();
   const closestErrorSavingMessage = jQuery => jQuery.closest('.question-form').find('[data-status="error-saving"]');
   const questionId = jQuery => jQuery.closest('.form-answer').attr('data-autosave');
-  const isStale = jQuery => jQuery.closest('.question-form').find('.answer-locking').text().length !== 0;
+  const isStale = jQuery => jQuery.closest('.question-form').find('.answer-locking').text().trim().length !== 0;
   const isReadOnly = () => $('.form-answer fieldset:disabled').length > 0;
   /*
    * A map of debounced functions, one for each input, textarea or select change at any


### PR DESCRIPTION
Fixes #1878  .

also needed to add a `.trim()` to the end of the `isStale` function due to breaking the html up onto separate lines.
