### PR TITLE
Alternate implimentation of 1935

### DIFF
--- a/app/models/concerns/validation_messages.rb
+++ b/app/models/concerns/validation_messages.rb
@@ -7,4 +7,11 @@ module ValidationMessages
 
   INCLUSION_MESSAGE = _("isn't a valid value")
 
+  # NOTE: if the logic for org.publishable changes, this must be changed
+  PUBLISHABLE_MESSAGE = _("cannot be true for default Org")
+
+  HISTORIC_MESSAGE = _("cannot be true for historic versions")
+
+
+
 end

--- a/app/models/concerns/validation_values.rb
+++ b/app/models/concerns/validation_values.rb
@@ -1,3 +1,4 @@
 module ValidationValues
   BOOLEAN_VALUES = [true, false].freeze
+  FALSE = [false].freeze
 end

--- a/app/models/guidance_group.rb
+++ b/app/models/guidance_group.rb
@@ -52,6 +52,8 @@ class GuidanceGroup < ActiveRecord::Base
   validates :published, inclusion: { in: BOOLEAN_VALUES,
                                      message: INCLUSION_MESSAGE }
 
+  validates :published, acceptance: {accept: false, message: PUBLISHABLE_MESSAGE },
+                        unless: :publishable?
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW
   #
@@ -66,6 +68,15 @@ class GuidanceGroup < ActiveRecord::Base
   }
 
   scope :published, -> { where(published: true) }
+
+
+  # Can this guidance group be published?
+  # Currently, publishability is solely an attribute of the org
+  #
+  # returns Boolean
+  def publishable?
+    org.can_publish?
+  end
 
   # =================
   # = Class methods =

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -213,6 +213,15 @@ class Org < ActiveRecord::Base
     self.token_permission_types << token_permission_type unless self.token_permission_types.include? token_permission_type
   end
 
+  # Can this org publish content?
+  # Currently, we are saying that all organisations, bar the other_org, can
+  # publish content (Guidance and Templates)
+  #
+  # returns Boolean
+  def can_publish?
+    !self.is_other
+  end
+
   private
 
   ##

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -88,6 +88,13 @@ class Template < ActiveRecord::Base
 
   validates :family_id, presence: { message: PRESENCE_MESSAGE }
 
+  validates :published, acceptance: { accept: false, message: PUBLISHABLE_MESSAGE },
+                        unless: :publishable?
+
+  validates :published, acceptance: { message: HISTORIC_MESSAGE },
+                        unless: :latest?
+
+
 
   # =============
   # = Callbacks =
@@ -328,6 +335,14 @@ class Template < ActiveRecord::Base
   def removable?
     versions = Template.includes(:plans).where(family_id: family_id)
     versions.reject { |version| version.plans.empty? }.empty?
+  end
+
+  # Can this guidance group be published?
+  # Currently, publishability is solely an attribute of the org
+  #
+  # returns Boolean
+  def publishable?
+    org.can_publish?
   end
 
   # Returns a new unpublished copy of self with a new family_id, version = zero

--- a/spec/models/guidance_group_spec.rb
+++ b/spec/models/guidance_group_spec.rb
@@ -10,11 +10,27 @@ RSpec.describe GuidanceGroup, type: :model do
 
     it { is_expected.to allow_value(true).for(:optional_subset)  }
 
-    it { is_expected.to allow_value(true).for(:published) }
-
     it { is_expected.to allow_value(false).for(:optional_subset)  }
 
-    it { is_expected.to allow_value(false).for(:published) }
+    context "publishable" do
+
+      before { subject.expects(:publishable?).returns(true) }
+
+      it { is_expected.to allow_value(true).for(:published) }
+
+      it { is_expected.to allow_value(false).for(:published) }
+
+    end
+
+    context "not publishable" do
+
+      before { subject.expects(:publishable?).returns(false) }
+
+      it { is_expected.to allow_value(false).for(:published) }
+
+      it { is_expected.not_to allow_value(true).for(:published) }
+
+    end
 
   end
 
@@ -23,6 +39,30 @@ RSpec.describe GuidanceGroup, type: :model do
     it { is_expected.to belong_to :org }
 
     it { is_expected.to have_many :guidances }
+
+  end
+
+  describe "#publishable?" do
+
+    let!(:guidance_group) { build(:guidance_group) }
+
+    subject { guidance_group.publishable? }
+
+    context "When org can publish" do
+
+      before { guidance_group.org.expects(:can_publish?).returns(true) }
+
+      it { is_expected.to eql(true) }
+
+    end
+
+    context "When org cannot publish" do
+
+      before { guidance_group.org.expects(:can_publish?).returns(false) }
+
+      it { is_expected.to eql(false) }
+
+    end
 
   end
 

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -5,7 +5,38 @@ RSpec.describe Template, type: :model do
   context "validations" do
     it { is_expected.to validate_presence_of(:title) }
 
-    it { is_expected.to allow_values(true, false).for(:published) }
+    context "org can publish" do
+
+      before { subject.org.expects(:can_publish?).returns(true) }
+
+      context "latest template" do
+        before { subject.expects(:latest?).returns(true) }
+
+        it { is_expected.to allow_values(true, false).for(:published) }
+
+      end
+
+      context "not latest template" do
+
+        before { subject.expects(:latest?).returns(false) }
+
+        it { is_expected.to allow_value(false).for(:published) }
+
+        it { is_expected.not_to allow_value(true).for(:published) }
+
+      end
+
+    end
+
+    context "org cannot publish" do
+
+      before { subject.org.expects(:can_publish?).returns(false) }
+
+      it { is_expected.to allow_value(false).for(:published) }
+
+      it { is_expected.not_to allow_value(true).for(:published) }
+
+    end
 
     # This is currently being set in the defaults before validation
     # it { is_expected.not_to allow_value(nil).for(:published) }
@@ -1360,6 +1391,31 @@ RSpec.describe Template, type: :model do
       it "raises an error" do
         expect { subject }.to raise_error(StandardError)
       end
+
+    end
+
+  end
+
+
+  describe "#publishable?" do
+
+    let!(:template) { build(:template) }
+
+    subject { template.publishable? }
+
+    context "When org can publish" do
+
+      before { template.org.expects(:can_publish?).returns(true) }
+
+      it { is_expected.to eql(true) }
+
+    end
+
+    context "When org cannot publish" do
+
+      before { template.org.expects(:can_publish?).returns(false) }
+
+      it { is_expected.to eql(false) }
 
     end
 


### PR DESCRIPTION
Taclking 1935 from the 'prevent data we dont want' angle rather than adding logic to filter out this unwanted data.  I think this approach will be easier to maintain in the long run.


- `publishable?` method added to template and guidance_group models
- `can_publish` method added in org model
- Conditional validations on the published field added to template and guidance to enforce false unless publishable.
- Change template publish controller action to be in line with the error reporting across the rest of the site.
- Push down controller logic on publishability of templates into model.
- Small improvement to unpublish query performance
