### PR TITLE
Rewrite version method to return only SHA

### DIFF
--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -4,7 +4,7 @@
 module VersionHelper
 
   # The current release version for HEAD
-  VERSION = `git describe --tags --long`
+  VERSION = `git rev-parse HEAD`.strip
 
   # The current release version for HEAD
   #


### PR DESCRIPTION
Changes proposed in this PR:
- Instead of version helper showing current tagged version, show SHA (more useful for dev releases)