### PR TITLE
Rewrite tooltip for draggable sections

### DIFF
--- a/app/views/org_admin/phases/container.html.erb
+++ b/app/views/org_admin/phases/container.html.erb
@@ -59,7 +59,7 @@
                     <div class='text-right text-muted'>
                       <% if template.latest? && (modifiable || template.customization_of.present?) %>
                         <i class="fa fa-info-circle small"></i>
-                        <%= _("Drag arrows to rearrange customized sections.") %>
+                        <%= _("Drag arrows to rearrange sections.") %>
                         <% unless phase.sections.all?(&:modifiable?) %>
                           <%= _("You may place them before or after the main template sections.") %>
                         <% end %>


### PR DESCRIPTION
Fixes #1940  .

Changes proposed in this PR:
- Rewrite tooltip for draggable sections. Removed 'customized' completely (rather than adding a conditional) as this makes sense in both contexts.