### PR TITLE
Remove unnecessary validator from OrgIdentifier model

### DIFF
--- a/app/models/org_identifier.rb
+++ b/app/models/org_identifier.rb
@@ -35,7 +35,7 @@ class OrgIdentifier < ActiveRecord::Base
                                                  message: UNIQUENESS_MESSAGE }
 
   validates :identifier, presence: { message: PRESENCE_MESSAGE },
-                         uniqueness: { message: UNIQUENESS_MESSAGE }
+                         uniqueness: { message: UNIQUENESS_MESSAGE, scope: org_id }
 
   validates :org, presence: { message: PRESENCE_MESSAGE }
 

--- a/app/models/org_identifier.rb
+++ b/app/models/org_identifier.rb
@@ -34,8 +34,7 @@ class OrgIdentifier < ActiveRecord::Base
   validates :identifier_scheme_id, uniqueness: { scope: :org_id,
                                                  message: UNIQUENESS_MESSAGE }
 
-  validates :identifier, presence: { message: PRESENCE_MESSAGE },
-                         uniqueness: { message: UNIQUENESS_MESSAGE, scope: org_id }
+  validates :identifier, presence: { message: PRESENCE_MESSAGE }
 
   validates :org, presence: { message: PRESENCE_MESSAGE }
 


### PR DESCRIPTION
Fixes #1934 

Discovered issue with OrgIdentifier validation when going through the output of the `data_cleanup:find_known_invalidations` task. The OrgIdentifier was checking for the unstopped uniqueness of the 'identifier' field. DMPTool has a scenario though where 2 institutions point to the same Shib IdP.

There was already a check for uniqueness against the identifier_scheme so the additional requirement on the identifier was not necessary. 