### PR TITLE
[1941] removed template_id argument from phases update

### DIFF
--- a/app/controllers/org_admin/phases_controller.rb
+++ b/app/controllers/org_admin/phases_controller.rb
@@ -172,7 +172,7 @@ module OrgAdmin
     private
 
     def phase_params
-      params.require(:phase).permit(:title, :description, :number, :template_id)
+      params.require(:phase).permit(:title, :description, :number)
     end
 
   end


### PR DESCRIPTION
this changes if template gets versioned so setting it from the page results in the server correctly rejecting the change.

I checked sections/questions but this seems to just affect the phase controller

