### PR TITLE
Added check to ensure that the model stems from ActiveRecord::Base in data_cleanup

### DIFF
--- a/lib/data_cleanup/model_check.rb
+++ b/lib/data_cleanup/model_check.rb
@@ -19,12 +19,14 @@ module DataCleanup
       when 'EXCLUDE'
         return if model.model_name.in?(models.split(","))
       end
-      DataCleanup.display "Checking #{model.model_name.plural}:"
-      model.find_in_batches do |batch|
-        instance_check = InstanceCheck.new
-        batch.each { |instance| instance_check.(instance) }
+      if model.ancestors.include?(ActiveRecord::Base)
+        DataCleanup.display "Checking #{model.model_name.plural}:"
+        model.find_in_batches do |batch|
+          instance_check = InstanceCheck.new
+          batch.each { |instance| instance_check.(instance) }
+        end
+        DataCleanup.display ""
       end
-      DataCleanup.display ""
     end
   end
 end


### PR DESCRIPTION
Discovered bug while running `data_cleanup.find_invalid_records` that was throwing an error for the SectionSorter object because it does not inherit from ActiveRecord::Base.

Added a simple check to make sure the model is an ActiveRecord object before checking its validity.