### PR TITLE
Added limitations to 'Other' org user's access

### DIFF
--- a/app/models/guidance_group.rb
+++ b/app/models/guidance_group.rb
@@ -65,7 +65,7 @@ class GuidanceGroup < ActiveRecord::Base
     where("name LIKE ?", search_pattern)
   }
 
-  scope :published, -> { where(published: true) }
+  scope :published, -> { where(published: true).joins(:org).where('orgs.is_other = ?', false) }
 
   # =================
   # = Class methods =

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -244,21 +244,24 @@ class User < ActiveRecord::Base
   #
   # Returns Boolean
   def can_grant_permissions?
-    perms.include? Perm.grant_permissions
+    perms.include?(Perm.grant_permissions) && !self.org.is_other
   end
 
   # Can the User modify organisation templates?
   #
   # Returns Boolean
   def can_modify_templates?
-    self.perms.include? Perm.modify_templates
+
+puts "HERE: #{!self.org.is_other} - #{self.org.abbreviation}"
+
+    self.perms.include?(Perm.modify_templates) && !self.org.is_other
   end
 
   # Can the User modify organisation guidance?
   #
   # Returns Boolean
   def can_modify_guidance?
-    perms.include? Perm.modify_guidance
+    perms.include?(Perm.modify_guidance) && !self.org.is_other
   end
 
   # Can the User use the API?
@@ -272,7 +275,7 @@ class User < ActiveRecord::Base
   #
   # Returns Boolean
   def can_modify_org_details?
-    perms.include? Perm.change_org_details
+    perms.include?(Perm.change_org_details) && !self.org.is_other
   end
 
   ##

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,14 +230,14 @@ class User < ActiveRecord::Base
   #
   # Returns Boolean
   def can_add_orgs?
-    perms.include? Perm.add_orgs
+    perms.include?(Perm.add_orgs) && !self.org.is_other
   end
 
   # Can the User change their organisation affiliations?
   #
   # Returns Boolean
   def can_change_org?
-    perms.include? Perm.change_affiliation
+    perms.include?(Perm.change_affiliation)
   end
 
   # Can the User can grant their permissions to others?
@@ -251,9 +251,6 @@ class User < ActiveRecord::Base
   #
   # Returns Boolean
   def can_modify_templates?
-
-puts "HERE: #{!self.org.is_other} - #{self.org.abbreviation}"
-
     self.perms.include?(Perm.modify_templates) && !self.org.is_other
   end
 
@@ -268,7 +265,7 @@ puts "HERE: #{!self.org.is_other} - #{self.org.abbreviation}"
   #
   # Returns Boolean
   def can_use_api?
-    perms.include? Perm.use_api
+    perms.include?(Perm.use_api) && !self.org.is_other
   end
 
   # Can the User modify their org's details?
@@ -283,7 +280,7 @@ puts "HERE: #{!self.org.is_other} - #{self.org.abbreviation}"
   #
   # Returns Boolean
   def can_grant_api_to_orgs?
-    perms.include? Perm.grant_api
+    perms.include?(Perm.grant_api) && !self.org.is_other
   end
 
   # Removes the api_token from the user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -398,11 +398,39 @@ RSpec.describe User, type: :model do
 
   end
 
+  describe "#can_add_orgs? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "add_organisations") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
+
+    subject { user.can_add_orgs? }
+
+    it { is_expected.to eq(false) }
+
+  end
+
   describe "#can_change_org?" do
 
     let!(:perms) { create_list(:perm, 1, name: "change_org_affiliation") }
 
     let!(:user) { create(:user, perms: perms) }
+
+    subject { user.can_change_org? }
+
+    it { is_expected.to eq(true) }
+
+  end
+
+  describe "#can_change_org? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "change_org_affiliation") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
 
     subject { user.can_change_org? }
 
@@ -422,6 +450,20 @@ RSpec.describe User, type: :model do
 
   end
 
+  describe "#can_grant_permissions? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "grant_permissions") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
+
+    subject { user.can_grant_permissions? }
+
+    it { is_expected.to eq(false) }
+
+  end
+
   describe "#can_modify_templates?" do
 
     let!(:perms) { create_list(:perm, 1, name: "modify_templates") }
@@ -431,6 +473,20 @@ RSpec.describe User, type: :model do
     subject { user.can_modify_templates? }
 
     it { is_expected.to eq(true) }
+
+  end
+
+  describe "#can_modify_templates? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "modify_templates") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
+
+    subject { user.can_modify_templates? }
+
+    it { is_expected.to eq(false) }
 
   end
 
@@ -446,6 +502,20 @@ RSpec.describe User, type: :model do
 
   end
 
+  describe "#can_modify_guidance? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "modify_guidance") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
+
+    subject { user.can_modify_guidance? }
+
+    it { is_expected.to eq(false) }
+
+  end
+
   describe "#can_use_api?" do
 
     let!(:perms) { create_list(:perm, 1, name: "use_api") }
@@ -455,6 +525,20 @@ RSpec.describe User, type: :model do
     subject { user.can_use_api? }
 
     it { is_expected.to eq(true) }
+
+  end
+
+  describe "#can_use_api? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "use_api") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
+
+    subject { user.can_use_api? }
+
+    it { is_expected.to eq(false) }
 
   end
 
@@ -470,6 +554,20 @@ RSpec.describe User, type: :model do
 
   end
 
+  describe "#can_modify_org_details? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "change_org_details") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
+
+    subject { user.can_modify_org_details? }
+
+    it { is_expected.to eq(false) }
+
+  end
+
   describe "#can_grant_api_to_orgs?" do
 
     let!(:perms) { create_list(:perm, 1, name: "grant_api_to_orgs") }
@@ -479,6 +577,20 @@ RSpec.describe User, type: :model do
     subject { user.can_grant_api_to_orgs? }
 
     it { is_expected.to eq(true) }
+
+  end
+
+  describe "#can_grant_api_to_orgs? when user associated with 'Other' Org" do
+
+    let!(:perms) { create_list(:perm, 1, name: "grant_api_to_orgs") }
+
+    let!(:org) { create(:org, is_other: true) }
+
+    let!(:user) { create(:user, perms: perms, org: org) }
+
+    subject { user.can_grant_api_to_orgs? }
+
+    it { is_expected.to eq(false) }
 
   end
 


### PR DESCRIPTION
Fixes #1935.

Changes proposed in this PR:
- Added additional where clause to `published` scope to exclude the `orgs.is_other` Org. Technically that org does not have admins and should never have guidance or templates. There are situations though where a Super Admin can switch to the 'other' org and still have access to the guidance page and is then able to create guidance. 
- Added additional checks to prevent users associated with the 'Other' Org from accessing the Template, Guidance and User Permissions endpoints. This should prevent the original issue from occurring in the first place.
