### PR TITLE
Refactor validation checking to exclude non-ARs

### DIFF
--- a/app/models/section_sorter.rb
+++ b/app/models/section_sorter.rb
@@ -72,11 +72,6 @@ class SectionSorter
     end
   end
 
-  # needed for the find_invalid_records rake task
-  def self.model_name
-    "SectionSorter"
-  end
-
   private
 
   def modifiable_values

--- a/lib/data_cleanup/model_check.rb
+++ b/lib/data_cleanup/model_check.rb
@@ -12,6 +12,7 @@ module DataCleanup
     end
 
     def call
+      return unless model.superclass == ActiveRecord::Base
       rule, models = ARGV[1].to_s.split("=")
       case rule
       when 'INCLUDE'


### PR DESCRIPTION
Minor update. Refactor DataCleanup code to only load ActiveRecord::Base subclasses, and ignore POROs.

Removed superfluous method in SectionSorter.