### PR TITLE
Added new find_known_invalidations and updated upgrade tasks

### DIFF
--- a/lib/tasks/data_cleanup.rake
+++ b/lib/tasks/data_cleanup.rake
@@ -36,227 +36,68 @@ namespace :data_cleanup do
     end
   end
 
-  desc "Check that each of the known type of invalidation is fixed."
+  desc "Check records for validation errors"
   task :find_known_invalidations => :environment do
-    ## Annotation
+    models.each do |model|
+      DataCleanup.display "Checking #{model.name} records"
+      if model.respond_to?(:_validate_callbacks)
+        model._validate_callbacks.to_a.collect(&:filter).each do |filter|
+          ids, msg   = [], ""
 
-    # Find with blank question
-    results = Annotation.joins("LEFT OUTER JOIN questions ON questions.id = annotations.question_id")
-                        .where(questions: { id: nil })
-    report_known_invalidations(results, "Annotation", "missing question record")
+          case filter.class.name
+          when 'ActiveRecord::Validations::PresenceValidator'
+            ids, msg = check_presence(model, filter)
 
-    # Find with blank org
-    results = Annotation.joins("LEFT OUTER JOIN orgs ON orgs.id = annotations.org_id")
-                        .where(orgs: { id: nil })
-    report_known_invalidations(results, "Annotation", "missing org record")
+          when "ActiveRecord::Validations::UniquenessValidator"
+            ids, msg = check_uniqueness(model, filter)
 
-    # Find with blank text
-    results = Annotation.where(text: [nil, ""])
-    report_known_invalidations(results, "Annotation", "text is blank")
+          when "ActiveModel::Validations::InclusionValidator"
+            ids, msg = check_inclusion(model, filter)
 
-    # Find with duplicate type
-    results = Annotation.group(:question_id, :type, :org_id)
-                .count
-                .select { |k,v| v > 1 }
-    report_known_invalidations(results, "Annotation", "type is a duplicate")
+          when "ActiveModel::Validations::FormatValidator"
+            ids, msg = check_format(model, filter)
 
-    ## Answer
+          when "ActiveModel::Validations::LengthValidator"
+            ids, msg = check_length(model, filter)
 
-    # Fix blank plan
-    results = Answer.joins("LEFT OUTER JOIN plans ON plans.id = answers.plan_id")
-                    .where(plans: { id: nil })
-    report_known_invalidations(results, "Answer", "missing plan record")
+          when "ActiveModel::Validations::NumericalityValidator"
+            ids, msg = check_numericality(model, filter)
 
-    # Fix blank question
-    results = Answer.joins("LEFT OUTER JOIN questions ON questions.id = answers.question_id")
-                    .where(questions: { id: nil })
-    report_known_invalidations(results, "Question", "missing question record")
+          when "ActiveModel::Validations::ConfirmationValidator"
+            # Skip
 
-    # Fix blank user
-    results = Answer.joins("LEFT OUTER JOIN users ON users.id = answers.user_id")
-                    .where(users: { id: nil })
-                    .includes(plan: { roles: :user })
-    report_known_invalidations(results, "Answer", "missing user record")
+          when "Dragonfly::Model::Validations::PropertyValidator"
+            # Skip
 
-    # Fix duplicate question
-    results = Answer.group(:question_id, :plan_id).count.select { |k,v| v > 1 }
-    report_known_invalidations(results, "Answer", "question is a duplicate")
+          when "Symbol"
+            # Skip
 
-    ## ExportedPlan
+          when "OrgLinksValidator"
+            ids, msg = check_local_validators(model, [:links], "OrgLinksValidator")
 
-    # Fix blank plan
-    results = ExportedPlan
-                .joins("LEFT OUTER JOIN plans on plans.id = exported_plans.plan_id")
-                .where(plans: { id: nil })
-    report_known_invalidations(results, "ExportedPlan", "missing plan record")
+          when "TemplateLinksValidator"
+            # Skip
+            ids, msg = check_local_validators(model, [:links], "TemplateLinksValidator")
 
-    ## GuidanceGroup
+          when "EmailValidator"
+            # Skip
+            ids, msg = check_local_validators(model, filter.attributes, "EmailValidator")
 
-    # Fix blank org
-    results = GuidanceGroup
-                .joins("LEFT OUTER JOIN orgs on orgs.id = guidance_groups.org_id")
-                .where(orgs: { id: nil })
-    report_known_invalidations(results, "GuidanceGroup", "missing org record")
+          when "AfterValidator"
+            # Skip
+            ids, msg = check_local_validators(model, filter.attributes, "AfterValidator")
 
-    ## Guidance
+          else
+            p "Unhandled validator type: #{filter.class.name}"
+            p filter.inspect
+          end
 
-    # Fix blank guidance_group
-    results = Guidance
-                .joins("LEFT OUTER JOIN guidance_groups on guidance_groups.id = guidances.guidance_group_id")
-                .where(guidance_groups: { id: nil })
-    report_known_invalidations(results, "Guidance", "missing guidance_group record")
-
-    ## Note
-
-    # Fix blank user
-    results = Note.joins("LEFT OUTER JOIN users on users.id = notes.user_id")
-                  .where(users: { id: nil })
-    report_known_invalidations(results, "Note", "missing user record")
-
-    # Fix blank answer
-    results = Note.joins("LEFT OUTER JOIN answers on answers.id = notes.answer_id")
-                  .where(answers: { id: nil })
-    report_known_invalidations(results, "Note", "missing answer record")
-
-    ## Org
-
-    # Fix blank abbreviation
-    results = Org.where(abbreviation: [nil, ""])
-    report_known_invalidations(results, "Org", "abbreviation is blank")
-
-    # Fix blank feedback_email_msg
-    results = Org.where(feedback_enabled: true, feedback_email_msg: [nil, ""])
-    report_known_invalidations(results, "Org", "feedback_email_msg is blank")
-
-    # Fix blank feedback_email_subject
-    results = Org.where(feedback_enabled: true, feedback_email_subject: [nil, ""])
-    report_known_invalidations(results, "Org", "feedback_email_subject is blank")
-
-    # Fix blank language
-    results = Org.where(language: [nil, ""])
-    report_known_invalidations(results, "Org", "language is blank")
-
-    # Fix blank contact_email
-    results = Org.where.not(contact_email: [nil, ""])
-                 .select { |o| o.contact_email !~ /[\w\d\.\-]+@[\w\d\.\-]/ }
-    report_known_invalidations(results, "Org", "contact_email is invalid")
-
-    ## OrgIdentifier
-
-    # Fix blank org
-    results = OrgIdentifier.joins("LEFT OUTER JOIN orgs on orgs.id = org_identifiers.org_id")
-                  .where(orgs: { id: nil })
-    report_known_invalidations(results, "OrgIdentifier", "missing org record")
-
-    ## Phase
-
-    # Fix blank template
-    results = Phase.joins("LEFT OUTER JOIN templates on templates.id = phases.template_id")
-                  .where(templates: { id: nil })
-    report_known_invalidations(results, "Phase", "missing template record")
-
-    # Fix duplicate number
-    results = Phase.group(:number, :template_id).count.select { |k,v| v > 1 }
-    report_known_invalidations(results, "Phase", "duplicate_number is invalid")
-
-    ## Plan
-
-    # Fix blank template
-    results = Plan.joins("LEFT OUTER JOIN templates on templates.id = plans.template_id")
-                  .where(templates: { id: nil })
-    report_known_invalidations(results, "Plan", "missing template record")
-
-    # Fix blank title
-    results = Plan.where(title: [nil, ''])
-    report_known_invalidations(results, "Plan", "title is blank")
-
-    ## Pref
-
-    # Fix blank user
-    results = Pref.joins("LEFT OUTER JOIN users on users.id = prefs.user_id")
-                  .where(users: { id: nil })
-    report_known_invalidations(results, "Pref", "missing user record")
-
-    ## Question
-
-    # Fix blank section
-    results = Question.joins("LEFT OUTER JOIN sections on sections.id = questions.section_id")
-                  .where(sections: { id: nil })
-    report_known_invalidations(results, "Question", "missing section record")
-
-    # Fix blank question_format
-    results = Question.joins("LEFT OUTER JOIN question_formats on question_formats.id = questions.question_format_id")
-                  .where(question_formats: { id: nil })
-    report_known_invalidations(results, "Question", "missing question_format record")
-
-    # Fix duplicate number
-    results = Question.group(:number, :section_id).count.select { |k,v| v > 1 }
-    report_known_invalidations(results, "Question", "number is duplicate")
-
-    ## QuestionFormat
-
-    # Fix blank description
-    results = QuestionFormat.where(description: ["", nil])
-    report_known_invalidations(results, "QuestionFormat", "description is blank")
-
-    ## QuestionOption
-
-    # Fix blank question
-    results = QuestionOption.joins("LEFT OUTER JOIN questions on questions.id = question_options.question_id")
-                  .where(questions: { id: nil })
-    report_known_invalidations(results, "QuestionOption", "missing question record")
-
-    ## Region
-
-    # Fix blank description
-    results = Region.where(description: ["", nil])
-    report_known_invalidations(results, "Region", "description is blank")
-
-    ## Role
-
-    # Fix blank plan
-    results = Role.joins("LEFT OUTER JOIN plans ON plans.id = roles.plan_id")
-                  .where(plans: { id: nil })
-    report_known_invalidations(results, "Role", "missing plan record")
-
-    # Fix blank user
-    results = Role.joins("LEFT OUTER JOIN users ON users.id = roles.user_id")
-                  .where(users: { id: nil })
-    report_known_invalidations(results, "Role", "missing user record")
-
-    ## Section
-
-    # Fix blank phase
-    results = Section.joins("LEFT OUTER JOIN phases ON phases.id = sections.phase_id")
-                  .where(phases: { id: nil })
-    report_known_invalidations(results, "Section", "missing phase record")
-
-    # Fix duplicate number
-    results = Section.group(:number, :phase_id).count.select { |k,v| v > 1 }
-    report_known_invalidations(results, "Section", "number is duplicate")
-
-    ## Template
-
-    # Fix blank org
-    results = Template.joins("LEFT OUTER JOIN orgs ON orgs.id = templates.org_id")
-                  .where(orgs: { id: nil })
-    report_known_invalidations(results, "Template", "missing org record")
-
-    # Fix blank customization_of
-    results = Template.where("customization_of is not null and customization_of not in (?)", Template.all.pluck(:family_id))
-    report_known_invalidations(results, "Template", "missing customization_of record")
-
-    # Fix blank locale
-    results = Template.where(locale: [nil, ""])
-    report_known_invalidations(results, "Template", "locale is blank")
-
-    ## UserIdentifier
-
-    # Fix blank user
-    results = UserIdentifier
-                .joins("LEFT OUTER JOIN users ON users.id = user_identifiers.user_id")
-                .where(users: { id: nil })
-    report_known_invalidations(results, "UserIdentifier", "missing user record")
+          if msg.present?
+            DataCleanup.display msg, color: ids.any? ? :red : :green
+          end
+        end
+      end
+    end
   end
 
   private
@@ -273,5 +114,152 @@ namespace :data_cleanup do
     Dir[Rails.root.join("app", "models", "*.rb")].map do |model_path|
       model_path.split("/").last.gsub(".rb", "").classify.constantize
     end.sort_by(&:name)
+  end
+
+  def singular?(value)
+    str = value.to_s
+    #p "#{str.pluralize} != #{str} && #{str.singularize} == #{str}"
+    str.pluralize != str && str.singularize == str
+  end
+
+  def check_presence(klass, filter)
+    table = klass.name.tableize
+    instance = klass.new
+    ids, msg = [], ""
+    filter.attributes.map(&:to_s).each do |attr|
+      join = attr.pluralize.tableize
+
+      # Determine if its an association so we can check for orphans
+      if models.map(&:name).include?(attr.camelize)
+        # Determine if the model is a child in the relationship
+        if singular?(attr)
+          ids = klass.joins("LEFT OUTER JOIN #{join} ON #{join}.id = #{table}.#{attr}_id")
+                         .where(join.to_sym => { id: nil })
+          msg = "  #{ids.count} orphaned records due to nil or missing #{attr}"
+        end
+
+      elsif instance.send(attr.to_sym).is_a?(ActiveRecord::Associations::CollectionProxy)
+        # If the instance is an association in the other direction just make sure
+        # it has children
+
+        # Skip this one becausue Guidance <--> Themes is a many to many join and this
+        # particular validation is handled elsewhere
+
+      else
+        unless attr == "password"
+          # Find any records where the field is blank or nil
+          ids = klass.where(attr.to_sym => [nil, ""])
+          msg = "  #{ids.count} records with a empty #{attr} field"
+        end
+      end
+    end
+    [ids, msg]
+  end
+
+  def check_uniqueness(klass, filter)
+    instance = klass.new
+    group = [filter.attributes.map{ |a| instance.respond_to?("#{a}_id") ? "#{a}_id".to_sym : a }]
+
+    if filter.options[:scope].present?
+      group << filter.options[:scope]
+    end
+    group = group.flatten.uniq
+    ids = klass.group(group).count.select{ |k, v| v > 1 }
+    [ids, "  #{ids.count} records that are not unique per (#{group.join(', ')})"]
+  end
+
+  def check_inclusion(klass, filter)
+    ids, msg = [], ""
+    if filter.options[:in].present?
+      filter.attributes.each do |attr|
+        ids << klass.where.not(attr.to_sym => filter.options[:in]).pluck(:id)
+      end
+      ids = ids.flatten.uniq
+      msg = "  #{ids.count} records that do not have a valid value for #{filter.attributes}, should be #{filter.options[:in]}"
+    end
+    [ids, msg]
+  end
+
+  def check_format(klass, filter)
+    ids = []
+    if filter.options[:with].present?
+      filter.attributes.each do |attr|
+        # skip password validaton since the field is encrypted through Devise
+        unless attr == :password
+          ids = klass.where.not(attr.to_sym => filter.options[:when]).pluck(:id)
+        end
+      end
+      ids = ids.flatten.uniq
+    end
+    [ids.flatten.uniq, "  #{ids.count} records that do not have valid #{filter.attributes}"]
+  end
+
+  def check_length(klass, filter)
+    ids = []
+    shoulda = ""
+    filter.attributes.each do |attr|
+      unless [:password, :logo].include?(attr)
+        qry = ""
+        if filter.options[:minimum].present?
+          qry += "CHAR_LENGTH(#{attr}) < #{filter.options[:minimum]}"
+          shoulda += ">= #{filter.options[:maximum]}"
+        end
+
+        if filter.options[:maximum].present?
+          unless qry.blank?
+            qry += " OR "
+            should += " and "
+          end
+          qry += "CHAR_LENGTH(#{attr}) > #{filter.options[:maximum]}"
+          shoulda += "<= #{filter.options[:maximum]}"
+        end
+
+        unless qry.blank?
+          ids << klass.where(qry).pluck(:id)
+        end
+      end
+    end
+    ids = ids.flatten.uniq
+    [ids, "  #{ids.count} records that are an invalid length for fields #{filter.attributes} should be #{shoulda}"]
+  end
+
+  def check_numericality(klass, filter)
+    filter.attributes.each do |attr|
+      qry = ""
+      shoulda = ""
+      if filter.options[:only_integer].present?
+        qry = "CEIL(#{attr}) != #{attr}"
+        shoulda = "been an integer"
+      end
+      if filter.options[:greater_than].present?
+        qry += qry.blank? ? "" : " OR "
+        shoulda += shoulda.blank? ? "" : " and "
+        qry += "#{attr} <= #{filter.options[:greater_than]}"
+        shoulda += " length > #{filter.options[:greater_than]}"
+      end
+      if filter.options[:less_than].present?
+        qry += qry.blank? ? "" : " OR "
+        shoulda += shoulda.blank? ? "" : " and "
+        qry += "#{attr} >= #{filter.options[:less_than]}"
+        shoulda += " length < #{filter.options[:less_than]}"
+      end
+
+      ids = klass.where(qry).pluck(:id)
+      [ids, "  #{ids.count} records that are an invalid #{filter.attributes} because it should #{shoulda}"]
+    end
+  end
+
+  def check_local_validators(klass, attributes, validator)
+    ids = []
+    klass.all.each do |org|
+      org.valid?
+      attributes.each do |attr|
+        unless org.errors[attr.to_sym].blank?
+          ids << org.id
+        end
+      end
+    end
+    ids = ids.flatten.uniq
+    [ids, "  #{ids.count} records that have an invalid #{attributes}. See the #{validator} for further details"]
   end
 end

--- a/lib/tasks/data_cleanup.rake
+++ b/lib/tasks/data_cleanup.rake
@@ -148,7 +148,11 @@ namespace :data_cleanup do
       else
         unless attr == "password"
           # Find any records where the field is blank or nil
-          ids = klass.where(attr.to_sym => [nil, ""])
+          if filter.options.present? && filter.options[:if].present?
+            ids = klass.where(attr.to_sym => [nil, ""]).select{ |r| r.send(filter.options[:if]) }.map(&:id)
+          else
+            ids = klass.where(attr.to_sym => [nil, ""])
+          end
           msg = "  #{ids.count} records with a empty #{attr} field"
         end
       end

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -5,7 +5,7 @@ namespace :upgrade do
   task v2_0_0_part_1: :environment do
     Rake::Task['upgrade:add_default_values_v2_0_0'].execute
     Rake::Task['db:migrate'].execute
-    Rake::Task['data_cleanup:find_invalid_records'].execute
+    Rake::Task['data_cleanup:find_known_invalidations'].execute
     puts "If any invalid records were reported above you will need to correct them before running part 2."
   end
 


### PR DESCRIPTION
1) Created a new Rake task, `upgrade:add_default_values_v2_0_0`,  that adds all new default values to fields that may no longer be NULL (e.g. `guidance_groups.optional_subset`

2) Replaced the `upgrade:find_known_invalidations` Rake task with one that runs through each model's attributes` validators and runs a corresponding SQL query to check their validity. (Checks the individual instance's `.valid?` for our homegrown validators due to them not providing enough info). This should be more inclusive than the old one and will hopefully remain relevant as changes occur in the future.

3) Broke `update:v2_0_0` Rake tasks into 2 parts. 
Part 1 `update:v2_0_0_part_1` does the following:
- Runs `upgrade:add_default_values_v2_0_0` 
- Runs `db:migrate`
- Runs `upgrade:find_known_invalidations` with a message afterward instructing the user to correct the issue before proceeding any further

Part 2 `update:v2_0_0_part_2` does the following:
- Runs `data_cleanup:clean_invalid_records` which will pick up any defined rules
- Runs `upgrade:add_versioning_id_to_templates` to populate the new versional_id fields
- Runs `upgrade:normalize_language_formats` to correct any ISO formatting issues
- Runs `stat:build` to build out the new Stats tables
