### PR TITLE
Some fixes for a few data cleanup scripts and a few new ones

### DIFF
--- a/lib/data_cleanup/rules/annotation/fix_blank_org.rb
+++ b/lib/data_cleanup/rules/annotation/fix_blank_org.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank org on Annotation
+    module Annotation
+      class FixBlankOrg < Rules::Base
+
+        def description
+          "Fix blank org on Annotation"
+        end
+
+        def call
+          ids = ::Annotation.joins("LEFT OUTER JOIN orgs ON orgs.id = annotations.org_id")
+                      .where(orgs: { id: nil }).ids
+          log("Destroying Annotation without Org: #{ids}")
+          ::Annotation.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/annotation/fix_blank_question.rb
+++ b/lib/data_cleanup/rules/annotation/fix_blank_question.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank question on Annotation
+    module Annotation
+      class FixBlankQuestion < Rules::Base
+
+        def description
+          "Fix blank question on Annotation"
+        end
+
+        def call
+          ids = ::Annotation.joins("LEFT OUTER JOIN questions ON questions.id = annotations.question_id")
+                      .where(questions: { id: nil }).ids
+          log("Destroying Annotation without Question: #{ids}")
+          ::Annotation.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/answer/fix_blank_plan.rb
+++ b/lib/data_cleanup/rules/answer/fix_blank_plan.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank user on Answer
+    module Answer
+      class FixBlankUser < Rules::Base
+
+        def description
+          "Fix blank plan on Answer"
+        end
+
+        def call
+          ::Answer.where.not(plan_id: Plan.all.collect(&:id)).each do |answer|
+            unless answer.plan.present?
+              log("Destroying orphaned Answer##{answer.id}")
+              answer.destroy
+            end
+          end
+        end
+
+      end
+    end
+
+  end
+end

--- a/lib/data_cleanup/rules/answer/fix_blank_plan.rb
+++ b/lib/data_cleanup/rules/answer/fix_blank_plan.rb
@@ -3,14 +3,14 @@ module DataCleanup
   module Rules
     # Fix blank user on Answer
     module Answer
-      class FixBlankUser < Rules::Base
+      class FixBlankPlan < Rules::Base
 
         def description
           "Fix blank plan on Answer"
         end
 
         def call
-          ::Answer.where.not(plan_id: Plan.all.collect(&:id)).each do |answer|
+          ::Answer.where.not(plan_id: ::Plan.all.collect(&:id)).each do |answer|
             unless answer.plan.present?
               log("Destroying orphaned Answer##{answer.id}")
               answer.destroy

--- a/lib/data_cleanup/rules/answer/fix_blank_question.rb
+++ b/lib/data_cleanup/rules/answer/fix_blank_question.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 module DataCleanup
   module Rules
-    # Fix blank plan on Answer
+    # Fix blank user on Answer
     module Answer
-      class FixBlankPlan < Rules::Base
+      class FixBlankQuestion < Rules::Base
 
         def description
-          "Fix blank plan on Answer"
+          "Fix blank question on Answer"
         end
 
         def call
-          ::Answer.where.not(plan_id: ::Plan.all.collect(&:id)).each do |answer|
-            unless answer.plan.present?
+          ::Answer.where.not(question_id: ::Question.all.collect(&:id)).each do |answer|
+            unless answer.question.present?
               log("Destroying orphaned Answer##{answer.id}")
               answer.destroy
             end

--- a/lib/data_cleanup/rules/guidance/fix_blank_guidance_group.rb
+++ b/lib/data_cleanup/rules/guidance/fix_blank_guidance_group.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank guidance_group on Guidance
+    module Guidance
+      class FixBlankGuidanceGroup < Rules::Base
+
+        def description
+          "Fix blank guidance_group on Guidance"
+        end
+
+        def call
+          ids = ::Guidance.joins("LEFT OUTER JOIN guidance_groups ON guidance_groups.id = guidances.guidance_group_id")
+                      .where(guidance_groups: { id: nil }).ids
+          log("Destroying Guidance without GuidanceGroup: #{ids}")
+          ::Guidance.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/guidance_group/fix_blank_org.rb
+++ b/lib/data_cleanup/rules/guidance_group/fix_blank_org.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank org on GuidanceGroup
+    module GuidanceGroup
+      class FixBlankOrg < Rules::Base
+
+        def description
+          "Fix blank org on GuidanceGroup"
+        end
+
+        def call
+          ids = ::GuidanceGroup.joins("LEFT OUTER JOIN orgs ON orgs.id = guidance_groups.org_id")
+                      .where(orgs: { id: nil }).ids
+          log("Destroying GuidanceGroup without Org: #{ids}")
+          ::GuidanceGroup.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/note/fix_blank_answer.rb
+++ b/lib/data_cleanup/rules/note/fix_blank_answer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank answer on Note
+    module Note
+      class FixBlankAnswer < Rules::Base
+
+        def description
+          "Fix blank answer on Note"
+        end
+
+        def call
+          ids = ::Note.joins("LEFT OUTER JOIN answers ON answers.id = notes.answer_id")
+                      .where(answers: { id: nil }).ids
+          log("Destroying Note without Answer: #{ids}")
+          ::Note.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/note/fix_blank_user.rb
+++ b/lib/data_cleanup/rules/note/fix_blank_user.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank user on Note
+    module Note
+      class FixBlankUser < Rules::Base
+
+        def description
+          "Fix blank user on Note"
+        end
+
+        def call
+          ids = ::Note.joins("LEFT OUTER JOIN users ON users.id = notes.user_id")
+                      .where(users: { id: nil }).ids
+          log("Destroying Note without User: #{ids}")
+          ::Note.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/org/fix_blank_abbreviation.rb
+++ b/lib/data_cleanup/rules/org/fix_blank_abbreviation.rb
@@ -22,7 +22,7 @@ module DataCleanup
           else
             # Raise an exception if there are Orgs with no abbreviation and
             # no YAML file was defined
-            if ::Org.where(abbreviation: nil)
+            if ::Org.where(abbreviation: nil).present?
               raise "Please create a YAML file at #{YAML_FILE_PATH}"
             end
           end

--- a/lib/data_cleanup/rules/org/fix_blank_feedback_email_msg.rb
+++ b/lib/data_cleanup/rules/org/fix_blank_feedback_email_msg.rb
@@ -17,9 +17,9 @@ module DataCleanup
         end
 
         def call
-          ids = ::Org.where(feedback_enabled: true, feedback_email_msg: "").pluck(:id)
+          ids = ::Org.where(feedback_enabled: true, feedback_email_msg: [nil, ""]).pluck(:id)
           log("Adding default feedback_enabled for orgs: #{ids}")
-          ::Org.where(feedback_enabled: true, feedback_email_msg: "")
+          ::Org.where(id: ids)
              .update_all(feedback_email_msg: DEFAULT_MSG)
         end
       end

--- a/lib/data_cleanup/rules/org/fix_blank_feedback_email_subject.rb
+++ b/lib/data_cleanup/rules/org/fix_blank_feedback_email_subject.rb
@@ -10,9 +10,9 @@ module DataCleanup
         end
 
         def call
-          ids = ::Org.where(feedback_enabled: true, feedback_email_subject: "").pluck(:id)
+          ids = ::Org.where(feedback_enabled: true, feedback_email_subject: [nil, ""]).pluck(:id)
           log("Adding default feedback_email_subject for orgs: #{ids}")
-          ::Org.where(feedback_enabled: true, feedback_email_subject: "")
+          ::Org.where(id: ids)
                .update_all(feedback_email_subject: DEFAULT_SUBJECT)
         end
       end

--- a/lib/data_cleanup/rules/org/fix_blank_language.rb
+++ b/lib/data_cleanup/rules/org/fix_blank_language.rb
@@ -12,9 +12,9 @@ module DataCleanup
         end
 
         def call
-          ids = ::Org.where(language: nil).pluck(:id)
+          ids = ::Org.where(language: [nil, ""]).pluck(:id)
           log("Setting language to #{DEFAULT_LANGUAGE} for Orgs: #{ids}")
-          ::Org.where(language: nil).update_all(language_id: DEFAULT_LANGUAGE.id)
+          ::Org.where(id: ids).update_all(language_id: DEFAULT_LANGUAGE.id)
         end
       end
     end

--- a/lib/data_cleanup/rules/org_identifier/fix_blank_org.rb
+++ b/lib/data_cleanup/rules/org_identifier/fix_blank_org.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank org on OrgIdentifier
+    module OrgIdentifier
+      class FixBlankOrg < Rules::Base
+
+        def description
+          "Fix blank org on OrgIdentifier"
+        end
+
+        def call
+          ids = ::OrgIdentifier.joins("LEFT OUTER JOIN orgs ON orgs.id = org_identifiers.org_id")
+                      .where(orgs: { id: nil }).ids
+          log("Destroying OrgIdentifier without Org: #{ids}")
+          ::OrgIdentifier.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/phase/fix_blank_template.rb
+++ b/lib/data_cleanup/rules/phase/fix_blank_template.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank template on Phase
+    module Phase
+      class FixBlankTemplate < Rules::Base
+
+        def description
+          "Fix blank template on Phase"
+        end
+
+        def call
+          ids = ::Phase.joins("LEFT OUTER JOIN templates ON templates.id = phases.template_id")
+                      .where(templates: { id: nil }).ids
+          log("Destroying Phase without Template: #{ids}")
+          ::Phase.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/plan/fix_blank_template.rb
+++ b/lib/data_cleanup/rules/plan/fix_blank_template.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank template on Plan
+    module Plan
+      class FixBlankTemplate < Rules::Base
+
+        def description
+          "Fix blank template on Plan"
+        end
+
+        def call
+          ids = ::Plan.joins("LEFT OUTER JOIN templates ON templates.id = plans.template_id")
+                      .where(templates: { id: nil }).ids
+          log("Destroying Plan without Template: #{ids}")
+          ::Plan.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/pref/fix_blank_user.rb
+++ b/lib/data_cleanup/rules/pref/fix_blank_user.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank user on Pref
+    module Pref
+      class FixBlankUser < Rules::Base
+
+        def description
+          "Fix blank user on Pref"
+        end
+
+        def call
+          ids = ::Pref.joins("LEFT OUTER JOIN users ON users.id = prefs.user_id")
+                      .where(users: { id: nil }).ids
+          log("Destroying Pref without User: #{ids}")
+          ::Pref.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/question/fix_blank_question_format.rb
+++ b/lib/data_cleanup/rules/question/fix_blank_question_format.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank question_format on Question
+    module Question
+      class FixBlankQuestionFormat < Rules::Base
+
+        def description
+          "Fix blank question_format on Question"
+        end
+
+        def call
+          text_area = ::QuestionFormat.where("lower(title) = 'text area")
+          ::Question.joins("LEFT OUTER JOIN question_formats ON question_formats.id = questions.question_format_id")
+                      .where(question_formats: { id: nil }).each do |question|
+            log("Defaulting Question with missing QuestionFormat to TextArea: #{ids}")
+
+            question.update_attributes(question_format: text_area)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/question/fix_blank_section.rb
+++ b/lib/data_cleanup/rules/question/fix_blank_section.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank section on Question
+    module Question
+      class FixBlankSection < Rules::Base
+
+        def description
+          "Fix blank section on Question"
+        end
+
+        def call
+          ids = ::Question.joins("LEFT OUTER JOIN sections ON sections.id = questions.section_id")
+                      .where(sections: { id: nil }).ids
+          log("Destroying Question without Section: #{ids}")
+          ::Question.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/question_format/fix_blank_description.rb
+++ b/lib/data_cleanup/rules/question_format/fix_blank_description.rb
@@ -10,7 +10,7 @@ module DataCleanup
         end
 
         def call
-          ::QuestionFormat.where(description: "").each do |qf|
+          ::QuestionFormat.where(description: [nil, ""]).each do |qf|
             log("Adding default description to QuestionFormat##{qf.id}")
             qf.update!(description: "#{qf.title} format")
           end

--- a/lib/data_cleanup/rules/role/fix_blank_plan.rb
+++ b/lib/data_cleanup/rules/role/fix_blank_plan.rb
@@ -10,7 +10,8 @@ module DataCleanup
         end
 
         def call
-          ids = ::Role.where(plan: nil).ids
+          ids = ::Role.joins("LEFT OUTER JOIN plans ON plans.id = roles.plan_id")
+                      .where(plans: { id: nil }).ids
           log("Destroying Roles without Plan: #{ids}")
           ::Role.destroy(ids)
         end

--- a/lib/data_cleanup/rules/role/fix_blank_user.rb
+++ b/lib/data_cleanup/rules/role/fix_blank_user.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank plan on Role
+    module Role
+      class FixBlankUser < Rules::Base
+
+        def description
+          "Fix blank user on Role"
+        end
+
+        def call
+          ids = ::Role.joins("LEFT OUTER JOIN users ON users.id = roles.user_id")
+                      .where(users: { id: nil }).ids
+          log("Destroying Roles without User: #{ids}")
+          ::Role.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/section/fix_blank_phase.rb
+++ b/lib/data_cleanup/rules/section/fix_blank_phase.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank phase on Section
+    module Section
+      class FixBlankPhase < Rules::Base
+
+        def description
+          "Fix blank phase on Section"
+        end
+
+        def call
+          ids = ::Section.joins("LEFT OUTER JOIN phases ON phases.id = sections.phase_id")
+                      .where(phases: { id: nil }).ids
+          log("Destroying Section without Phase: #{ids}")
+          ::Section.destroy(ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/data_cleanup/rules/template/fix_blank_locale.rb
+++ b/lib/data_cleanup/rules/template/fix_blank_locale.rb
@@ -8,7 +8,7 @@ module DataCleanup
         end
 
         def call
-          ids = ::Template.where(locale: nil).ids
+          ids = ::Template.where(locale: [nil, ""]).ids
           log("Setting locale to #{FastGettext.default_locale} for Templates #{ids}")
           ::Template.where(id: ids).update_all(locale: FastGettext.default_locale)
         end

--- a/lib/data_cleanup/rules/template/fix_blank_org.rb
+++ b/lib/data_cleanup/rules/template/fix_blank_org.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module DataCleanup
+  module Rules
+    # Fix blank org on Template
+    module Template
+      class FixBlankOrg < Rules::Base
+
+        def description
+          "Fix blank org on Template"
+        end
+
+        def call
+          ::Template.where("customization_of is not null and customization_of not in (?)", ::Template.all.pluck(:family_id)).each do |customization|
+            log("Setting customization_of to NULL for Template without matching family_id: #{ids}")
+            customization.update_attributes(customization_of: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/data_cleanup.rake
+++ b/lib/tasks/data_cleanup.rake
@@ -40,6 +40,16 @@ namespace :data_cleanup do
   task :find_known_invalidations => :environment do
     ## Annotation
 
+    # Find with blank question
+    results = Annotation.joins("LEFT OUTER JOIN questions ON questions.id = annotations.question_id")
+                        .where(questions: { id: nil })
+    report_known_invalidations(results, "Annotation", "missing question record")
+
+    # Find with blank org
+    results = Annotation.joins("LEFT OUTER JOIN orgs ON orgs.id = annotations.org_id")
+                        .where(orgs: { id: nil })
+    report_known_invalidations(results, "Annotation", "missing org record")
+
     # Find with blank text
     results = Annotation.where(text: [nil, ""])
     report_known_invalidations(results, "Annotation", "text is blank")
@@ -53,15 +63,20 @@ namespace :data_cleanup do
     ## Answer
 
     # Fix blank plan
-    blank_plans = Answer.where.not(plan_id: Plan.all.collect(&:id))
-    report_known_invalidations(blank_plans, "Answer", "plan is blank")
+    results = Answer.joins("LEFT OUTER JOIN plans ON plans.id = answers.plan_id")
+                    .where(plans: { id: nil })
+    report_known_invalidations(results, "Answer", "missing plan record")
+
+    # Fix blank question
+    results = Answer.joins("LEFT OUTER JOIN questions ON questions.id = answers.question_id")
+                    .where(questions: { id: nil })
+    report_known_invalidations(results, "Question", "missing question record")
 
     # Fix blank user
-    results = Answer.where.not(answers: {id: blank_plans})
-                    .joins("LEFT OUTER JOIN users ON users.id = answers.user_id")
+    results = Answer.joins("LEFT OUTER JOIN users ON users.id = answers.user_id")
                     .where(users: { id: nil })
                     .includes(plan: { roles: :user })
-    report_known_invalidations(results, "Answer", "user is blank")
+    report_known_invalidations(results, "Answer", "missing user record")
 
     # Fix duplicate question
     results = Answer.group(:question_id, :plan_id).count.select { |k,v| v > 1 }
@@ -73,7 +88,35 @@ namespace :data_cleanup do
     results = ExportedPlan
                 .joins("LEFT OUTER JOIN plans on plans.id = exported_plans.plan_id")
                 .where(plans: { id: nil })
-    report_known_invalidations(results, "ExportedPlan", "plan is blank")
+    report_known_invalidations(results, "ExportedPlan", "missing plan record")
+
+    ## GuidanceGroup
+
+    # Fix blank org
+    results = GuidanceGroup
+                .joins("LEFT OUTER JOIN orgs on orgs.id = guidance_groups.org_id")
+                .where(orgs: { id: nil })
+    report_known_invalidations(results, "GuidanceGroup", "missing org record")
+
+    ## Guidance
+
+    # Fix blank guidance_group
+    results = Guidance
+                .joins("LEFT OUTER JOIN guidance_groups on guidance_groups.id = guidances.guidance_group_id")
+                .where(guidance_groups: { id: nil })
+    report_known_invalidations(results, "Guidance", "missing guidance_group record")
+
+    ## Note
+
+    # Fix blank user
+    results = Note.joins("LEFT OUTER JOIN users on users.id = notes.user_id")
+                  .where(users: { id: nil })
+    report_known_invalidations(results, "Note", "missing user record")
+
+    # Fix blank answer
+    results = Note.joins("LEFT OUTER JOIN answers on answers.id = notes.answer_id")
+                  .where(answers: { id: nil })
+    report_known_invalidations(results, "Note", "missing answer record")
 
     ## Org
 
@@ -85,17 +128,32 @@ namespace :data_cleanup do
     results = Org.where(feedback_enabled: true, feedback_email_msg: [nil, ""])
     report_known_invalidations(results, "Org", "feedback_email_msg is blank")
 
+    # Fix blank feedback_email_subject
     results = Org.where(feedback_enabled: true, feedback_email_subject: [nil, ""])
     report_known_invalidations(results, "Org", "feedback_email_subject is blank")
 
+    # Fix blank language
     results = Org.where(language: [nil, ""])
     report_known_invalidations(results, "Org", "language is blank")
 
+    # Fix blank contact_email
     results = Org.where.not(contact_email: [nil, ""])
                  .select { |o| o.contact_email !~ /[\w\d\.\-]+@[\w\d\.\-]/ }
     report_known_invalidations(results, "Org", "contact_email is invalid")
 
+    ## OrgIdentifier
+
+    # Fix blank org
+    results = OrgIdentifier.joins("LEFT OUTER JOIN orgs on orgs.id = org_identifiers.org_id")
+                  .where(orgs: { id: nil })
+    report_known_invalidations(results, "OrgIdentifier", "missing org record")
+
     ## Phase
+
+    # Fix blank template
+    results = Phase.joins("LEFT OUTER JOIN templates on templates.id = phases.template_id")
+                  .where(templates: { id: nil })
+    report_known_invalidations(results, "Phase", "missing template record")
 
     # Fix duplicate number
     results = Phase.group(:number, :template_id).count.select { |k,v| v > 1 }
@@ -103,11 +161,33 @@ namespace :data_cleanup do
 
     ## Plan
 
+    # Fix blank template
+    results = Plan.joins("LEFT OUTER JOIN templates on templates.id = plans.template_id")
+                  .where(templates: { id: nil })
+    report_known_invalidations(results, "Plan", "missing template record")
+
     # Fix blank title
     results = Plan.where(title: [nil, ''])
     report_known_invalidations(results, "Plan", "title is blank")
 
+    ## Pref
+
+    # Fix blank user
+    results = Pref.joins("LEFT OUTER JOIN users on users.id = prefs.user_id")
+                  .where(users: { id: nil })
+    report_known_invalidations(results, "Pref", "missing user record")
+
     ## Question
+
+    # Fix blank section
+    results = Question.joins("LEFT OUTER JOIN sections on sections.id = questions.section_id")
+                  .where(sections: { id: nil })
+    report_known_invalidations(results, "Question", "missing section record")
+
+    # Fix blank question_format
+    results = Question.joins("LEFT OUTER JOIN question_formats on question_formats.id = questions.question_format_id")
+                  .where(question_formats: { id: nil })
+    report_known_invalidations(results, "Question", "missing question_format record")
 
     # Fix duplicate number
     results = Question.group(:number, :section_id).count.select { |k,v| v > 1 }
@@ -118,6 +198,13 @@ namespace :data_cleanup do
     # Fix blank description
     results = QuestionFormat.where(description: ["", nil])
     report_known_invalidations(results, "QuestionFormat", "description is blank")
+
+    ## QuestionOption
+
+    # Fix blank question
+    results = QuestionOption.joins("LEFT OUTER JOIN questions on questions.id = question_options.question_id")
+                  .where(questions: { id: nil })
+    report_known_invalidations(results, "QuestionOption", "missing question record")
 
     ## Region
 
@@ -130,20 +217,34 @@ namespace :data_cleanup do
     # Fix blank plan
     results = Role.joins("LEFT OUTER JOIN plans ON plans.id = roles.plan_id")
                   .where(plans: { id: nil })
-    report_known_invalidations(results, "Role", "plan is blank")
+    report_known_invalidations(results, "Role", "missing plan record")
 
     # Fix blank user
     results = Role.joins("LEFT OUTER JOIN users ON users.id = roles.user_id")
                   .where(users: { id: nil })
-    report_known_invalidations(results, "Role", "user is blank")
+    report_known_invalidations(results, "Role", "missing user record")
 
     ## Section
+
+    # Fix blank phase
+    results = Section.joins("LEFT OUTER JOIN phases ON phases.id = sections.phase_id")
+                  .where(phases: { id: nil })
+    report_known_invalidations(results, "Section", "missing phase record")
 
     # Fix duplicate number
     results = Section.group(:number, :phase_id).count.select { |k,v| v > 1 }
     report_known_invalidations(results, "Section", "number is duplicate")
 
     ## Template
+
+    # Fix blank org
+    results = Template.joins("LEFT OUTER JOIN orgs ON orgs.id = templates.org_id")
+                  .where(orgs: { id: nil })
+    report_known_invalidations(results, "Template", "missing org record")
+
+    # Fix blank customization_of
+    results = Template.where("customization_of is not null and customization_of not in (?)", Template.all.pluck(:family_id))
+    report_known_invalidations(results, "Template", "missing customization_of record")
 
     # Fix blank locale
     results = Template.where(locale: [nil, ""])
@@ -155,7 +256,7 @@ namespace :data_cleanup do
     results = UserIdentifier
                 .joins("LEFT OUTER JOIN users ON users.id = user_identifiers.user_id")
                 .where(users: { id: nil })
-    report_known_invalidations(results, "UserIdentifier", "user is blank")
+    report_known_invalidations(results, "UserIdentifier", "missing user record")
   end
 
   private

--- a/lib/tasks/data_cleanup.rake
+++ b/lib/tasks/data_cleanup.rake
@@ -132,6 +132,11 @@ namespace :data_cleanup do
                   .where(plans: { id: nil })
     report_known_invalidations(results, "Role", "plan is blank")
 
+    # Fix blank user
+    results = Role.joins("LEFT OUTER JOIN users ON users.id = roles.user_id")
+                  .where(users: { id: nil })
+    report_known_invalidations(results, "Role", "user is blank")
+
     ## Section
 
     # Fix duplicate number

--- a/lib/tasks/data_cleanup.rake
+++ b/lib/tasks/data_cleanup.rake
@@ -52,8 +52,13 @@ namespace :data_cleanup do
 
     ## Answer
 
+    # Fix blank plan
+    blank_plans = Answer.where.not(plan_id: Plan.all.collect(&:id))
+    report_known_invalidations(blank_plans, "Answer", "plan is blank")
+
     # Fix blank user
-    results = Answer.joins("LEFT OUTER JOIN users ON users.id = answers.user_id")
+    results = Answer.where.not(answers: {id: blank_plans})
+                    .joins("LEFT OUTER JOIN users ON users.id = answers.user_id")
                     .where(users: { id: nil })
                     .includes(plan: { roles: :user })
     report_known_invalidations(results, "Answer", "user is blank")

--- a/lib/tasks/stat.rake
+++ b/lib/tasks/stat.rake
@@ -1,4 +1,13 @@
 namespace :stat do
+
+  desc "Build all stats"
+  task build: :environment do
+    Rake::Task['stat:create:created_plan'].execute
+    Rake::Task['stat:create:joined_user'].execute
+    Rake::Task['stat:create_last_month:created_plan'].execute
+    Rake::Task['stat:create_last_month:joined_user'].execute
+  end
+
   namespace :create do
     desc "Creates created plan stats for every org since they joined"
     task created_plan: :environment do

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -5,6 +5,7 @@ namespace :upgrade do
   task v2_0_0: :environment do
     Rake::Task['upgrade:add_versioning_id_to_templates'].execute
     Rake::Task['upgrade:normalize_language_formats'].execute
+    Rake::Task['stat:build'].execute
   end
 
   desc "Upgrade to v1.1.2"

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -1,24 +1,10 @@
 require 'set'
 namespace :upgrade do
 
-  desc "Update Language abbreviations to use ISO format"
-  task :normalize_language_formats => :environment do
-    Language.all.each do |language|
-      language.update(abbreviation: LocaleFormatter.new(language.abbreviation))
-    end
-    Template.all.each do |template|
-      next if template.locale.blank?
-      template.update(locale: LocaleFormatter.new(template.locale))
-    end
-    Theme.all.each do |theme|
-      next if theme.locale.blank?
-      theme.update(locale: LocaleFormatter.new(theme.locale))
-    end
-  end
-
-  desc "Upgrade to v1.2.0"
-  task v1_2_0: :environment do
+  desc "Upgrade to v2.0.0"
+  task v2_0_0: :environment do
     Rake::Task['upgrade:add_versioning_id_to_templates'].execute
+    Rake::Task['upgrade:normalize_language_formats'].execute
   end
 
   desc "Upgrade to v1.1.2"
@@ -603,10 +589,22 @@ namespace :upgrade do
         end
       end
     end
-
   end
 
-
+  desc "Update Language abbreviations to use ISO format"
+  task :normalize_language_formats => :environment do
+    Language.all.each do |language|
+      language.update(abbreviation: LocaleFormatter.new(language.abbreviation))
+    end
+    Template.all.each do |template|
+      next if template.locale.blank?
+      template.update(locale: LocaleFormatter.new(template.locale))
+    end
+    Theme.all.each do |theme|
+      next if theme.locale.blank?
+      theme.update(locale: LocaleFormatter.new(theme.locale))
+    end
+  end
 
   private
 
@@ -623,6 +621,5 @@ namespace :upgrade do
       exit 1
     end
   end
-
 
 end


### PR DESCRIPTION
Some changes to improve the data cleanup scripts.

Changes proposed in this PR:
- Added check for Role who's user no longer exists
- Fixed issue with cleanup of Roles with a plan_id that no longer exists
- Updated all cleanups for blank fields so that they check for both nil and an empty string
- Fixed issue with check for Org abbreviation Yaml
- Added a high level `stat:build` task that runs other 4 tasks
- Added a new `upgrade:v2_0_0` rake task
- Reorganized the upgrade.rake file to move the locale task to the bottom with the other new tasks
- Added additional orphaned record checks that might be encountered by others