### PR TITLE
added hidden field to plan_export_form, updated controller auth logic…

### DIFF
--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -7,20 +7,20 @@ class PlanExportsController < ApplicationController
   def show
     @plan = Plan.includes(:answers).find(params[:plan_id])
 
-    if publicly_authorized?
+    if privately_authorized? && export_params[:form].present?
+      @show_coversheet         = export_params[:project_details].present?
+      @show_sections_questions = export_params[:question_headings].present?
+      @show_unanswered         = export_params[:unanswered_questions].present?
+      @show_custom_sections    = export_params[:custom_sections].present?
+      @public_plan             = false
+
+    elsif publicly_authorized?
       skip_authorization
       @show_coversheet         = true
       @show_sections_questions = true
       @show_unanswered         = true
       @show_custom_sections    = true
       @public_plan             = true
-
-    elsif privately_authorized?
-      @show_coversheet         = export_params[:project_details].present?
-      @show_sections_questions = export_params[:question_headings].present?
-      @show_unanswered         = export_params[:unanswered_questions].present?
-      @show_custom_sections    = export_params[:custom_sections].present?
-      @public_plan             = false
 
     else
       raise Pundit::NotAuthorizedError

--- a/app/views/plans/_download_form.html.erb
+++ b/app/views/plans/_download_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_tag(plan_export_path(@plan), method: :get, target: '_blank', id: 'download_form') do |f| %>
   <h2><%= _("Download settings") %></h2>
-
+  <%= hidden_field_tag 'export[form]', true %>
   <% if @phase_options.length > 1 %>
     <div class="form-group">
       <%= label_tag(:phase_id, _("Select phase to download")) %>


### PR DESCRIPTION
Addresses separate issues in bottom comment of the issue.

Settings were not applying to owners of public plans as the auth overrode arguments in requests to export publically visible plans.
Added a hidden field to check if the request comes from the download form.
Allow users settings to apply if this form field is present