### PR TITLE
added JS to force external links to openin a new tab

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,6 +77,7 @@
 
     <%
     constants_json = {
+      HOST: request.host,
       PASSWORD_MIN_LENGTH: 8,
       PASSWORD_MAX_LENGTH: 128,
       MAX_NUMBER_ORG_URLS: 3,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,7 +77,7 @@
 
     <%
     constants_json = {
-      HOST: request.host,
+      HOST: (Rails.env.development? || Rails.env.test? ? 'localhost' : Socket.gethostname),
       PASSWORD_MIN_LENGTH: 8,
       PASSWORD_MAX_LENGTH: 128,
       MAX_NUMBER_ORG_URLS: 3,

--- a/lib/assets/javascripts/application.js
+++ b/lib/assets/javascripts/application.js
@@ -7,6 +7,7 @@ import './utils/tabHelper';
 import './utils/tooltipHelper';
 import './utils/popoverHelper';
 import './utils/requiredField';
+import './utils/externalLink';
 
 // Page specific JS
 import './views/answers/edit';

--- a/lib/assets/javascripts/utils/externalLink.js
+++ b/lib/assets/javascripts/utils/externalLink.js
@@ -4,12 +4,15 @@ import getConstant from '../constants';
 $(() => {
   $('body').click('a[href^="http"]', (e) => {
     const link = $(e.target);
-    const regex = new RegExp(`^https?://${getConstant('HOST')}`); // /^https?:\/\./i;
+    const protocol = new RegExp('^https?');
+    const regex = new RegExp(`^https?://${getConstant('HOST')}`);
     const exceptions = {
       ids: ['connect-orcid-button', 'view-all-templates'],
     };
+    // Internal links are typically just the path, but also check for other domains
     if (
       !link.attr('target') &&
+      protocol.test(link.attr('href')) &&
       !regex.test(link.attr('href')) &&
       !(exceptions.ids.indexOf(link.attr('id')) >= 0)
     ) {

--- a/lib/assets/javascripts/utils/externalLink.js
+++ b/lib/assets/javascripts/utils/externalLink.js
@@ -1,0 +1,19 @@
+import getConstant from '../constants';
+
+// Globally ensure that any URLs that are directing the user offsite open in a new tab/window
+$(() => {
+  $('body').click('a[href^="http"]', (e) => {
+    const link = $(e.target);
+    const regex = new RegExp(`^https?://${getConstant('HOST')}`); // /^https?:\/\./i;
+    const exceptions = {
+      ids: ['connect-orcid-button', 'view-all-templates'],
+    };
+    if (
+      !link.attr('target') &&
+      !regex.test(link.attr('href')) &&
+      !(exceptions.ids.indexOf(link.attr('id')) >= 0)
+    ) {
+      link.attr('target', '_blank');
+    }
+  });
+});


### PR DESCRIPTION
We're doing this in the DMPTool already so submitting for inclusion to Roadmap to address #1916.

This JS logic will force any external link (unless its in the exceptions list) to open in a new browser tab. We went through and did this for static links, but this will also catch links embedded in user input data like guidance and questions/answers.
