### PR TITLE
Translations for v2

### DIFF
--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -39,8 +39,7 @@ class OrgAdmin::PlansController < ApplicationController
       # rubocop:enable LineLength
     else
       redirect_to org_admin_plans_path,
-        alert: _("Unable to notify user that you have finished providing feedback."
-      )
+        alert: _("Unable to notify user that you have finished providing feedback.")
     end
   end
 

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -192,7 +192,8 @@ module OrgAdmin
       rescue ActiveSupport::JSON.parse_error
         render(json: {
           status: :bad_request,
-          msg: _("Error parsing links for a #{template_type(template)}")
+          msg: _("Error parsing links for a %{template}") %
+               { template: template_type(template) }
         })
         return
       rescue => e

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -117,20 +117,21 @@ module ExportablePlan
   def prepare_coversheet_for_csv(csv, headings, hash)
     csv << [ hash[:attribution].many? ?
              _("Creators: ") :
-             _("Creator:"), _(hash[:attribution].join(", ")) ]
-    csv << [ "Affiliation: ", _(hash[:affiliation]) ]
+             _("Creator:"), _("%{authors}") % { authors: hash[:attribution].join(", ") } ]
+    csv << [ "Affiliation: ", _("%{affiliation}") % { affiliation: hash[:affiliation] } ]
     if hash[:funder].present?
-      csv << [ _("Template: "), _(hash[:funder]) ]
+      csv << [ _("Template: "), _("%{funder}") % { funder: hash[:funder] } ]
     else
-      csv << [ _("Template: "), _(hash[:template] + hash[:customizer]) ]
+      csv << [ _("Template: "), _("%{template}") % { template: hash[:template] + hash[:customizer] } ]
     end
     if self.grant_number.present?
-      csv << [ _("Grant number: "), _(self.grant_number) ]
+      csv << [ _("Grant number: "), _("%{grant_number}") % { grant_number: self.grant_number } ]
     end
     if self.description.present?
-      csv << [ _("Project abstract: "), _(Nokogiri::HTML(self.description).text) ]
+      csv << [ _("Project abstract: "), _("%{description}") %
+               { description: Nokogiri::HTML(self.description).text } ]
     end
-    csv << [ _("Last modified: "), _(self.updated_at.to_date.strftime("%d-%m-%Y")) ]
+    csv << [ _("Last modified: "), _("%{date}") % { date: self.updated_at.to_date.strftime("%d-%m-%Y") } ]
     csv << [ _("Copyright information:"),
              _("The above plan creator(s) have agreed that others may use as
              much of the text of this plan as they would like in their own plans,

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -8,8 +8,8 @@
     <%= _('Hello %{user_email}') %{ :user_email => user_email } %>
   </p>
   <p>
-    <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
-            " their Data Management Plan in %{tool_name}") % {
+    <%= _("Your colleague %{inviter_name} has invited you to contribute to
+            their Data Management Plan in %{tool_name}") % {
       tool_name: tool_name,
       inviter_name: @inviter.name(false)
     } %>

--- a/config/locale/app.pot
+++ b/config/locale/app.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-03-12 16:41+0000\n"
-"PO-Revision-Date: 2018-06-20 16:23:24-0700\n"
+"PO-Revision-Date: 2018-10-19 11:10:54-0700\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -44,11 +44,19 @@ msgstr ""
 msgid "#{text}"
 msgstr ""
 
+#, fuzzy
+msgid "%{affiliation}"
+msgstr ""
+
 msgid "%{application_name}"
 msgstr ""
 
-msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#, fuzzy
+msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website <em class=\"sr-only\">(new window)</em></a>. If you would like to contact us about %{application_name}, please fill out the form below."
 msgstr ""
+
+#msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#msgstr ""
 
 msgid "%{application_name}: %{user_name} requested feedback on a plan"
 msgstr ""
@@ -59,13 +67,33 @@ msgstr ""
 msgid "%{application_name}: Your plan has been submitted for feedback"
 msgstr ""
 
+#, fuzzy
+msgid "%{authors}"
+msgstr ""
+
 msgid "%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don't want to accept the invitation, please ignore this email."
 msgstr ""
 
 msgid "%{commenter_name} has commented on the plan %{plan_title}. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
 msgstr ""
 
-msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgstr ""
+
+#, fuzzy
+msgid "%{date}"
+msgstr ""
+
+#, fuzzy
+msgid "%{description}"
+msgstr ""
+
+#, fuzzy
+msgid "%{funder}"
+msgstr ""
+
+#, fuzzy
+msgid "%{grant_number}"
 msgstr ""
 
 msgid "%{org_name} Plans"
@@ -80,8 +108,8 @@ msgstr ""
 msgid "%{org} Example Answer"
 msgstr ""
 
-msgid "%{org} Guidance"
-msgstr ""
+#msgid "%{org} Guidance"
+#msgstr ""
 
 msgid "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
 msgstr ""
@@ -89,7 +117,11 @@ msgstr ""
 msgid "%{plan_owner} has been notified that you have finished providing feedback"
 msgstr ""
 
-msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgstr ""
+
+#, fuzzy
+msgid "%{template}"
 msgstr ""
 
 msgid "%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}"
@@ -98,11 +130,11 @@ msgstr ""
 msgid "%{tool_name}: A new comment was added to %{plan_title}"
 msgstr ""
 
-msgid "%{username}'s profile"
-msgstr ""
+#msgid "%{username}'s profile"
+#msgstr ""
 
-msgid "%{value} is not a valid format"
-msgstr ""
+#msgid "%{value} is not a valid format"
+#msgstr ""
 
 msgid "'Download' allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application."
 msgstr ""
@@ -161,8 +193,13 @@ msgstr ""
 msgid "A Data Management Plan in %{application_name} has been shared with you"
 msgstr ""
 
-msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#, fuzzy
+msgid "A Data Management Plan in %{tool_name} has been shared \"\"
+"                   \"with you"
 msgstr ""
+
+#msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#msgstr ""
 
 msgid "A colleague has invited you to contribute to their Data Management Plan in %{tool_name}"
 msgstr ""
@@ -209,8 +246,8 @@ msgstr ""
 msgid "Access removed"
 msgstr ""
 
-msgid "Accessibility"
-msgstr ""
+#msgid "Accessibility"
+#msgstr ""
 
 msgid "Actions"
 msgstr ""
@@ -314,6 +351,10 @@ msgstr ""
 msgid "An error has occurred while saving/resetting your export settings."
 msgstr ""
 
+#, fuzzy
+msgid "An error occurred when requesting feedback for this plan."
+msgstr ""
+
 msgid "Annotations"
 msgstr ""
 
@@ -392,8 +433,13 @@ msgstr ""
 msgid "Begin typing to see a filtered list"
 msgstr ""
 
-msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#, fuzzy
+msgid "Below is a list of users registered for your organisation. You can"
+"        sort the data by each field."
 msgstr ""
+
+#msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#msgstr ""
 
 msgid "Body"
 msgstr ""
@@ -497,14 +543,14 @@ msgstr ""
 msgid "Copyright information:"
 msgstr ""
 
-msgid "Could not create your %{o}."
-msgstr ""
+#msgid "Could not create your %{o}."
+#msgstr ""
 
-msgid "Could not delete the %{o}."
-msgstr ""
+#msgid "Could not delete the %{o}."
+#msgstr ""
 
-msgid "Could not update your %{o}."
-msgstr ""
+#msgid "Could not update your %{o}."
+#msgstr ""
 
 msgid "Create Organisation"
 msgstr ""
@@ -548,13 +594,17 @@ msgstr ""
 msgid "Created date"
 msgstr ""
 
-msgid "Created using the %{application_name} service. Last modified %{date}"
-msgstr ""
+#msgid "Created using the %{application_name} service. Last modified %{date}"
+#msgstr ""
 
 msgid "Created using the %{application_name}. Last modified %{date}"
 msgstr ""
 
 msgid "Creator:"
+msgstr ""
+
+#, fuzzy
+msgid "Creators:"
 msgstr ""
 
 msgid "Creators: "
@@ -566,7 +616,23 @@ msgstr ""
 msgid "Current password"
 msgstr ""
 
+#, fuzzy
+msgid "Customisable Templates"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are published"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are unpublished"
+msgstr ""
+
 msgid "Customise"
+msgstr ""
+
+#, fuzzy
+msgid "Customise phase"
 msgstr ""
 
 msgid "Customising for your Organisation"
@@ -575,14 +641,14 @@ msgstr ""
 msgid "Customizable Templates"
 msgstr ""
 
-msgid "Customizations are published"
-msgstr ""
+#msgid "Customizations are published"
+#msgstr ""
 
-msgid "Customizations are unpublished"
-msgstr ""
+#msgid "Customizations are unpublished"
+#msgstr ""
 
-msgid "Customize phase"
-msgstr ""
+#msgid "Customize phase"
+#msgstr ""
 
 msgid "DMP Background"
 msgstr ""
@@ -599,7 +665,11 @@ msgstr ""
 msgid "DMPRoadmap ('the tool', 'the system"
 msgstr ""
 
-msgid "DOCX"
+#msgid "DOCX"
+#msgstr ""
+
+#, fuzzy
+msgid "DOCX <em class=\"sr-only\">(new window)</em>"
 msgstr ""
 
 msgid "Data Contact Person"
@@ -656,16 +726,36 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-msgid "Download Plan"
+#msgid "Download Plan"
+#msgstr ""
+
+#, fuzzy
+msgid "Download Plan <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
+msgid "Download global usage"
 msgstr ""
 
 msgid "Download plans"
 msgstr ""
 
+#, fuzzy
+msgid "Download plans <em class=\"sr-only\">(new window)</span>"
+msgstr ""
+
 msgid "Download settings"
 msgstr ""
 
+#, fuzzy
+msgid "Download users"
+msgstr ""
+
 msgid "Draft"
+msgstr ""
+
+#, fuzzy
+msgid "Drag arrows to rearrange sections."
 msgstr ""
 
 msgid "Edit"
@@ -674,8 +764,8 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-msgid "Edit Theme"
-msgstr ""
+#msgid "Edit Theme"
+#msgstr ""
 
 msgid "Edit User Privileges"
 msgstr ""
@@ -746,14 +836,18 @@ msgstr ""
 msgid "Enter your guidance here. You can include links where needed."
 msgstr ""
 
-msgid "Error parsing links for a #{template_type(template)}"
+#msgid "Error parsing links for a #{template_type(template)}"
+#msgstr ""
+
+#, fuzzy
+msgid "Error parsing links for a %{template}"
 msgstr ""
 
-msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
-msgstr ""
+#msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#msgstr ""
 
-msgid "Error raised while saving the visibility for plan id %{plan_id}"
-msgstr ""
+#msgid "Error raised while saving the visibility for plan id %{plan_id}"
+#msgstr ""
 
 msgid "Error:"
 msgstr ""
@@ -989,8 +1083,12 @@ msgstr ""
 msgid "Invalid maximum pages"
 msgstr ""
 
-msgid "Invitation to %{email} issued successfully. \n"
+#, fuzzy
+msgid "Invitation to %{email} issued successfully."
 msgstr ""
+
+#msgid "Invitation to %{email} issued successfully. \n"
+#msgstr ""
 
 msgid "Invite collaborators"
 msgstr ""
@@ -1115,14 +1213,18 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#, fuzzy
+msgid "New Notification"
+msgstr ""
+
 msgid "New Question"
 msgstr ""
 
 msgid "New Template"
 msgstr ""
 
-msgid "New Theme"
-msgstr ""
+#msgid "New Theme"
+#msgstr ""
 
 msgid "New notification"
 msgstr ""
@@ -1137,6 +1239,10 @@ msgid "New plans"
 msgstr ""
 
 msgid "New question:"
+msgstr ""
+
+#, fuzzy
+msgid "New theme"
 msgstr ""
 
 msgid "New users"
@@ -1211,11 +1317,11 @@ msgstr ""
 msgid "Notification Preferences"
 msgstr ""
 
-msgid "Notification created successfully"
-msgstr ""
+#msgid "Notification created successfully"
+#msgstr ""
 
-msgid "Notification updated successfully"
-msgstr ""
+#msgid "Notification updated successfully"
+#msgstr ""
 
 msgid "Notifications"
 msgstr ""
@@ -1331,6 +1437,10 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
+#, fuzzy
+msgid "PDF <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
 msgid "PDF formatting"
 msgstr ""
 
@@ -1370,8 +1480,8 @@ msgstr ""
 msgid "Plan Description"
 msgstr ""
 
-msgid "Plan Guidance Configuration"
-msgstr ""
+#msgid "Plan Guidance Configuration"
+#msgstr ""
 
 msgid "Plan ID"
 msgstr ""
@@ -1394,37 +1504,49 @@ msgstr ""
 msgid "Plans"
 msgstr ""
 
-msgid "Please check the box to continue."
-msgstr ""
+#msgid "Please check the box to continue."
+#msgstr ""
 
 msgid "Please choose an organisation"
 msgstr ""
 
-msgid "Please choose one of the options."
-msgstr ""
+#msgid "Please choose one of the options."
+#msgstr ""
 
 msgid "Please do not reply to this email."
 msgstr ""
 
-msgid "Please enter a First name."
+#msgid "Please enter a First name."
+#msgstr ""
+
+#, fuzzy
+msgid "Please enter a First name. "
 msgstr ""
 
-msgid "Please enter a Last name."
+#msgid "Please enter a Last name."
+#msgstr ""
+
+#, fuzzy
+msgid "Please enter a Last name. "
 msgstr ""
 
 msgid "Please enter a password confirmation"
 msgstr ""
 
-msgid "Please enter a valid number."
-msgstr ""
+#msgid "Please enter a valid number."
+#msgstr ""
 
-msgid "Please enter a valid value."
-msgstr ""
+#msgid "Please enter a valid value."
+#msgstr ""
 
 msgid "Please enter an email address"
 msgstr ""
 
-msgid "Please enter an email address."
+#msgid "Please enter an email address."
+#msgstr ""
+
+#, fuzzy
+msgid "Please enter an email address. "
 msgstr ""
 
 msgid "Please enter the name of your organisation"
@@ -1463,8 +1585,8 @@ msgstr ""
 msgid "Please select a valid research organisation from the list."
 msgstr ""
 
-msgid "Please select a value from the list."
-msgstr ""
+#msgid "Please select a value from the list."
+#msgstr ""
 
 msgid "Please select an item from the list."
 msgstr ""
@@ -1613,6 +1735,10 @@ msgstr ""
 msgid "Questions"
 msgstr ""
 
+#, fuzzy
+msgid "Re-order sections"
+msgstr ""
+
 msgid "Read only"
 msgstr ""
 
@@ -1637,7 +1763,11 @@ msgstr ""
 msgid "Remove this link"
 msgstr ""
 
-msgid "Request Expert Feedback - Automated Email:"
+#msgid "Request Expert Feedback - Automated Email:"
+#msgstr ""
+
+#, fuzzy
+msgid "Request Expert Feedback - Message Displayed on Share Plan Tab:"
 msgstr ""
 
 msgid "Request Feedback"
@@ -1664,6 +1794,12 @@ msgstr ""
 msgid "Run your own filter"
 msgstr ""
 
+#, fuzzy
+msgid "SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48"
+"       hours. If you have questions pertaining to this action please contact us"
+"       at %{organisation_email}."
+msgstr ""
+
 msgid "Same as Principal Investigator"
 msgstr ""
 
@@ -1679,7 +1815,11 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-msgid "Save Unsuccessful."
+#msgid "Save Unsuccessful."
+#msgstr ""
+
+#, fuzzy
+msgid "Save Unsuccessful. "
 msgstr ""
 
 msgid "Saving..."
@@ -1719,17 +1859,25 @@ msgstr ""
 msgid "Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s)."
 msgstr ""
 
+#, fuzzy
+msgid "Select Guidance"
+msgstr ""
+
 msgid "Select all"
 msgstr ""
 
 msgid "Select an organisation from the list."
 msgstr ""
 
+#, fuzzy
+msgid "Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+msgstr ""
+
 msgid "Select one or more themes that are relevant to this question. This will allow similarly themed organisation-level guidance to appear alongside your question."
 msgstr ""
 
-msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
-msgstr ""
+#msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+#msgstr ""
 
 msgid "Select phase to download"
 msgstr ""
@@ -1770,20 +1918,20 @@ msgstr ""
 msgid "Shibboleth Entity Id"
 msgstr ""
 
-msgid "Should be after start date"
-msgstr ""
+#msgid "Should be after start date"
+#msgstr ""
 
-msgid "Should be before expiration date"
-msgstr ""
+#msgid "Should be before expiration date"
+#msgstr ""
 
-msgid "Should be today or later"
-msgstr ""
+#msgid "Should be today or later"
+#msgstr ""
 
-msgid "Should be tomorrow or later"
-msgstr ""
+#msgid "Should be tomorrow or later"
+#msgstr ""
 
-msgid "Show"
-msgstr ""
+#msgid "Show"
+#msgstr ""
 
 msgid "Show password"
 msgstr ""
@@ -1812,6 +1960,10 @@ msgstr ""
 msgid "Someone has requested a link to change your %{tool_name} password. You can do this through the link below."
 msgstr ""
 
+#, fuzzy
+msgid "Sort by %{sort_field}"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
@@ -1830,18 +1982,22 @@ msgstr ""
 msgid "Successfully %{action} %{username}'s account."
 msgstr ""
 
-msgid "Successfully %{action} your %{object}."
+#, fuzzy
+msgid "Successfully %{action} the %{object}."
 msgstr ""
+
+#msgid "Successfully %{action} your %{object}."
+#msgstr ""
 
 #, fuzzy
 msgid "Successfully changed the permissions for #{@role.user.email}. They have been notified via email."
 msgstr ""
 
-msgid "Successfully deleted your theme"
-msgstr ""
+#msgid "Successfully deleted your theme"
+#msgstr ""
 
-msgid "Successfully destroyed your notification"
-msgstr ""
+#msgid "Successfully destroyed your notification"
+#msgstr ""
 
 msgid "Successfully signed in"
 msgstr ""
@@ -1852,8 +2008,8 @@ msgstr ""
 msgid "Successfully unpublished your #{template_type(template)}"
 msgstr ""
 
-msgid "Successfully updated %{username}"
-msgstr ""
+#msgid "Successfully updated %{username}"
+#msgstr ""
 
 msgid "Super Admin"
 msgstr ""
@@ -1924,6 +2080,15 @@ msgstr ""
 msgid "The Digital Curation Centre and UC3 team at the California Digital Library have developed and delivered tools for data management planning since the advent of open data policies in 2011. "
 msgstr ""
 
+#, fuzzy
+msgid "The above plan creator(s) have agreed that others may use as"
+"             much of the text of this plan as they would like in their own plans,"
+"             and customise it as necessary. You do not need to credit the creator(s)"
+"             as the source of the language used, but using any of the plan's text"
+"             does not imply that the creator(s) endorse, or have any relationship to,"
+"             your project or proposal"
+msgstr ""
+
 msgid "The current #{scheme.description} iD has been already linked to a user with email #{identifier.user.email}"
 msgstr ""
 
@@ -1945,11 +2110,11 @@ msgstr ""
 msgid "The new platform will be separate from the services each of our teams runs on top of it. Our shared goal: provide a combined DMPRoadmap platform as a core infrastructure for DMPs. Future enhancements will focus on making DMPs machine actionable so please continue sharing your use cases."
 msgstr ""
 
-msgid "The password must be between 8 and 128 characters."
-msgstr ""
+#msgid "The password must be between 8 and 128 characters."
+#msgstr ""
 
-msgid "The passwords must match."
-msgstr ""
+#msgid "The passwords must match."
+#msgstr ""
 
 msgid "The plan %{plan_title} had its visibility changed to %{plan_visibility}."
 msgstr ""
@@ -1972,17 +2137,17 @@ msgstr ""
 msgid "The table below lists the plans that you have created, and that have been shared with you by others. You can edit, share, download, make a copy, or remove these plans at any time."
 msgstr ""
 
-msgid "The theme with id %{id} could not be destroyed"
-msgstr ""
+#msgid "The theme with id %{id} could not be destroyed"
+#msgstr ""
 
 msgid "The ‘Share’ tab is also where you can set your plan visibility."
 msgstr ""
 
-msgid "Theme created successfully"
-msgstr ""
+#msgid "Theme created successfully"
+#msgstr ""
 
-msgid "Theme updated successfully"
-msgstr ""
+#msgid "Theme updated successfully"
+#msgstr ""
 
 msgid "Themes"
 msgstr ""
@@ -2014,8 +2179,8 @@ msgstr ""
 msgid "There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer"
 msgstr ""
 
-msgid "There is no theme associated with id %{id}"
-msgstr ""
+#msgid "There is no theme associated with id %{id}"
+#msgstr ""
 
 msgid "There may also be an option to request feedback on your plan. This is available when research support staff at your organisation have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
 msgstr ""
@@ -2023,8 +2188,8 @@ msgstr ""
 msgid "There seems to be a problem with your logo. Please upload it again."
 msgstr ""
 
-msgid "This allows you to order sections."
-msgstr ""
+#msgid "This allows you to order sections."
+#msgstr ""
 
 msgid "This allows you to order the phases of your template."
 msgstr ""
@@ -2110,6 +2275,10 @@ msgstr ""
 msgid "Unable to %{action} %{username}"
 msgstr ""
 
+#, fuzzy
+msgid "Unable to %{action} the %{object}.%{errors}"
+msgstr ""
+
 msgid "Unable to change the plan's status since it is needed at least %{percentage} percentage responded"
 msgstr ""
 
@@ -2119,10 +2288,18 @@ msgstr ""
 msgid "Unable to change your organisation affiliation at this time."
 msgstr ""
 
-msgid "Unable to create a new section because the phase you specified does not exist."
+#msgid "Unable to create a new section because the phase you specified does not exist."
+#msgstr ""
+
+#, fuzzy
+msgid "Unable to create a new section. The phase you specified does not exist."
 msgstr ""
 
 msgid "Unable to create a new version of this template."
+msgstr ""
+
+#, fuzzy
+msgid "Unable to create your account.#{errors_for_display(resource)}"
 msgstr ""
 
 msgid "Unable to customize that template."
@@ -2158,11 +2335,11 @@ msgstr ""
 msgid "Unable to remove the plan"
 msgstr ""
 
-msgid "Unable to save since notification parameter is missing"
-msgstr ""
+#msgid "Unable to save since notification parameter is missing"
+#msgstr ""
 
-msgid "Unable to save since theme parameter is missing"
-msgstr ""
+#msgid "Unable to save since theme parameter is missing"
+#msgstr ""
 
 msgid "Unable to submit your request"
 msgstr ""
@@ -2170,8 +2347,8 @@ msgstr ""
 msgid "Unable to submit your request for feedback at this time."
 msgstr ""
 
-msgid "Unable to transfer your customizations."
-msgstr ""
+#msgid "Unable to transfer your customizations."
+#msgstr ""
 
 msgid "Unable to unlink your account from %{is}."
 msgstr ""
@@ -2179,8 +2356,8 @@ msgstr ""
 msgid "Unable to unpublish your #{template_type(template)}."
 msgstr ""
 
-msgid "Unable to update %{username}"
-msgstr ""
+#msgid "Unable to update %{username}"
+#msgstr ""
 
 msgid "Unknown"
 msgstr ""
@@ -2242,8 +2419,8 @@ msgstr ""
 msgid "User accounts"
 msgstr ""
 
-msgid "User not found."
-msgstr ""
+#msgid "User not found."
+#msgstr ""
 
 msgid "Users"
 msgstr ""
@@ -2260,6 +2437,10 @@ msgstr ""
 msgid "View all guidance"
 msgstr ""
 
+#, fuzzy
+msgid "View all notifications"
+msgstr ""
+
 msgid "View all organisations"
 msgstr ""
 
@@ -2267,6 +2448,10 @@ msgid "View all search results"
 msgstr ""
 
 msgid "View all templates"
+msgstr ""
+
+#, fuzzy
+msgid "View all themes"
 msgstr ""
 
 msgid "View all users"
@@ -2293,8 +2478,8 @@ msgstr ""
 msgid "We invite you to peruse the DMPRoadmap GitHub wiki to learn how to "
 msgstr ""
 
-msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
-msgstr ""
+#msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
+#msgstr ""
 
 msgid "We will hold the personal data you provided us for as long as you continue using the %{application_name} service. Your personal data can be removed from this service upon request to the %{application_name} team within a period of 30 days."
 msgstr ""
@@ -2425,16 +2610,28 @@ msgstr ""
 msgid "You may change your notification preferences on your profile page."
 msgstr ""
 
+#, fuzzy
+msgid "You may change your notification preferences on your profile page. "
+msgstr ""
+
+#, fuzzy
+msgid "You may place them before or after the main template sections."
+msgstr ""
+
 msgid "You must accept the terms and conditions to register."
 msgstr ""
 
-msgid "You must agree to the term and conditions."
-msgstr ""
+#msgid "You must agree to the term and conditions."
+#msgstr ""
 
-msgid "You must enter a valid URL (e.g. https://organisation.org)."
-msgstr ""
+#msgid "You must enter a valid URL (e.g. https://organisation.org)."
+#msgstr ""
 
-msgid "You must enter a valid email address."
+#msgid "You must enter a valid email address."
+#msgstr ""
+
+#, fuzzy
+msgid "You must provide a valid email address and select a permission level."
 msgstr ""
 
 msgid "You must select a funder from the list or click the checkbox."
@@ -2485,6 +2682,11 @@ msgstr ""
 msgid "Your account has been successfully linked to your institutional credentials. You will now be able to sign in with them."
 msgstr ""
 
+#, fuzzy
+msgid "Your colleague %{inviter_name} has invited you to contribute to"
+"            their Data Management Plan in %{tool_name}"
+msgstr ""
+
 msgid "Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change."
 msgstr ""
 
@@ -2515,8 +2717,8 @@ msgstr ""
 msgid "Your project is now a test."
 msgstr ""
 
-msgid "Your request for feedback has been submitted."
-msgstr ""
+#msgid "Your request for feedback has been submitted."
+#msgstr ""
 
 msgid "account has been locked due to an excessive number of unsuccessful sign in attempts."
 msgstr ""
@@ -2560,8 +2762,8 @@ msgstr ""
 msgid "can't be less than zero"
 msgstr ""
 
-msgid "changed"
-msgstr ""
+#msgid "changed"
+#msgstr ""
 
 msgid "co-owner"
 msgstr ""
@@ -2576,6 +2778,14 @@ msgid "completed_plans"
 msgstr ""
 
 msgid "copied"
+msgstr ""
+
+#, fuzzy
+msgid "copy"
+msgstr ""
+
+#, fuzzy
+msgid "create"
 msgstr ""
 
 msgid "created"
@@ -2594,6 +2804,10 @@ msgid "deactivate"
 msgstr ""
 
 msgid "deactivated"
+msgstr ""
+
+#, fuzzy
+msgid "delete"
 msgstr ""
 
 msgid "deleted"
@@ -2617,8 +2831,12 @@ msgstr ""
 msgid "generate_version! requires a published template"
 msgstr ""
 
-msgid "guidance"
+#, fuzzy
+msgid "get involved<em class=\"sr-only\"> (new window)</em>"
 msgstr ""
+
+#msgid "guidance"
+#msgstr ""
 
 msgid "guidance group"
 msgstr ""
@@ -2629,6 +2847,10 @@ msgstr ""
 msgid "into your browser"
 msgstr ""
 
+#, fuzzy
+msgid "isn't a valid value"
+msgstr ""
+
 msgid "locals should be a Hash object"
 msgstr ""
 
@@ -2636,6 +2858,10 @@ msgid "logo"
 msgstr ""
 
 msgid "mock project for testing, practice, or educational purposes"
+msgstr ""
+
+#, fuzzy
+msgid "must be after %{date}"
 msgstr ""
 
 msgid "must be logged in"
@@ -2653,8 +2879,8 @@ msgstr ""
 msgid "must have access to plans api"
 msgstr ""
 
-msgid "note"
-msgstr ""
+#msgid "note"
+#msgstr ""
 
 msgid "obj should be a Phase, Section, Question, or Annotation"
 msgstr ""
@@ -2680,23 +2906,27 @@ msgstr ""
 msgid "page for guidance."
 msgstr ""
 
-msgid "password"
-msgstr ""
+#msgid "password"
+#msgstr ""
 
 msgid "path_params should be a Hash object"
 msgstr ""
 
-msgid "permissions"
+#, fuzzy
+msgid "permission"
 msgstr ""
 
-msgid "phase"
-msgstr ""
+#msgid "permissions"
+#msgstr ""
+
+#msgid "phase"
+#msgstr ""
 
 msgid "plan"
 msgstr ""
 
-msgid "plan's visibility"
-msgstr ""
+#msgid "plan's visibility"
+#msgstr ""
 
 msgid "plans"
 msgstr ""
@@ -2710,10 +2940,18 @@ msgstr ""
 msgid "profile"
 msgstr ""
 
+#, fuzzy
+msgid "profile for %{username}"
+msgstr ""
+
 msgid "project details coversheet"
 msgstr ""
 
 msgid "public"
+msgstr ""
+
+#, fuzzy
+msgid "publish"
 msgstr ""
 
 msgid "query_params should be a Hash object"
@@ -2737,13 +2975,21 @@ msgstr ""
 msgid "read-only"
 msgstr ""
 
+#, fuzzy
+msgid "remove"
+msgstr ""
+
 msgid "removed"
 msgstr ""
 
 msgid "reviewer"
 msgstr ""
 
-msgid "role"
+#msgid "role"
+#msgstr ""
+
+#, fuzzy
+msgid "save"
 msgstr ""
 
 msgid "saved"
@@ -2782,11 +3028,23 @@ msgstr ""
 msgid "unanswered questions"
 msgstr ""
 
+#, fuzzy
+msgid "unpublish"
+msgstr ""
+
+#, fuzzy
+msgid "update"
+msgstr ""
+
 msgid "updated"
 msgstr ""
 
-msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#, fuzzy
+msgid "upgrade cannot be carried out since there is no published template of its current funder"
 msgstr ""
+
+#msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#msgstr ""
 
 msgid "upgrade_customization! requires a customised template"
 msgstr ""

--- a/config/locale/de/app.po
+++ b/config/locale/de/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2018-06-20 16:23:24-0700\n"
+"PO-Revision-Date: 2018-10-19 11:10:55-0700\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -49,12 +49,19 @@ msgstr ""
 msgid "#{text}"
 msgstr ""
 
+#, fuzzy
+msgid "%{affiliation}"
+msgstr ""
+
 msgid "%{application_name}"
 msgstr "DMPonline"
 
 #, fuzzy
-msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
-msgstr "DMPonline"
+msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website <em class=\"sr-only\">(new window)</em></a>. If you would like to contact us about %{application_name}, please fill out the form below."
+msgstr ""
+
+#msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#msgstr "DMPonline"
 
 #, fuzzy
 msgid "%{application_name}: %{user_name} requested feedback on a plan"
@@ -69,6 +76,10 @@ msgid "%{application_name}: Your plan has been submitted for feedback"
 msgstr "DMPonline"
 
 #, fuzzy
+msgid "%{authors}"
+msgstr ""
+
+#, fuzzy
 msgid "%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don't want to accept the invitation, please ignore this email."
 msgstr "(or copy"
 
@@ -76,9 +87,24 @@ msgstr "(or copy"
 msgid "%{commenter_name} has commented on the plan %{plan_title}. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
 msgstr "Kommentar"
 
+#msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgstr "Kommentar"
+
 #, fuzzy
-msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
-msgstr "Kommentar"
+msgid "%{date}"
+msgstr ""
+
+#, fuzzy
+msgid "%{description}"
+msgstr ""
+
+#, fuzzy
+msgid "%{funder}"
+msgstr ""
+
+#, fuzzy
+msgid "%{grant_number}"
+msgstr ""
 
 #, fuzzy
 msgid "%{org_name} Plans"
@@ -96,9 +122,8 @@ msgstr "plans"
 msgid "%{org} Example Answer"
 msgstr "Beispielantwort"
 
-#, fuzzy
-msgid "%{org} Guidance"
-msgstr "Hilfestellung"
+#msgid "%{org} Guidance"
+#msgstr "Hilfestellung"
 
 #, fuzzy
 msgid "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
@@ -107,9 +132,12 @@ msgstr "Frage"
 msgid "%{plan_owner} has been notified that you have finished providing feedback"
 msgstr "plans"
 
+#msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgstr "DMPonline"
+
 #, fuzzy
-msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
-msgstr "DMPonline"
+msgid "%{template}"
+msgstr ""
 
 #, fuzzy
 msgid "%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}"
@@ -119,12 +147,11 @@ msgstr "plans"
 msgid "%{tool_name}: A new comment was added to %{plan_title}"
 msgstr "Kommentar"
 
-#, fuzzy
-msgid "%{username}'s profile"
-msgstr "user"
+#msgid "%{username}'s profile"
+#msgstr "user"
 
-msgid "%{value} is not a valid format"
-msgstr ""
+#msgid "%{value} is not a valid format"
+#msgstr ""
 
 #, fuzzy
 msgid "'Download' allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application."
@@ -194,8 +221,12 @@ msgid "A Data Management Plan in %{application_name} has been shared with you"
 msgstr "DMPonline"
 
 #, fuzzy
-msgid "A Data Management Plan in %{tool_name} has been shared with you"
-msgstr "DMPonline"
+msgid "A Data Management Plan in %{tool_name} has been shared \"\"
+"                   \"with you"
+msgstr ""
+
+#msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#msgstr "DMPonline"
 
 #, fuzzy
 msgid "A colleague has invited you to contribute to their Data Management Plan in %{tool_name}"
@@ -247,8 +278,8 @@ msgstr "Über DMPonline"
 msgid "Access removed"
 msgstr ""
 
-msgid "Accessibility"
-msgstr ""
+#msgid "Accessibility"
+#msgstr ""
 
 msgid "Actions"
 msgstr "Aktionen"
@@ -373,6 +404,10 @@ msgstr "Organisation"
 msgid "An error has occurred while saving/resetting your export settings."
 msgstr ""
 
+#, fuzzy
+msgid "An error occurred when requesting feedback for this plan."
+msgstr ""
+
 msgid "Annotations"
 msgstr ""
 
@@ -467,8 +502,13 @@ msgstr "Fragen"
 msgid "Begin typing to see a filtered list"
 msgstr ""
 
-msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
-msgstr "Folgend findet sich die Liste von Benutzern registriert bzgl. Ihrer Org. Sie können diese Liste bzgl. aller Felder sortieren."
+#, fuzzy
+msgid "Below is a list of users registered for your organisation. You can"
+"        sort the data by each field."
+msgstr ""
+
+#msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#msgstr "Folgend findet sich die Liste von Benutzern registriert bzgl. Ihrer Org. Sie können diese Liste bzgl. aller Felder sortieren."
 
 msgid "Body"
 msgstr ""
@@ -590,17 +630,14 @@ msgstr "templates"
 msgid "Copyright information:"
 msgstr ""
 
-#, fuzzy
-msgid "Could not create your %{o}."
-msgstr ""
+#msgid "Could not create your %{o}."
+#msgstr ""
 
-#, fuzzy
-msgid "Could not delete the %{o}."
-msgstr ""
+#msgid "Could not delete the %{o}."
+#msgstr ""
 
-#, fuzzy
-msgid "Could not update your %{o}."
-msgstr ""
+#msgid "Could not update your %{o}."
+#msgstr ""
 
 #, fuzzy
 msgid "Create Organisation"
@@ -652,15 +689,18 @@ msgstr "Angelegt am"
 msgid "Created date"
 msgstr "Angelegt am"
 
-#, fuzzy
-msgid "Created using the %{application_name} service. Last modified %{date}"
-msgstr "DMPonline"
+#msgid "Created using the %{application_name} service. Last modified %{date}"
+#msgstr "DMPonline"
 
 #, fuzzy
 msgid "Created using the %{application_name}. Last modified %{date}"
 msgstr "DMPonline"
 
 msgid "Creator:"
+msgstr ""
+
+#, fuzzy
+msgid "Creators:"
 msgstr ""
 
 msgid "Creators: "
@@ -672,8 +712,24 @@ msgstr ""
 msgid "Current password"
 msgstr "Aktuelles Passwort"
 
+#, fuzzy
+msgid "Customisable Templates"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are published"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are unpublished"
+msgstr ""
+
 msgid "Customise"
 msgstr "Anpassen"
+
+#, fuzzy
+msgid "Customise phase"
+msgstr ""
 
 #, fuzzy
 msgid "Customising for your Organisation"
@@ -683,15 +739,14 @@ msgstr "Organisation"
 msgid "Customizable Templates"
 msgstr "Vorlagen"
 
-msgid "Customizations are published"
-msgstr ""
+#msgid "Customizations are published"
+#msgstr ""
 
-msgid "Customizations are unpublished"
-msgstr ""
+#msgid "Customizations are unpublished"
+#msgstr ""
 
-#, fuzzy
-msgid "Customize phase"
-msgstr "Phase"
+#msgid "Customize phase"
+#msgstr "Phase"
 
 #, fuzzy
 msgid "DMP Background"
@@ -712,7 +767,11 @@ msgstr ""
 msgid "DMPRoadmap ('the tool', 'the system"
 msgstr ""
 
-msgid "DOCX"
+#msgid "DOCX"
+#msgstr ""
+
+#, fuzzy
+msgid "DOCX <em class=\"sr-only\">(new window)</em>"
 msgstr ""
 
 msgid "Data Contact Person"
@@ -772,18 +831,37 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
+#msgid "Download Plan"
+#msgstr "plans"
+
 #, fuzzy
-msgid "Download Plan"
-msgstr "plans"
+msgid "Download Plan <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
+msgid "Download global usage"
+msgstr ""
 
 #, fuzzy
 msgid "Download plans"
 msgstr "plans"
 
+#, fuzzy
+msgid "Download plans <em class=\"sr-only\">(new window)</span>"
+msgstr ""
+
 msgid "Download settings"
 msgstr ""
 
+#, fuzzy
+msgid "Download users"
+msgstr ""
+
 msgid "Draft"
+msgstr ""
+
+#, fuzzy
+msgid "Drag arrows to rearrange sections."
 msgstr ""
 
 msgid "Edit"
@@ -793,9 +871,8 @@ msgstr "Bearbeiten"
 msgid "Edit Profile"
 msgstr "Profil bearbeiten"
 
-#, fuzzy
-msgid "Edit Theme"
-msgstr "Bearbeiten"
+#msgid "Edit Theme"
+#msgstr "Bearbeiten"
 
 msgid "Edit User Privileges"
 msgstr "Bearbeiten Benutzerberechtigungen"
@@ -877,16 +954,18 @@ msgstr "Geben Sie spezifische Hilfestellung an, die diese Frage begleiten soll. 
 msgid "Enter your guidance here. You can include links where needed."
 msgstr "Hilfestellung hier eingeben; Verweise auf andere Web-Seiten können integriert werden."
 
-#, fuzzy
-msgid "Error parsing links for a #{template_type(template)}"
-msgstr "templates"
+#msgid "Error parsing links for a #{template_type(template)}"
+#msgstr "templates"
 
-msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#, fuzzy
+msgid "Error parsing links for a %{template}"
 msgstr ""
 
-#, fuzzy
-msgid "Error raised while saving the visibility for plan id %{plan_id}"
-msgstr "plans"
+#msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#msgstr ""
+
+#msgid "Error raised while saving the visibility for plan id %{plan_id}"
+#msgstr "plans"
 
 msgid "Error:"
 msgstr ""
@@ -1158,8 +1237,11 @@ msgid "Invalid maximum pages"
 msgstr "Ungültige maximale Anzahl von Seiten"
 
 #, fuzzy
-msgid "Invitation to %{email} issued successfully. \n"
+msgid "Invitation to %{email} issued successfully."
 msgstr ""
+
+#msgid "Invitation to %{email} issued successfully. \n"
+#msgstr ""
 
 msgid "Invite collaborators"
 msgstr ""
@@ -1303,6 +1385,10 @@ msgid "Name"
 msgstr "Name"
 
 #, fuzzy
+msgid "New Notification"
+msgstr ""
+
+#, fuzzy
 msgid "New Question"
 msgstr "Frage"
 
@@ -1310,8 +1396,8 @@ msgstr "Frage"
 msgid "New Template"
 msgstr "Neue Vorlage"
 
-msgid "New Theme"
-msgstr ""
+#msgid "New Theme"
+#msgstr ""
 
 msgid "New notification"
 msgstr ""
@@ -1330,6 +1416,10 @@ msgstr "plans"
 #, fuzzy
 msgid "New question:"
 msgstr "Frage"
+
+#, fuzzy
+msgid "New theme"
+msgstr ""
 
 #, fuzzy
 msgid "New users"
@@ -1419,12 +1509,11 @@ msgstr "Kommentar"
 msgid "Notification Preferences"
 msgstr ""
 
-#, fuzzy
-msgid "Notification created successfully"
-msgstr "Erstellt"
+#msgid "Notification created successfully"
+#msgstr "Erstellt"
 
-msgid "Notification updated successfully"
-msgstr ""
+#msgid "Notification updated successfully"
+#msgstr ""
 
 msgid "Notifications"
 msgstr ""
@@ -1571,6 +1660,10 @@ msgid "PDF"
 msgstr ""
 
 #, fuzzy
+msgid "PDF <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
 msgid "PDF formatting"
 msgstr "PDF Formatierung"
 
@@ -1616,9 +1709,8 @@ msgstr "Kontakt für Planen"
 msgid "Plan Description"
 msgstr "Beschreibung"
 
-#, fuzzy
-msgid "Plan Guidance Configuration"
-msgstr "Hilfestellung"
+#msgid "Plan Guidance Configuration"
+#msgstr "Hilfestellung"
 
 msgid "Plan ID"
 msgstr "Planenbezeichner"
@@ -1643,44 +1735,51 @@ msgstr ""
 msgid "Plans"
 msgstr "plans"
 
-msgid "Please check the box to continue."
-msgstr ""
+#msgid "Please check the box to continue."
+#msgstr ""
 
 #, fuzzy
 msgid "Please choose an organisation"
 msgstr "Organisation"
 
-msgid "Please choose one of the options."
-msgstr ""
+#msgid "Please choose one of the options."
+#msgstr ""
 
 msgid "Please do not reply to this email."
 msgstr ""
 
-#, fuzzy
-msgid "Please enter a First name."
-msgstr "Bitte geben Sie ihren Vornamen ein."
+#msgid "Please enter a First name."
+#msgstr "Bitte geben Sie ihren Vornamen ein."
 
 #, fuzzy
-msgid "Please enter a Last name."
-msgstr "Bitte geben Sie ihren Vornamen ein."
+msgid "Please enter a First name. "
+msgstr ""
+
+#msgid "Please enter a Last name."
+#msgstr "Bitte geben Sie ihren Vornamen ein."
+
+#, fuzzy
+msgid "Please enter a Last name. "
+msgstr ""
 
 msgid "Please enter a password confirmation"
 msgstr ""
 
-#, fuzzy
-msgid "Please enter a valid number."
-msgstr "Bitte geben Sie ihren Vornamen ein."
+#msgid "Please enter a valid number."
+#msgstr "Bitte geben Sie ihren Vornamen ein."
 
-#, fuzzy
-msgid "Please enter a valid value."
-msgstr "Bitte geben Sie ihren Vornamen ein."
+#msgid "Please enter a valid value."
+#msgstr "Bitte geben Sie ihren Vornamen ein."
 
 msgid "Please enter an email address"
 msgstr ""
 
+#msgid "Please enter an email address."
+#msgstr "Bitte prüfen Sie die Korrektheit ihrer Web-Adresse."
+
 #, fuzzy
-msgid "Please enter an email address."
-msgstr "Bitte prüfen Sie die Korrektheit ihrer Web-Adresse."
+msgid "Please enter an email address. "
+msgstr ""
 
 #, fuzzy
 msgid "Please enter the name of your organisation"
@@ -1725,8 +1824,8 @@ msgstr "Organisation"
 msgid "Please select a valid research organisation from the list."
 msgstr "Organisation"
 
-msgid "Please select a value from the list."
-msgstr ""
+#msgid "Please select a value from the list."
+#msgstr ""
 
 msgid "Please select an item from the list."
 msgstr ""
@@ -1900,6 +1999,10 @@ msgstr "Fragentext"
 msgid "Questions"
 msgstr "Fragen"
 
+#, fuzzy
+msgid "Re-order sections"
+msgstr ""
+
 msgid "Read only"
 msgstr "Nur Lesen"
 
@@ -1929,9 +2032,12 @@ msgstr "Entfernen"
 msgid "Remove this link"
 msgstr "Entfernen"
 
+#msgid "Request Expert Feedback - Automated Email:"
+#msgstr "E-Mail"
+
 #, fuzzy
-msgid "Request Expert Feedback - Automated Email:"
-msgstr "E-Mail"
+msgid "Request Expert Feedback - Message Displayed on Share Plan Tab:"
+msgstr ""
 
 msgid "Request Feedback"
 msgstr ""
@@ -1960,6 +2066,12 @@ msgid "Run your own filter"
 msgstr ""
 
 #, fuzzy
+msgid "SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48"
+"       hours. If you have questions pertaining to this action please contact us"
+"       at %{organisation_email}."
+msgstr ""
+
+#, fuzzy
 msgid "Same as Principal Investigator"
 msgstr ""
 
@@ -1978,9 +2090,12 @@ msgstr "Organisation"
 msgid "Save"
 msgstr "Speichern"
 
+#msgid "Save Unsuccessful."
+#msgstr "Speichern"
+
 #, fuzzy
-msgid "Save Unsuccessful."
-msgstr "Speichern"
+msgid "Save Unsuccessful. "
+msgstr ""
 
 msgid "Saving..."
 msgstr "Speichere..."
@@ -2023,6 +2138,10 @@ msgstr ""
 msgid "Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s)."
 msgstr "Anpassungen bearbeiten"
 
+#, fuzzy
+msgid "Select Guidance"
+msgstr ""
+
 msgid "Select all"
 msgstr ""
 
@@ -2031,12 +2150,15 @@ msgid "Select an organisation from the list."
 msgstr "Organisation"
 
 #, fuzzy
+msgid "Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+msgstr ""
+
+#, fuzzy
 msgid "Select one or more themes that are relevant to this question. This will allow similarly themed organisation-level guidance to appear alongside your question."
 msgstr "Organisation"
 
-#, fuzzy
-msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
-msgstr ""
+#msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+#msgstr ""
 
 #, fuzzy
 msgid "Select phase to download"
@@ -2084,20 +2206,20 @@ msgstr ""
 msgid "Shibboleth Entity Id"
 msgstr ""
 
-msgid "Should be after start date"
-msgstr ""
+#msgid "Should be after start date"
+#msgstr ""
 
-msgid "Should be before expiration date"
-msgstr ""
+#msgid "Should be before expiration date"
+#msgstr ""
 
-msgid "Should be today or later"
-msgstr ""
+#msgid "Should be today or later"
+#msgstr ""
 
-msgid "Should be tomorrow or later"
-msgstr ""
+#msgid "Should be tomorrow or later"
+#msgstr ""
 
-msgid "Show"
-msgstr ""
+#msgid "Show"
+#msgstr ""
 
 #, fuzzy
 msgid "Show password"
@@ -2134,6 +2256,10 @@ msgid "Someone has requested a link to change your %{tool_name} password. You ca
 msgstr "password. You can do this through the link below."
 
 #, fuzzy
+msgid "Sort by %{sort_field}"
+msgstr ""
+
+#, fuzzy
 msgid "Start"
 msgstr "Teilen"
 
@@ -2154,19 +2280,21 @@ msgid "Successfully %{action} %{username}'s account."
 msgstr "user"
 
 #, fuzzy
-msgid "Successfully %{action} your %{object}."
+msgid "Successfully %{action} the %{object}."
 msgstr ""
+
+#msgid "Successfully %{action} your %{object}."
+#msgstr ""
 
 #, fuzzy
 msgid "Successfully changed the permissions for #{@role.user.email}. They have been notified via email."
 msgstr ""
 
-#, fuzzy
-msgid "Successfully deleted your theme"
-msgstr "Löschen"
+#msgid "Successfully deleted your theme"
+#msgstr "Löschen"
 
-msgid "Successfully destroyed your notification"
-msgstr ""
+#msgid "Successfully destroyed your notification"
+#msgstr ""
 
 msgid "Successfully signed in"
 msgstr ""
@@ -2178,9 +2306,8 @@ msgstr ""
 msgid "Successfully unpublished your #{template_type(template)}"
 msgstr "templates"
 
-#, fuzzy
-msgid "Successfully updated %{username}"
-msgstr "user"
+#msgid "Successfully updated %{username}"
+#msgstr "user"
 
 msgid "Super Admin"
 msgstr ""
@@ -2265,6 +2392,15 @@ msgid "The Digital Curation Centre and UC3 team at the California Digital Librar
 msgstr "am"
 
 #, fuzzy
+msgid "The above plan creator(s) have agreed that others may use as"
+"             much of the text of this plan as they would like in their own plans,"
+"             and customise it as necessary. You do not need to credit the creator(s)"
+"             as the source of the language used, but using any of the plan's text"
+"             does not imply that the creator(s) endorse, or have any relationship to,"
+"             your project or proposal"
+msgstr ""
+
+#, fuzzy
 msgid "The current #{scheme.description} iD has been already linked to a user with email #{identifier.user.email}"
 msgstr "user"
 
@@ -2289,13 +2425,11 @@ msgstr ""
 msgid "The new platform will be separate from the services each of our teams runs on top of it. Our shared goal: provide a combined DMPRoadmap platform as a core infrastructure for DMPs. Future enhancements will focus on making DMPs machine actionable so please continue sharing your use cases."
 msgstr "am"
 
-#, fuzzy
-msgid "The password must be between 8 and 128 characters."
-msgstr "Passwort"
+#msgid "The password must be between 8 and 128 characters."
+#msgstr "Passwort"
 
-#, fuzzy
-msgid "The passwords must match."
-msgstr "Passwort"
+#msgid "The passwords must match."
+#msgstr "Passwort"
 
 #, fuzzy
 msgid "The plan %{plan_title} had its visibility changed to %{plan_visibility}."
@@ -2323,19 +2457,18 @@ msgstr "Organisation"
 msgid "The table below lists the plans that you have created, and that have been shared with you by others. You can edit, share, download, make a copy, or remove these plans at any time."
 msgstr "Erstellt"
 
-msgid "The theme with id %{id} could not be destroyed"
-msgstr ""
+#msgid "The theme with id %{id} could not be destroyed"
+#msgstr ""
 
 #, fuzzy
 msgid "The ‘Share’ tab is also where you can set your plan visibility."
 msgstr ""
 
-#, fuzzy
-msgid "Theme created successfully"
-msgstr "Erstellt"
+#msgid "Theme created successfully"
+#msgstr "Erstellt"
 
-msgid "Theme updated successfully"
-msgstr ""
+#msgid "Theme updated successfully"
+#msgstr ""
 
 msgid "Themes"
 msgstr "Themen"
@@ -2375,8 +2508,8 @@ msgstr "plans"
 msgid "There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer"
 msgstr ""
 
-msgid "There is no theme associated with id %{id}"
-msgstr ""
+#msgid "There is no theme associated with id %{id}"
+#msgstr ""
 
 #, fuzzy
 msgid "There may also be an option to request feedback on your plan. This is available when research support staff at your organisation have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
@@ -2385,8 +2518,8 @@ msgstr ""
 msgid "There seems to be a problem with your logo. Please upload it again."
 msgstr "Es scheint ein Problem mit unserem Logo zu sein. Bitte laden Sie es erneut."
 
-msgid "This allows you to order sections."
-msgstr "Hier können Sie die Reihenfolge der Abschnitte bestimmen."
+#msgid "This allows you to order sections."
+#msgstr "Hier können Sie die Reihenfolge der Abschnitte bestimmen."
 
 msgid "This allows you to order the phases of your template."
 msgstr "Hier können sie die Abfolge der Phasen in Ihrer Vorlage bestimmen."
@@ -2491,6 +2624,10 @@ msgid "Unable to %{action} %{username}"
 msgstr "user"
 
 #, fuzzy
+msgid "Unable to %{action} the %{object}.%{errors}"
+msgstr ""
+
+#, fuzzy
 msgid "Unable to change the plan's status since it is needed at least %{percentage} percentage responded"
 msgstr "plans"
 
@@ -2502,13 +2639,20 @@ msgstr "plans"
 msgid "Unable to change your organisation affiliation at this time."
 msgstr "Organisation"
 
+#msgid "Unable to create a new section because the phase you specified does not exist."
+#msgstr "Abschnitt"
+
 #, fuzzy
-msgid "Unable to create a new section because the phase you specified does not exist."
-msgstr "Abschnitt"
+msgid "Unable to create a new section. The phase you specified does not exist."
+msgstr ""
 
 #, fuzzy
 msgid "Unable to create a new version of this template."
 msgstr "templates"
+
+#, fuzzy
+msgid "Unable to create your account.#{errors_for_display(resource)}"
+msgstr ""
 
 #, fuzzy
 msgid "Unable to customize that template."
@@ -2553,11 +2697,11 @@ msgstr "templates"
 msgid "Unable to remove the plan"
 msgstr "plans"
 
-msgid "Unable to save since notification parameter is missing"
-msgstr ""
+#msgid "Unable to save since notification parameter is missing"
+#msgstr ""
 
-msgid "Unable to save since theme parameter is missing"
-msgstr ""
+#msgid "Unable to save since theme parameter is missing"
+#msgstr ""
 
 msgid "Unable to submit your request"
 msgstr ""
@@ -2565,8 +2709,8 @@ msgstr ""
 msgid "Unable to submit your request for feedback at this time."
 msgstr ""
 
-msgid "Unable to transfer your customizations."
-msgstr ""
+#msgid "Unable to transfer your customizations."
+#msgstr ""
 
 msgid "Unable to unlink your account from %{is}."
 msgstr ""
@@ -2575,9 +2719,8 @@ msgstr ""
 msgid "Unable to unpublish your #{template_type(template)}."
 msgstr "templates"
 
-#, fuzzy
-msgid "Unable to update %{username}"
-msgstr "user"
+#msgid "Unable to update %{username}"
+#msgstr "user"
 
 msgid "Unknown"
 msgstr ""
@@ -2649,8 +2792,8 @@ msgstr "Organisation"
 msgid "User accounts"
 msgstr ""
 
-msgid "User not found."
-msgstr ""
+#msgid "User not found."
+#msgstr ""
 
 msgid "Users"
 msgstr "Nutzer"
@@ -2669,6 +2812,10 @@ msgid "View all guidance"
 msgstr "Alle Hilfestellungen ansehen"
 
 #, fuzzy
+msgid "View all notifications"
+msgstr ""
+
+#, fuzzy
 msgid "View all organisations"
 msgstr "Organisation"
 
@@ -2678,6 +2825,10 @@ msgstr "Ansicht"
 
 msgid "View all templates"
 msgstr "Alle Vorlagen ansehen"
+
+#, fuzzy
+msgid "View all themes"
+msgstr ""
 
 #, fuzzy
 msgid "View all users"
@@ -2709,9 +2860,8 @@ msgstr "templates"
 msgid "We invite you to peruse the DMPRoadmap GitHub wiki to learn how to "
 msgstr ""
 
-#, fuzzy
-msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
-msgstr ""
+#msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
+#msgstr ""
 
 #, fuzzy
 msgid "We will hold the personal data you provided us for as long as you continue using the %{application_name} service. Your personal data can be removed from this service upon request to the %{application_name} team within a period of 30 days."
@@ -2868,19 +3018,29 @@ msgstr "Aktionen"
 msgid "You may change your notification preferences on your profile page."
 msgstr ""
 
+#, fuzzy
+msgid "You may change your notification preferences on your profile page. "
+msgstr ""
+
+#, fuzzy
+msgid "You may place them before or after the main template sections."
+msgstr ""
+
 msgid "You must accept the terms and conditions to register."
 msgstr ""
 
+#msgid "You must agree to the term and conditions."
+#msgstr ""
+
+#msgid "You must enter a valid URL (e.g. https://organisation.org)."
+#msgstr "Organisation"
+
+#msgid "You must enter a valid email address."
+#msgstr "Bitte geben Sie eine gültige E-Mail-Adresse an."
+
 #, fuzzy
-msgid "You must agree to the term and conditions."
+msgid "You must provide a valid email address and select a permission level."
 msgstr ""
-
-#, fuzzy
-msgid "You must enter a valid URL (e.g. https://organisation.org)."
-msgstr "Organisation"
-
-msgid "You must enter a valid email address."
-msgstr "Bitte geben Sie eine gültige E-Mail-Adresse an."
 
 #, fuzzy
 msgid "You must select a funder from the list or click the checkbox."
@@ -2945,6 +3105,11 @@ msgid "Your account has been successfully linked to your institutional credentia
 msgstr "Your "
 
 #, fuzzy
+msgid "Your colleague %{inviter_name} has invited you to contribute to"
+"            their Data Management Plan in %{tool_name}"
+msgstr ""
+
+#, fuzzy
 msgid "Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change."
 msgstr "Passwort"
 
@@ -2984,9 +3149,8 @@ msgstr "plans"
 msgid "Your project is now a test."
 msgstr "Your "
 
-#, fuzzy
-msgid "Your request for feedback has been submitted."
-msgstr "Your "
+#msgid "Your request for feedback has been submitted."
+#msgstr "Your "
 
 #, fuzzy
 msgid "account has been locked due to an excessive number of unsuccessful sign in attempts."
@@ -3038,8 +3202,8 @@ msgstr ""
 msgid "can't be less than zero"
 msgstr ""
 
-msgid "changed"
-msgstr ""
+#msgid "changed"
+#msgstr ""
 
 #, fuzzy
 msgid "co-owner"
@@ -3057,6 +3221,14 @@ msgid "completed_plans"
 msgstr ""
 
 msgid "copied"
+msgstr ""
+
+#, fuzzy
+msgid "copy"
+msgstr ""
+
+#, fuzzy
+msgid "create"
 msgstr ""
 
 #, fuzzy
@@ -3079,6 +3251,10 @@ msgid "deactivate"
 msgstr ""
 
 msgid "deactivated"
+msgstr ""
+
+#, fuzzy
+msgid "delete"
 msgstr ""
 
 #, fuzzy
@@ -3107,8 +3283,12 @@ msgstr "Organisation"
 msgid "generate_version! requires a published template"
 msgstr "templates"
 
-msgid "guidance"
+#, fuzzy
+msgid "get involved<em class=\"sr-only\"> (new window)</em>"
 msgstr ""
+
+#msgid "guidance"
+#msgstr ""
 
 #, fuzzy
 msgid "guidance group"
@@ -3121,6 +3301,10 @@ msgstr ""
 msgid "into your browser"
 msgstr "into your browser)."
 
+#, fuzzy
+msgid "isn't a valid value"
+msgstr ""
+
 msgid "locals should be a Hash object"
 msgstr ""
 
@@ -3130,6 +3314,10 @@ msgstr ""
 
 #, fuzzy
 msgid "mock project for testing, practice, or educational purposes"
+msgstr ""
+
+#, fuzzy
+msgid "must be after %{date}"
 msgstr ""
 
 #, fuzzy
@@ -3150,9 +3338,8 @@ msgstr "guidances"
 msgid "must have access to plans api"
 msgstr "guidances"
 
-#, fuzzy
-msgid "note"
-msgstr "Kommentar"
+#msgid "note"
+#msgstr "Kommentar"
 
 #, fuzzy
 msgid "obj should be a Phase, Section, Question, or Annotation"
@@ -3183,28 +3370,28 @@ msgstr "Organisation"
 msgid "page for guidance."
 msgstr ""
 
-#, fuzzy
-msgid "password"
-msgstr "Passwort"
+#msgid "password"
+#msgstr "Passwort"
 
 msgid "path_params should be a Hash object"
 msgstr ""
 
 #, fuzzy
-msgid "permissions"
-msgstr "Zugriffsrechte"
+msgid "permission"
+msgstr ""
 
-#, fuzzy
-msgid "phase"
-msgstr "Phase"
+#msgid "permissions"
+#msgstr "Zugriffsrechte"
+
+#msgid "phase"
+#msgstr "Phase"
 
 #, fuzzy
 msgid "plan"
 msgstr "plans"
 
-#, fuzzy
-msgid "plan's visibility"
-msgstr "Sichtweite"
+#msgid "plan's visibility"
+#msgstr "Sichtweite"
 
 #, fuzzy
 msgid "plans"
@@ -3221,10 +3408,18 @@ msgid "profile"
 msgstr ""
 
 #, fuzzy
+msgid "profile for %{username}"
+msgstr ""
+
+#, fuzzy
 msgid "project details coversheet"
 msgstr ""
 
 msgid "public"
+msgstr ""
+
+#, fuzzy
+msgid "publish"
 msgstr ""
 
 msgid "query_params should be a Hash object"
@@ -3255,6 +3450,10 @@ msgid "read-only"
 msgstr "Nur Lesen"
 
 #, fuzzy
+msgid "remove"
+msgstr ""
+
+#, fuzzy
 msgid "removed"
 msgstr "Entfernen"
 
@@ -3262,9 +3461,12 @@ msgstr "Entfernen"
 msgid "reviewer"
 msgstr "Vorschau"
 
+#msgid "role"
+#msgstr "Rolle"
+
 #, fuzzy
-msgid "role"
-msgstr "Rolle"
+msgid "save"
+msgstr ""
 
 #, fuzzy
 msgid "saved"
@@ -3313,12 +3515,23 @@ msgid "unanswered questions"
 msgstr ""
 
 #, fuzzy
+msgid "unpublish"
+msgstr ""
+
+#, fuzzy
+msgid "update"
+msgstr ""
+
+#, fuzzy
 msgid "updated"
 msgstr "Bearbeiten"
 
 #, fuzzy
-msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
-msgstr "templates"
+msgid "upgrade cannot be carried out since there is no published template of its current funder"
+msgstr ""
+
+#msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#msgstr "templates"
 
 #, fuzzy
 msgid "upgrade_customization! requires a customised template"

--- a/config/locale/en_GB/app.po
+++ b/config/locale/en_GB/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2018-06-20 16:23:24-0700\n"
+"PO-Revision-Date: 2018-10-19 11:10:54-0700\n"
 "Last-Translator: Brian Riley brian.riley@ucop.edu\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en_GB\n"
@@ -43,11 +43,19 @@ msgstr ""
 msgid "#{text}"
 msgstr ""
 
+#, fuzzy
+msgid "%{affiliation}"
+msgstr ""
+
 msgid "%{application_name}"
 msgstr ""
 
-msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#, fuzzy
+msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website <em class=\"sr-only\">(new window)</em></a>. If you would like to contact us about %{application_name}, please fill out the form below."
 msgstr ""
+
+#msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#msgstr ""
 
 msgid "%{application_name}: %{user_name} requested feedback on a plan"
 msgstr ""
@@ -58,13 +66,33 @@ msgstr ""
 msgid "%{application_name}: Your plan has been submitted for feedback"
 msgstr ""
 
+#, fuzzy
+msgid "%{authors}"
+msgstr ""
+
 msgid "%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don't want to accept the invitation, please ignore this email."
 msgstr ""
 
 msgid "%{commenter_name} has commented on the plan %{plan_title}. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
 msgstr ""
 
-msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgstr ""
+
+#, fuzzy
+msgid "%{date}"
+msgstr ""
+
+#, fuzzy
+msgid "%{description}"
+msgstr ""
+
+#, fuzzy
+msgid "%{funder}"
+msgstr ""
+
+#, fuzzy
+msgid "%{grant_number}"
 msgstr ""
 
 msgid "%{org_name} Plans"
@@ -79,8 +107,8 @@ msgstr ""
 msgid "%{org} Example Answer"
 msgstr ""
 
-msgid "%{org} Guidance"
-msgstr ""
+#msgid "%{org} Guidance"
+#msgstr ""
 
 msgid "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
 msgstr ""
@@ -88,7 +116,11 @@ msgstr ""
 msgid "%{plan_owner} has been notified that you have finished providing feedback"
 msgstr ""
 
-msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgstr ""
+
+#, fuzzy
+msgid "%{template}"
 msgstr ""
 
 msgid "%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}"
@@ -97,11 +129,11 @@ msgstr ""
 msgid "%{tool_name}: A new comment was added to %{plan_title}"
 msgstr ""
 
-msgid "%{username}'s profile"
-msgstr ""
+#msgid "%{username}'s profile"
+#msgstr ""
 
-msgid "%{value} is not a valid format"
-msgstr ""
+#msgid "%{value} is not a valid format"
+#msgstr ""
 
 msgid "'Download' allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application."
 msgstr ""
@@ -160,8 +192,13 @@ msgstr ""
 msgid "A Data Management Plan in %{application_name} has been shared with you"
 msgstr ""
 
-msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#, fuzzy
+msgid "A Data Management Plan in %{tool_name} has been shared \"\"
+"                   \"with you"
 msgstr ""
+
+#msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#msgstr ""
 
 msgid "A colleague has invited you to contribute to their Data Management Plan in %{tool_name}"
 msgstr ""
@@ -208,8 +245,8 @@ msgstr ""
 msgid "Access removed"
 msgstr ""
 
-msgid "Accessibility"
-msgstr ""
+#msgid "Accessibility"
+#msgstr ""
 
 msgid "Actions"
 msgstr ""
@@ -313,6 +350,10 @@ msgstr ""
 msgid "An error has occurred while saving/resetting your export settings."
 msgstr ""
 
+#, fuzzy
+msgid "An error occurred when requesting feedback for this plan."
+msgstr ""
+
 msgid "Annotations"
 msgstr ""
 
@@ -391,8 +432,13 @@ msgstr ""
 msgid "Begin typing to see a filtered list"
 msgstr ""
 
-msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#, fuzzy
+msgid "Below is a list of users registered for your organisation. You can"
+"        sort the data by each field."
 msgstr ""
+
+#msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#msgstr ""
 
 msgid "Body"
 msgstr ""
@@ -496,14 +542,14 @@ msgstr ""
 msgid "Copyright information:"
 msgstr ""
 
-msgid "Could not create your %{o}."
-msgstr ""
+#msgid "Could not create your %{o}."
+#msgstr ""
 
-msgid "Could not delete the %{o}."
-msgstr ""
+#msgid "Could not delete the %{o}."
+#msgstr ""
 
-msgid "Could not update your %{o}."
-msgstr ""
+#msgid "Could not update your %{o}."
+#msgstr ""
 
 msgid "Create Organisation"
 msgstr ""
@@ -547,13 +593,17 @@ msgstr ""
 msgid "Created date"
 msgstr ""
 
-msgid "Created using the %{application_name} service. Last modified %{date}"
-msgstr ""
+#msgid "Created using the %{application_name} service. Last modified %{date}"
+#msgstr ""
 
 msgid "Created using the %{application_name}. Last modified %{date}"
 msgstr ""
 
 msgid "Creator:"
+msgstr ""
+
+#, fuzzy
+msgid "Creators:"
 msgstr ""
 
 msgid "Creators: "
@@ -565,7 +615,23 @@ msgstr ""
 msgid "Current password"
 msgstr ""
 
+#, fuzzy
+msgid "Customisable Templates"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are published"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are unpublished"
+msgstr ""
+
 msgid "Customise"
+msgstr ""
+
+#, fuzzy
+msgid "Customise phase"
 msgstr ""
 
 msgid "Customising for your Organisation"
@@ -574,14 +640,14 @@ msgstr ""
 msgid "Customizable Templates"
 msgstr "Customisable Templates"
 
-msgid "Customizations are published"
-msgstr "Customisations are published"
+#msgid "Customizations are published"
+#msgstr "Customisations are published"
 
-msgid "Customizations are unpublished"
-msgstr "Customisations are unpublished"
+#msgid "Customizations are unpublished"
+#msgstr "Customisations are unpublished"
 
-msgid "Customize phase"
-msgstr "Customise phase"
+#msgid "Customize phase"
+#msgstr "Customise phase"
 
 msgid "DMP Background"
 msgstr ""
@@ -598,7 +664,11 @@ msgstr ""
 msgid "DMPRoadmap ('the tool', 'the system"
 msgstr ""
 
-msgid "DOCX"
+#msgid "DOCX"
+#msgstr ""
+
+#, fuzzy
+msgid "DOCX <em class=\"sr-only\">(new window)</em>"
 msgstr ""
 
 msgid "Data Contact Person"
@@ -655,16 +725,36 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-msgid "Download Plan"
+#msgid "Download Plan"
+#msgstr ""
+
+#, fuzzy
+msgid "Download Plan <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
+msgid "Download global usage"
 msgstr ""
 
 msgid "Download plans"
 msgstr ""
 
+#, fuzzy
+msgid "Download plans <em class=\"sr-only\">(new window)</span>"
+msgstr ""
+
 msgid "Download settings"
 msgstr ""
 
+#, fuzzy
+msgid "Download users"
+msgstr ""
+
 msgid "Draft"
+msgstr ""
+
+#, fuzzy
+msgid "Drag arrows to rearrange sections."
 msgstr ""
 
 msgid "Edit"
@@ -673,8 +763,8 @@ msgstr ""
 msgid "Edit Profile"
 msgstr ""
 
-msgid "Edit Theme"
-msgstr ""
+#msgid "Edit Theme"
+#msgstr ""
 
 msgid "Edit User Privileges"
 msgstr ""
@@ -745,14 +835,18 @@ msgstr ""
 msgid "Enter your guidance here. You can include links where needed."
 msgstr ""
 
-msgid "Error parsing links for a #{template_type(template)}"
+#msgid "Error parsing links for a #{template_type(template)}"
+#msgstr ""
+
+#, fuzzy
+msgid "Error parsing links for a %{template}"
 msgstr ""
 
-msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
-msgstr ""
+#msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#msgstr ""
 
-msgid "Error raised while saving the visibility for plan id %{plan_id}"
-msgstr ""
+#msgid "Error raised while saving the visibility for plan id %{plan_id}"
+#msgstr ""
 
 msgid "Error:"
 msgstr ""
@@ -988,8 +1082,12 @@ msgstr ""
 msgid "Invalid maximum pages"
 msgstr ""
 
-msgid "Invitation to %{email} issued successfully. \n"
+#, fuzzy
+msgid "Invitation to %{email} issued successfully."
 msgstr ""
+
+#msgid "Invitation to %{email} issued successfully. \n"
+#msgstr ""
 
 msgid "Invite collaborators"
 msgstr ""
@@ -1114,14 +1212,18 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#, fuzzy
+msgid "New Notification"
+msgstr ""
+
 msgid "New Question"
 msgstr ""
 
 msgid "New Template"
 msgstr ""
 
-msgid "New Theme"
-msgstr ""
+#msgid "New Theme"
+#msgstr ""
 
 msgid "New notification"
 msgstr ""
@@ -1136,6 +1238,10 @@ msgid "New plans"
 msgstr ""
 
 msgid "New question:"
+msgstr ""
+
+#, fuzzy
+msgid "New theme"
 msgstr ""
 
 msgid "New users"
@@ -1210,11 +1316,11 @@ msgstr ""
 msgid "Notification Preferences"
 msgstr ""
 
-msgid "Notification created successfully"
-msgstr ""
+#msgid "Notification created successfully"
+#msgstr ""
 
-msgid "Notification updated successfully"
-msgstr ""
+#msgid "Notification updated successfully"
+#msgstr ""
 
 msgid "Notifications"
 msgstr ""
@@ -1330,6 +1436,10 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
+#, fuzzy
+msgid "PDF <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
 msgid "PDF formatting"
 msgstr ""
 
@@ -1369,8 +1479,8 @@ msgstr ""
 msgid "Plan Description"
 msgstr ""
 
-msgid "Plan Guidance Configuration"
-msgstr ""
+#msgid "Plan Guidance Configuration"
+#msgstr ""
 
 msgid "Plan ID"
 msgstr ""
@@ -1393,37 +1503,49 @@ msgstr ""
 msgid "Plans"
 msgstr ""
 
-msgid "Please check the box to continue."
-msgstr ""
+#msgid "Please check the box to continue."
+#msgstr ""
 
 msgid "Please choose an organisation"
 msgstr ""
 
-msgid "Please choose one of the options."
-msgstr ""
+#msgid "Please choose one of the options."
+#msgstr ""
 
 msgid "Please do not reply to this email."
 msgstr ""
 
-msgid "Please enter a First name."
+#msgid "Please enter a First name."
+#msgstr ""
+
+#, fuzzy
+msgid "Please enter a First name. "
 msgstr ""
 
-msgid "Please enter a Last name."
+#msgid "Please enter a Last name."
+#msgstr ""
+
+#, fuzzy
+msgid "Please enter a Last name. "
 msgstr ""
 
 msgid "Please enter a password confirmation"
 msgstr ""
 
-msgid "Please enter a valid number."
-msgstr ""
+#msgid "Please enter a valid number."
+#msgstr ""
 
-msgid "Please enter a valid value."
-msgstr ""
+#msgid "Please enter a valid value."
+#msgstr ""
 
 msgid "Please enter an email address"
 msgstr ""
 
-msgid "Please enter an email address."
+#msgid "Please enter an email address."
+#msgstr ""
+
+#, fuzzy
+msgid "Please enter an email address. "
 msgstr ""
 
 msgid "Please enter the name of your organisation"
@@ -1462,8 +1584,8 @@ msgstr ""
 msgid "Please select a valid research organisation from the list."
 msgstr ""
 
-msgid "Please select a value from the list."
-msgstr ""
+#msgid "Please select a value from the list."
+#msgstr ""
 
 msgid "Please select an item from the list."
 msgstr ""
@@ -1612,6 +1734,10 @@ msgstr ""
 msgid "Questions"
 msgstr ""
 
+#, fuzzy
+msgid "Re-order sections"
+msgstr ""
+
 msgid "Read only"
 msgstr ""
 
@@ -1636,7 +1762,11 @@ msgstr ""
 msgid "Remove this link"
 msgstr ""
 
-msgid "Request Expert Feedback - Automated Email:"
+#msgid "Request Expert Feedback - Automated Email:"
+#msgstr ""
+
+#, fuzzy
+msgid "Request Expert Feedback - Message Displayed on Share Plan Tab:"
 msgstr ""
 
 msgid "Request Feedback"
@@ -1663,6 +1793,12 @@ msgstr ""
 msgid "Run your own filter"
 msgstr ""
 
+#, fuzzy
+msgid "SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48"
+"       hours. If you have questions pertaining to this action please contact us"
+"       at %{organisation_email}."
+msgstr ""
+
 msgid "Same as Principal Investigator"
 msgstr ""
 
@@ -1678,7 +1814,11 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-msgid "Save Unsuccessful."
+#msgid "Save Unsuccessful."
+#msgstr ""
+
+#, fuzzy
+msgid "Save Unsuccessful. "
 msgstr ""
 
 msgid "Saving..."
@@ -1718,17 +1858,25 @@ msgstr ""
 msgid "Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s)."
 msgstr ""
 
+#, fuzzy
+msgid "Select Guidance"
+msgstr ""
+
 msgid "Select all"
 msgstr ""
 
 msgid "Select an organisation from the list."
 msgstr ""
 
+#, fuzzy
+msgid "Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+msgstr ""
+
 msgid "Select one or more themes that are relevant to this question. This will allow similarly themed organisation-level guidance to appear alongside your question."
 msgstr ""
 
-msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
-msgstr ""
+#msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+#msgstr ""
 
 msgid "Select phase to download"
 msgstr ""
@@ -1769,20 +1917,20 @@ msgstr ""
 msgid "Shibboleth Entity Id"
 msgstr ""
 
-msgid "Should be after start date"
-msgstr ""
+#msgid "Should be after start date"
+#msgstr ""
 
-msgid "Should be before expiration date"
-msgstr ""
+#msgid "Should be before expiration date"
+#msgstr ""
 
-msgid "Should be today or later"
-msgstr ""
+#msgid "Should be today or later"
+#msgstr ""
 
-msgid "Should be tomorrow or later"
-msgstr ""
+#msgid "Should be tomorrow or later"
+#msgstr ""
 
-msgid "Show"
-msgstr ""
+#msgid "Show"
+#msgstr ""
 
 msgid "Show password"
 msgstr ""
@@ -1811,6 +1959,10 @@ msgstr ""
 msgid "Someone has requested a link to change your %{tool_name} password. You can do this through the link below."
 msgstr ""
 
+#, fuzzy
+msgid "Sort by %{sort_field}"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
@@ -1829,18 +1981,22 @@ msgstr ""
 msgid "Successfully %{action} %{username}'s account."
 msgstr ""
 
-msgid "Successfully %{action} your %{object}."
+#, fuzzy
+msgid "Successfully %{action} the %{object}."
 msgstr ""
+
+#msgid "Successfully %{action} your %{object}."
+#msgstr ""
 
 #, fuzzy
 msgid "Successfully changed the permissions for #{@role.user.email}. They have been notified via email."
 msgstr ""
 
-msgid "Successfully deleted your theme"
-msgstr ""
+#msgid "Successfully deleted your theme"
+#msgstr ""
 
-msgid "Successfully destroyed your notification"
-msgstr ""
+#msgid "Successfully destroyed your notification"
+#msgstr ""
 
 msgid "Successfully signed in"
 msgstr ""
@@ -1851,8 +2007,8 @@ msgstr ""
 msgid "Successfully unpublished your #{template_type(template)}"
 msgstr ""
 
-msgid "Successfully updated %{username}"
-msgstr ""
+#msgid "Successfully updated %{username}"
+#msgstr ""
 
 msgid "Super Admin"
 msgstr ""
@@ -1923,6 +2079,15 @@ msgstr ""
 msgid "The Digital Curation Centre and UC3 team at the California Digital Library have developed and delivered tools for data management planning since the advent of open data policies in 2011. "
 msgstr ""
 
+#, fuzzy
+msgid "The above plan creator(s) have agreed that others may use as"
+"             much of the text of this plan as they would like in their own plans,"
+"             and customise it as necessary. You do not need to credit the creator(s)"
+"             as the source of the language used, but using any of the plan's text"
+"             does not imply that the creator(s) endorse, or have any relationship to,"
+"             your project or proposal"
+msgstr ""
+
 msgid "The current #{scheme.description} iD has been already linked to a user with email #{identifier.user.email}"
 msgstr ""
 
@@ -1944,11 +2109,11 @@ msgstr ""
 msgid "The new platform will be separate from the services each of our teams runs on top of it. Our shared goal: provide a combined DMPRoadmap platform as a core infrastructure for DMPs. Future enhancements will focus on making DMPs machine actionable so please continue sharing your use cases."
 msgstr ""
 
-msgid "The password must be between 8 and 128 characters."
-msgstr ""
+#msgid "The password must be between 8 and 128 characters."
+#msgstr ""
 
-msgid "The passwords must match."
-msgstr ""
+#msgid "The passwords must match."
+#msgstr ""
 
 msgid "The plan %{plan_title} had its visibility changed to %{plan_visibility}."
 msgstr ""
@@ -1971,17 +2136,17 @@ msgstr ""
 msgid "The table below lists the plans that you have created, and that have been shared with you by others. You can edit, share, download, make a copy, or remove these plans at any time."
 msgstr ""
 
-msgid "The theme with id %{id} could not be destroyed"
-msgstr ""
+#msgid "The theme with id %{id} could not be destroyed"
+#msgstr ""
 
 msgid "The ‘Share’ tab is also where you can set your plan visibility."
 msgstr ""
 
-msgid "Theme created successfully"
-msgstr ""
+#msgid "Theme created successfully"
+#msgstr ""
 
-msgid "Theme updated successfully"
-msgstr ""
+#msgid "Theme updated successfully"
+#msgstr ""
 
 msgid "Themes"
 msgstr ""
@@ -2013,8 +2178,8 @@ msgstr ""
 msgid "There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer"
 msgstr ""
 
-msgid "There is no theme associated with id %{id}"
-msgstr ""
+#msgid "There is no theme associated with id %{id}"
+#msgstr ""
 
 msgid "There may also be an option to request feedback on your plan. This is available when research support staff at your organisation have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
 msgstr ""
@@ -2022,8 +2187,8 @@ msgstr ""
 msgid "There seems to be a problem with your logo. Please upload it again."
 msgstr ""
 
-msgid "This allows you to order sections."
-msgstr ""
+#msgid "This allows you to order sections."
+#msgstr ""
 
 msgid "This allows you to order the phases of your template."
 msgstr ""
@@ -2109,6 +2274,10 @@ msgstr ""
 msgid "Unable to %{action} %{username}"
 msgstr ""
 
+#, fuzzy
+msgid "Unable to %{action} the %{object}.%{errors}"
+msgstr ""
+
 msgid "Unable to change the plan's status since it is needed at least %{percentage} percentage responded"
 msgstr ""
 
@@ -2118,10 +2287,18 @@ msgstr ""
 msgid "Unable to change your organisation affiliation at this time."
 msgstr ""
 
-msgid "Unable to create a new section because the phase you specified does not exist."
+#msgid "Unable to create a new section because the phase you specified does not exist."
+#msgstr ""
+
+#, fuzzy
+msgid "Unable to create a new section. The phase you specified does not exist."
 msgstr ""
 
 msgid "Unable to create a new version of this template."
+msgstr ""
+
+#, fuzzy
+msgid "Unable to create your account.#{errors_for_display(resource)}"
 msgstr ""
 
 msgid "Unable to customize that template."
@@ -2157,11 +2334,11 @@ msgstr ""
 msgid "Unable to remove the plan"
 msgstr ""
 
-msgid "Unable to save since notification parameter is missing"
-msgstr ""
+#msgid "Unable to save since notification parameter is missing"
+#msgstr ""
 
-msgid "Unable to save since theme parameter is missing"
-msgstr ""
+#msgid "Unable to save since theme parameter is missing"
+#msgstr ""
 
 msgid "Unable to submit your request"
 msgstr ""
@@ -2169,8 +2346,8 @@ msgstr ""
 msgid "Unable to submit your request for feedback at this time."
 msgstr ""
 
-msgid "Unable to transfer your customizations."
-msgstr "Unable to transfer your customisations."
+#msgid "Unable to transfer your customizations."
+#msgstr "Unable to transfer your customisations."
 
 msgid "Unable to unlink your account from %{is}."
 msgstr ""
@@ -2178,8 +2355,8 @@ msgstr ""
 msgid "Unable to unpublish your #{template_type(template)}."
 msgstr ""
 
-msgid "Unable to update %{username}"
-msgstr ""
+#msgid "Unable to update %{username}"
+#msgstr ""
 
 msgid "Unknown"
 msgstr ""
@@ -2241,8 +2418,8 @@ msgstr ""
 msgid "User accounts"
 msgstr ""
 
-msgid "User not found."
-msgstr ""
+#msgid "User not found."
+#msgstr ""
 
 msgid "Users"
 msgstr ""
@@ -2259,6 +2436,10 @@ msgstr ""
 msgid "View all guidance"
 msgstr ""
 
+#, fuzzy
+msgid "View all notifications"
+msgstr ""
+
 msgid "View all organisations"
 msgstr ""
 
@@ -2266,6 +2447,10 @@ msgid "View all search results"
 msgstr ""
 
 msgid "View all templates"
+msgstr ""
+
+#, fuzzy
+msgid "View all themes"
 msgstr ""
 
 msgid "View all users"
@@ -2292,8 +2477,8 @@ msgstr ""
 msgid "We invite you to peruse the DMPRoadmap GitHub wiki to learn how to "
 msgstr ""
 
-msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
-msgstr ""
+#msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
+#msgstr ""
 
 msgid "We will hold the personal data you provided us for as long as you continue using the %{application_name} service. Your personal data can be removed from this service upon request to the %{application_name} team within a period of 30 days."
 msgstr ""
@@ -2424,16 +2609,28 @@ msgstr ""
 msgid "You may change your notification preferences on your profile page."
 msgstr ""
 
+#, fuzzy
+msgid "You may change your notification preferences on your profile page. "
+msgstr ""
+
+#, fuzzy
+msgid "You may place them before or after the main template sections."
+msgstr ""
+
 msgid "You must accept the terms and conditions to register."
 msgstr ""
 
-msgid "You must agree to the term and conditions."
-msgstr ""
+#msgid "You must agree to the term and conditions."
+#msgstr ""
 
-msgid "You must enter a valid URL (e.g. https://organisation.org)."
-msgstr ""
+#msgid "You must enter a valid URL (e.g. https://organisation.org)."
+#msgstr ""
 
-msgid "You must enter a valid email address."
+#msgid "You must enter a valid email address."
+#msgstr ""
+
+#, fuzzy
+msgid "You must provide a valid email address and select a permission level."
 msgstr ""
 
 msgid "You must select a funder from the list or click the checkbox."
@@ -2484,6 +2681,11 @@ msgstr ""
 msgid "Your account has been successfully linked to your institutional credentials. You will now be able to sign in with them."
 msgstr ""
 
+#, fuzzy
+msgid "Your colleague %{inviter_name} has invited you to contribute to"
+"            their Data Management Plan in %{tool_name}"
+msgstr ""
+
 msgid "Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change."
 msgstr ""
 
@@ -2514,8 +2716,8 @@ msgstr ""
 msgid "Your project is now a test."
 msgstr ""
 
-msgid "Your request for feedback has been submitted."
-msgstr ""
+#msgid "Your request for feedback has been submitted."
+#msgstr ""
 
 msgid "account has been locked due to an excessive number of unsuccessful sign in attempts."
 msgstr ""
@@ -2559,8 +2761,8 @@ msgstr ""
 msgid "can't be less than zero"
 msgstr ""
 
-msgid "changed"
-msgstr ""
+#msgid "changed"
+#msgstr ""
 
 msgid "co-owner"
 msgstr ""
@@ -2575,6 +2777,14 @@ msgid "completed_plans"
 msgstr ""
 
 msgid "copied"
+msgstr ""
+
+#, fuzzy
+msgid "copy"
+msgstr ""
+
+#, fuzzy
+msgid "create"
 msgstr ""
 
 msgid "created"
@@ -2593,6 +2803,10 @@ msgid "deactivate"
 msgstr ""
 
 msgid "deactivated"
+msgstr ""
+
+#, fuzzy
+msgid "delete"
 msgstr ""
 
 msgid "deleted"
@@ -2616,8 +2830,12 @@ msgstr ""
 msgid "generate_version! requires a published template"
 msgstr ""
 
-msgid "guidance"
+#, fuzzy
+msgid "get involved<em class=\"sr-only\"> (new window)</em>"
 msgstr ""
+
+#msgid "guidance"
+#msgstr ""
 
 msgid "guidance group"
 msgstr ""
@@ -2628,6 +2846,10 @@ msgstr ""
 msgid "into your browser"
 msgstr ""
 
+#, fuzzy
+msgid "isn't a valid value"
+msgstr ""
+
 msgid "locals should be a Hash object"
 msgstr ""
 
@@ -2635,6 +2857,10 @@ msgid "logo"
 msgstr ""
 
 msgid "mock project for testing, practice, or educational purposes"
+msgstr ""
+
+#, fuzzy
+msgid "must be after %{date}"
 msgstr ""
 
 msgid "must be logged in"
@@ -2652,8 +2878,8 @@ msgstr ""
 msgid "must have access to plans api"
 msgstr ""
 
-msgid "note"
-msgstr ""
+#msgid "note"
+#msgstr ""
 
 msgid "obj should be a Phase, Section, Question, or Annotation"
 msgstr ""
@@ -2679,23 +2905,27 @@ msgstr ""
 msgid "page for guidance."
 msgstr ""
 
-msgid "password"
-msgstr ""
+#msgid "password"
+#msgstr ""
 
 msgid "path_params should be a Hash object"
 msgstr ""
 
-msgid "permissions"
+#, fuzzy
+msgid "permission"
 msgstr ""
 
-msgid "phase"
-msgstr ""
+#msgid "permissions"
+#msgstr ""
+
+#msgid "phase"
+#msgstr ""
 
 msgid "plan"
 msgstr ""
 
-msgid "plan's visibility"
-msgstr ""
+#msgid "plan's visibility"
+#msgstr ""
 
 msgid "plans"
 msgstr ""
@@ -2709,10 +2939,18 @@ msgstr ""
 msgid "profile"
 msgstr ""
 
+#, fuzzy
+msgid "profile for %{username}"
+msgstr ""
+
 msgid "project details coversheet"
 msgstr ""
 
 msgid "public"
+msgstr ""
+
+#, fuzzy
+msgid "publish"
 msgstr ""
 
 msgid "query_params should be a Hash object"
@@ -2736,13 +2974,21 @@ msgstr ""
 msgid "read-only"
 msgstr ""
 
+#, fuzzy
+msgid "remove"
+msgstr ""
+
 msgid "removed"
 msgstr ""
 
 msgid "reviewer"
 msgstr ""
 
-msgid "role"
+#msgid "role"
+#msgstr ""
+
+#, fuzzy
+msgid "save"
 msgstr ""
 
 msgid "saved"
@@ -2781,11 +3027,23 @@ msgstr ""
 msgid "unanswered questions"
 msgstr ""
 
+#, fuzzy
+msgid "unpublish"
+msgstr ""
+
+#, fuzzy
+msgid "update"
+msgstr ""
+
 msgid "updated"
 msgstr ""
 
-msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#, fuzzy
+msgid "upgrade cannot be carried out since there is no published template of its current funder"
 msgstr ""
+
+#msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#msgstr ""
 
 msgid "upgrade_customization! requires a customised template"
 msgstr ""

--- a/config/locale/en_US/app.po
+++ b/config/locale/en_US/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2018-06-20 16:23:24-0700\n"
+"PO-Revision-Date: 2018-10-19 11:10:54-0700\n"
 "Last-Translator: Brian Riley brian.riley@ucop.edu\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en_US\n"
@@ -44,10 +44,13 @@ msgstr ""
 msgid "#{text}"
 msgstr ""
 
+msgid "%{affiliation}"
+msgstr ""
+
 msgid "%{application_name}"
 msgstr ""
 
-msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website <em class=\"sr-only\">(new window)</em></a>. If you would like to contact us about %{application_name}, please fill out the form below."
 msgstr ""
 
 msgid "%{application_name}: %{user_name} requested feedback on a plan"
@@ -59,13 +62,25 @@ msgstr ""
 msgid "%{application_name}: Your plan has been submitted for feedback"
 msgstr ""
 
+msgid "%{authors}"
+msgstr ""
+
 msgid "%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don't want to accept the invitation, please ignore this email."
 msgstr ""
 
 msgid "%{commenter_name} has commented on the plan %{plan_title}. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
 msgstr ""
 
-msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+msgid "%{date}"
+msgstr ""
+
+msgid "%{description}"
+msgstr ""
+
+msgid "%{funder}"
+msgstr ""
+
+msgid "%{grant_number}"
 msgstr ""
 
 msgid "%{org_name} Plans"
@@ -80,28 +95,19 @@ msgstr ""
 msgid "%{org} Example Answer"
 msgstr ""
 
-msgid "%{org} Guidance"
-msgstr ""
-
 msgid "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
 msgstr ""
 
 msgid "%{plan_owner} has been notified that you have finished providing feedback"
 msgstr ""
 
-msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+msgid "%{template}"
 msgstr ""
 
 msgid "%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}"
 msgstr ""
 
 msgid "%{tool_name}: A new comment was added to %{plan_title}"
-msgstr ""
-
-msgid "%{username}'s profile"
-msgstr ""
-
-msgid "%{value} is not a valid format"
 msgstr ""
 
 msgid "'Download' allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application."
@@ -161,7 +167,9 @@ msgstr ""
 msgid "A Data Management Plan in %{application_name} has been shared with you"
 msgstr ""
 
-msgid "A Data Management Plan in %{tool_name} has been shared with you"
+msgid "A Data Management Plan in %{tool_name} has been shared \"\
+"
+"                   \"with you"
 msgstr ""
 
 msgid "A colleague has invited you to contribute to their Data Management Plan in %{tool_name}"
@@ -183,7 +191,7 @@ msgid "A new comment has been added to my DMP"
 msgstr ""
 
 msgid "A pertinent ID as determined by the funder and/or organisation."
-msgstr ""
+msgstr "A pertinent ID as determined by the funder and/or organization."
 
 msgid "A plan has been shared with me"
 msgstr ""
@@ -207,9 +215,6 @@ msgid "About %{application_name}"
 msgstr ""
 
 msgid "Access removed"
-msgstr ""
-
-msgid "Accessibility"
 msgstr ""
 
 msgid "Actions"
@@ -314,6 +319,9 @@ msgstr "Allows the user to manage organization affiliation"
 msgid "An error has occurred while saving/resetting your export settings."
 msgstr ""
 
+msgid "An error occurred when requesting feedback for this plan."
+msgstr ""
+
 msgid "Annotations"
 msgstr ""
 
@@ -392,8 +400,10 @@ msgstr ""
 msgid "Begin typing to see a filtered list"
 msgstr ""
 
-msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
-msgstr "Below is a list of users registered for your organization. You can sort the data by each field."
+msgid "Below is a list of users registered for your organisation. You can"
+"        sort the data by each field."
+msgstr "Below is a list of users registered for your organization. You can"
+"        sort the data by each field."
 
 msgid "Body"
 msgstr ""
@@ -497,15 +507,6 @@ msgstr ""
 msgid "Copyright information:"
 msgstr ""
 
-msgid "Could not create your %{o}."
-msgstr ""
-
-msgid "Could not delete the %{o}."
-msgstr ""
-
-msgid "Could not update your %{o}."
-msgstr ""
-
 msgid "Create Organisation"
 msgstr "Create Organization"
 
@@ -548,13 +549,13 @@ msgstr ""
 msgid "Created date"
 msgstr ""
 
-msgid "Created using the %{application_name} service. Last modified %{date}"
-msgstr ""
-
 msgid "Created using the %{application_name}. Last modified %{date}"
 msgstr ""
 
 msgid "Creator:"
+msgstr ""
+
+msgid "Creators:"
 msgstr ""
 
 msgid "Creators: "
@@ -566,23 +567,26 @@ msgstr ""
 msgid "Current password"
 msgstr ""
 
+msgid "Customisable Templates"
+msgstr "Customizable Templates"
+
+msgid "Customisations are published"
+msgstr "Customizations are published"
+
+msgid "Customisations are unpublished"
+msgstr "Customizations are unpublished"
+
 msgid "Customise"
 msgstr "Customize"
+
+msgid "Customise phase"
+msgstr "Customize phase"
 
 msgid "Customising for your Organisation"
 msgstr "Customizing for your Organization"
 
 msgid "Customizable Templates"
 msgstr "Customizable Templates"
-
-msgid "Customizations are published"
-msgstr "Customizations are published"
-
-msgid "Customizations are unpublished"
-msgstr "Customizations are unpublished"
-
-msgid "Customize phase"
-msgstr "Customize phase"
 
 msgid "DMP Background"
 msgstr ""
@@ -599,7 +603,7 @@ msgstr ""
 msgid "DMPRoadmap ('the tool', 'the system"
 msgstr ""
 
-msgid "DOCX"
+msgid "DOCX <em class=\"sr-only\">(new window)</em>"
 msgstr ""
 
 msgid "Data Contact Person"
@@ -656,25 +660,34 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-msgid "Download Plan"
+msgid "Download Plan <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+msgid "Download global usage"
 msgstr ""
 
 msgid "Download plans"
 msgstr ""
 
+msgid "Download plans <em class=\"sr-only\">(new window)</span>"
+msgstr ""
+
 msgid "Download settings"
 msgstr ""
 
+msgid "Download users"
+msgstr ""
+
 msgid "Draft"
+msgstr ""
+
+msgid "Drag arrows to rearrange sections."
 msgstr ""
 
 msgid "Edit"
 msgstr ""
 
 msgid "Edit Profile"
-msgstr ""
-
-msgid "Edit Theme"
 msgstr ""
 
 msgid "Edit User Privileges"
@@ -746,13 +759,7 @@ msgstr ""
 msgid "Enter your guidance here. You can include links where needed."
 msgstr ""
 
-msgid "Error parsing links for a #{template_type(template)}"
-msgstr ""
-
-msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
-msgstr ""
-
-msgid "Error raised while saving the visibility for plan id %{plan_id}"
+msgid "Error parsing links for a %{template}"
 msgstr ""
 
 msgid "Error:"
@@ -989,7 +996,7 @@ msgstr ""
 msgid "Invalid maximum pages"
 msgstr ""
 
-msgid "Invitation to %{email} issued successfully. \n"
+msgid "Invitation to %{email} issued successfully."
 msgstr ""
 
 msgid "Invite collaborators"
@@ -1115,13 +1122,13 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+msgid "New Notification"
+msgstr ""
+
 msgid "New Question"
 msgstr ""
 
 msgid "New Template"
-msgstr ""
-
-msgid "New Theme"
 msgstr ""
 
 msgid "New notification"
@@ -1137,6 +1144,9 @@ msgid "New plans"
 msgstr ""
 
 msgid "New question:"
+msgstr ""
+
+msgid "New theme"
 msgstr ""
 
 msgid "New users"
@@ -1209,12 +1219,6 @@ msgid "Notice:"
 msgstr ""
 
 msgid "Notification Preferences"
-msgstr ""
-
-msgid "Notification created successfully"
-msgstr ""
-
-msgid "Notification updated successfully"
 msgstr ""
 
 msgid "Notifications"
@@ -1331,6 +1335,9 @@ msgstr ""
 msgid "PDF"
 msgstr ""
 
+msgid "PDF <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
 msgid "PDF formatting"
 msgstr ""
 
@@ -1370,9 +1377,6 @@ msgstr ""
 msgid "Plan Description"
 msgstr ""
 
-msgid "Plan Guidance Configuration"
-msgstr ""
-
 msgid "Plan ID"
 msgstr ""
 
@@ -1394,37 +1398,25 @@ msgstr ""
 msgid "Plans"
 msgstr ""
 
-msgid "Please check the box to continue."
-msgstr ""
-
 msgid "Please choose an organisation"
 msgstr "Please choose an organization"
-
-msgid "Please choose one of the options."
-msgstr ""
 
 msgid "Please do not reply to this email."
 msgstr ""
 
-msgid "Please enter a First name."
+msgid "Please enter a First name. "
 msgstr ""
 
-msgid "Please enter a Last name."
+msgid "Please enter a Last name. "
 msgstr ""
 
 msgid "Please enter a password confirmation"
 msgstr ""
 
-msgid "Please enter a valid number."
-msgstr ""
-
-msgid "Please enter a valid value."
-msgstr ""
-
 msgid "Please enter an email address"
 msgstr ""
 
-msgid "Please enter an email address."
+msgid "Please enter an email address. "
 msgstr ""
 
 msgid "Please enter the name of your organisation"
@@ -1463,9 +1455,6 @@ msgstr "Please select a valid funding organization from the list."
 msgid "Please select a valid research organisation from the list."
 msgstr "Please select a valid research organization from the list."
 
-msgid "Please select a value from the list."
-msgstr ""
-
 msgid "Please select an item from the list."
 msgstr ""
 
@@ -1498,9 +1487,6 @@ msgstr ""
 
 msgid "Principal Investigator / Researcher"
 msgstr ""
-
-#msgid "Principal investigator"
-#msgstr ""
 
 msgid "Privacy statement"
 msgstr ""
@@ -1613,6 +1599,9 @@ msgstr ""
 msgid "Questions"
 msgstr ""
 
+msgid "Re-order sections"
+msgstr ""
+
 msgid "Read only"
 msgstr ""
 
@@ -1637,7 +1626,7 @@ msgstr ""
 msgid "Remove this link"
 msgstr ""
 
-msgid "Request Expert Feedback - Automated Email:"
+msgid "Request Expert Feedback - Message Displayed on Share Plan Tab:"
 msgstr ""
 
 msgid "Request Feedback"
@@ -1664,6 +1653,11 @@ msgstr ""
 msgid "Run your own filter"
 msgstr ""
 
+msgid "SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48"
+"       hours. If you have questions pertaining to this action please contact us"
+"       at %{organisation_email}."
+msgstr ""
+
 msgid "Same as Principal Investigator"
 msgstr ""
 
@@ -1679,7 +1673,7 @@ msgstr "Sample plans are provided by a funder, an organization or a trusted part
 msgid "Save"
 msgstr ""
 
-msgid "Save Unsuccessful."
+msgid "Save Unsuccessful. "
 msgstr ""
 
 msgid "Saving..."
@@ -1706,12 +1700,8 @@ msgstr ""
 msgid "See the full list"
 msgstr ""
 
-#, fuzzy
 msgid "See the full list of participating institutions"
 msgstr ""
-
-#msgid "See the full list of participating organisations"
-#msgstr ""
 
 msgid "See the full list of partner institutions."
 msgstr ""
@@ -1719,17 +1709,20 @@ msgstr ""
 msgid "Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s)."
 msgstr "Select 'Transfer customization' in the Actions menu to review your customization(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customization(s)."
 
+msgid "Select Guidance"
+msgstr ""
+
 msgid "Select all"
 msgstr ""
 
 msgid "Select an organisation from the list."
 msgstr "Select an organization from the list."
 
+msgid "Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+msgstr "Select one or more themes that are relevant to this guidance. This will display your generic organization-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+
 msgid "Select one or more themes that are relevant to this question. This will allow similarly themed organisation-level guidance to appear alongside your question."
 msgstr "Select one or more themes that are relevant to this question. This will allow similarly themed organization-level guidance to appear alongside your question."
-
-msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
-msgstr "Select one theme that is relevant to this guidance. This will display your generic organization-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
 
 msgid "Select phase to download"
 msgstr ""
@@ -1770,21 +1763,6 @@ msgstr ""
 msgid "Shibboleth Entity Id"
 msgstr ""
 
-msgid "Should be after start date"
-msgstr ""
-
-msgid "Should be before expiration date"
-msgstr ""
-
-msgid "Should be today or later"
-msgstr ""
-
-msgid "Should be tomorrow or later"
-msgstr ""
-
-msgid "Show"
-msgstr ""
-
 msgid "Show password"
 msgstr ""
 
@@ -1812,6 +1790,9 @@ msgstr ""
 msgid "Someone has requested a link to change your %{tool_name} password. You can do this through the link below."
 msgstr ""
 
+msgid "Sort by %{sort_field}"
+msgstr ""
+
 msgid "Start"
 msgstr ""
 
@@ -1830,17 +1811,10 @@ msgstr ""
 msgid "Successfully %{action} %{username}'s account."
 msgstr ""
 
-msgid "Successfully %{action} your %{object}."
+msgid "Successfully %{action} the %{object}."
 msgstr ""
 
-#, fuzzy
 msgid "Successfully changed the permissions for #{@role.user.email}. They have been notified via email."
-msgstr ""
-
-msgid "Successfully deleted your theme"
-msgstr ""
-
-msgid "Successfully destroyed your notification"
 msgstr ""
 
 msgid "Successfully signed in"
@@ -1850,9 +1824,6 @@ msgid "Successfully unlinked your account from %{is}."
 msgstr ""
 
 msgid "Successfully unpublished your #{template_type(template)}"
-msgstr ""
-
-msgid "Successfully updated %{username}"
 msgstr ""
 
 msgid "Super Admin"
@@ -1886,7 +1857,7 @@ msgid "Templates"
 msgstr ""
 
 msgid "Templates are provided by a funder, an organisation, or a trusted party."
-msgstr ""
+msgstr "Templates are provided by a funder, an organization, or a trusted party."
 
 msgid "Terms of use"
 msgstr ""
@@ -1924,6 +1895,14 @@ msgstr ""
 msgid "The Digital Curation Centre and UC3 team at the California Digital Library have developed and delivered tools for data management planning since the advent of open data policies in 2011. "
 msgstr ""
 
+msgid "The above plan creator(s) have agreed that others may use as"
+"             much of the text of this plan as they would like in their own plans,"
+"             and customise it as necessary. You do not need to credit the creator(s)"
+"             as the source of the language used, but using any of the plan's text"
+"             does not imply that the creator(s) endorse, or have any relationship to,"
+"             your project or proposal"
+msgstr ""
+
 msgid "The current #{scheme.description} iD has been already linked to a user with email #{identifier.user.email}"
 msgstr ""
 
@@ -1943,12 +1922,6 @@ msgid "The key %{key} does not have a valid set of object links"
 msgstr ""
 
 msgid "The new platform will be separate from the services each of our teams runs on top of it. Our shared goal: provide a combined DMPRoadmap platform as a core infrastructure for DMPs. Future enhancements will focus on making DMPs machine actionable so please continue sharing your use cases."
-msgstr ""
-
-msgid "The password must be between 8 and 128 characters."
-msgstr ""
-
-msgid "The passwords must match."
 msgstr ""
 
 msgid "The plan %{plan_title} had its visibility changed to %{plan_visibility}."
@@ -1972,16 +1945,7 @@ msgstr "The table below lists the plans that users at your organization have cre
 msgid "The table below lists the plans that you have created, and that have been shared with you by others. You can edit, share, download, make a copy, or remove these plans at any time."
 msgstr ""
 
-msgid "The theme with id %{id} could not be destroyed"
-msgstr ""
-
 msgid "The ‘Share’ tab is also where you can set your plan visibility."
-msgstr ""
-
-msgid "Theme created successfully"
-msgstr ""
-
-msgid "Theme updated successfully"
 msgstr ""
 
 msgid "Themes"
@@ -2014,16 +1978,10 @@ msgstr ""
 msgid "There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer"
 msgstr ""
 
-msgid "There is no theme associated with id %{id}"
-msgstr ""
-
 msgid "There may also be an option to request feedback on your plan. This is available when research support staff at your organisation have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
 msgstr "There may also be an option to request feedback on your plan. This is available when research support staff at your organization have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
 
 msgid "There seems to be a problem with your logo. Please upload it again."
-msgstr ""
-
-msgid "This allows you to order sections."
 msgstr ""
 
 msgid "This allows you to order the phases of your template."
@@ -2110,6 +2068,9 @@ msgstr ""
 msgid "Unable to %{action} %{username}"
 msgstr ""
 
+msgid "Unable to %{action} the %{object}.%{errors}"
+msgstr ""
+
 msgid "Unable to change the plan's status since it is needed at least %{percentage} percentage responded"
 msgstr ""
 
@@ -2119,10 +2080,13 @@ msgstr ""
 msgid "Unable to change your organisation affiliation at this time."
 msgstr "Unable to change your organization affiliation at this time."
 
-msgid "Unable to create a new section because the phase you specified does not exist."
+msgid "Unable to create a new section. The phase you specified does not exist."
 msgstr ""
 
 msgid "Unable to create a new version of this template."
+msgstr ""
+
+msgid "Unable to create your account.#{errors_for_display(resource)}"
 msgstr ""
 
 msgid "Unable to customize that template."
@@ -2158,28 +2122,16 @@ msgstr ""
 msgid "Unable to remove the plan"
 msgstr ""
 
-msgid "Unable to save since notification parameter is missing"
-msgstr ""
-
-msgid "Unable to save since theme parameter is missing"
-msgstr ""
-
 msgid "Unable to submit your request"
 msgstr ""
 
 msgid "Unable to submit your request for feedback at this time."
 msgstr ""
 
-msgid "Unable to transfer your customizations."
-msgstr "Unable to transfer your customizations."
-
 msgid "Unable to unlink your account from %{is}."
 msgstr ""
 
 msgid "Unable to unpublish your #{template_type(template)}."
-msgstr ""
-
-msgid "Unable to update %{username}"
 msgstr ""
 
 msgid "Unknown"
@@ -2242,9 +2194,6 @@ msgstr "Use the filters to generate organizational usage statistics for a custom
 msgid "User accounts"
 msgstr ""
 
-msgid "User not found."
-msgstr ""
-
 msgid "Users"
 msgstr ""
 
@@ -2260,6 +2209,9 @@ msgstr ""
 msgid "View all guidance"
 msgstr ""
 
+msgid "View all notifications"
+msgstr ""
+
 msgid "View all organisations"
 msgstr "View all organizations"
 
@@ -2267,6 +2219,9 @@ msgid "View all search results"
 msgstr ""
 
 msgid "View all templates"
+msgstr ""
+
+msgid "View all themes"
 msgstr ""
 
 msgid "View all users"
@@ -2291,9 +2246,6 @@ msgid "We found multiple DMP templates corresponding to your funder."
 msgstr ""
 
 msgid "We invite you to peruse the DMPRoadmap GitHub wiki to learn how to "
-msgstr ""
-
-msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
 msgstr ""
 
 msgid "We will hold the personal data you provided us for as long as you continue using the %{application_name} service. Your personal data can be removed from this service upon request to the %{application_name} team within a period of 30 days."
@@ -2399,7 +2351,7 @@ msgid "You can write pieces of guidance to be displayed by theme (e.g. generic g
 msgstr ""
 
 msgid "You cannot be assigned to other organisation since that option does not exist in the system. Please contact your system administrators."
-msgstr ""
+msgstr "You cannot be assigned to other organization since that option does not exist in the system. Please contact your system administrators."
 
 msgid "You cannot delete a #{template_type(template)} that has been used to create plans."
 msgstr ""
@@ -2414,7 +2366,7 @@ msgid "You have been granted administrator privileges in %{tool_name}:"
 msgstr ""
 
 msgid "You have been granted permission by your organisation to use our API. Your API token and instructions for using the API endpoints can be found at: %{link}"
-msgstr ""
+msgstr "You have been granted permission by your organization to use our API. Your API token and instructions for using the API endpoints can be found at: %{link}"
 
 msgid "You have been revoked administrator privileges in %{tool_name}."
 msgstr ""
@@ -2425,16 +2377,16 @@ msgstr ""
 msgid "You may change your notification preferences on your profile page."
 msgstr ""
 
+msgid "You may change your notification preferences on your profile page. "
+msgstr ""
+
+msgid "You may place them before or after the main template sections."
+msgstr ""
+
 msgid "You must accept the terms and conditions to register."
 msgstr ""
 
-msgid "You must agree to the term and conditions."
-msgstr ""
-
-msgid "You must enter a valid URL (e.g. https://organisation.org)."
-msgstr ""
-
-msgid "You must enter a valid email address."
+msgid "You must provide a valid email address and select a permission level."
 msgstr ""
 
 msgid "You must select a funder from the list or click the checkbox."
@@ -2485,6 +2437,11 @@ msgstr ""
 msgid "Your account has been successfully linked to your institutional credentials. You will now be able to sign in with them."
 msgstr ""
 
+msgid "Your colleague %{inviter_name} has invited you to contribute to
+"
+"            their Data Management Plan in %{tool_name}"
+msgstr ""
+
 msgid "Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change."
 msgstr ""
 
@@ -2513,9 +2470,6 @@ msgid "Your project is no longer a test."
 msgstr ""
 
 msgid "Your project is now a test."
-msgstr ""
-
-msgid "Your request for feedback has been submitted."
 msgstr ""
 
 msgid "account has been locked due to an excessive number of unsuccessful sign in attempts."
@@ -2560,9 +2514,6 @@ msgstr ""
 msgid "can't be less than zero"
 msgstr ""
 
-msgid "changed"
-msgstr ""
-
 msgid "co-owner"
 msgstr ""
 
@@ -2576,6 +2527,12 @@ msgid "completed_plans"
 msgstr ""
 
 msgid "copied"
+msgstr ""
+
+msgid "copy"
+msgstr ""
+
+msgid "create"
 msgstr ""
 
 msgid "created"
@@ -2594,6 +2551,9 @@ msgid "deactivate"
 msgstr ""
 
 msgid "deactivated"
+msgstr ""
+
+msgid "delete"
 msgstr ""
 
 msgid "deleted"
@@ -2617,7 +2577,7 @@ msgstr "generate_copy! requires an organization target"
 msgid "generate_version! requires a published template"
 msgstr ""
 
-msgid "guidance"
+msgid "get involved<em class=\"sr-only\"> (new window)</em>"
 msgstr ""
 
 msgid "guidance group"
@@ -2629,6 +2589,9 @@ msgstr ""
 msgid "into your browser"
 msgstr ""
 
+msgid "isn't a valid value"
+msgstr ""
+
 msgid "locals should be a Hash object"
 msgstr ""
 
@@ -2636,6 +2599,9 @@ msgid "logo"
 msgstr ""
 
 msgid "mock project for testing, practice, or educational purposes"
+msgstr ""
+
+msgid "must be after %{date}"
 msgstr ""
 
 msgid "must be logged in"
@@ -2651,9 +2617,6 @@ msgid "must have access to guidances api"
 msgstr ""
 
 msgid "must have access to plans api"
-msgstr ""
-
-msgid "note"
 msgstr ""
 
 msgid "obj should be a Phase, Section, Question, or Annotation"
@@ -2680,22 +2643,13 @@ msgstr "organizational"
 msgid "page for guidance."
 msgstr ""
 
-msgid "password"
-msgstr ""
-
 msgid "path_params should be a Hash object"
 msgstr ""
 
-msgid "permissions"
-msgstr ""
-
-msgid "phase"
+msgid "permission"
 msgstr ""
 
 msgid "plan"
-msgstr ""
-
-msgid "plan's visibility"
 msgstr ""
 
 msgid "plans"
@@ -2710,10 +2664,16 @@ msgstr ""
 msgid "profile"
 msgstr ""
 
+msgid "profile for %{username}"
+msgstr ""
+
 msgid "project details coversheet"
 msgstr ""
 
 msgid "public"
+msgstr ""
+
+msgid "publish"
 msgstr ""
 
 msgid "query_params should be a Hash object"
@@ -2737,13 +2697,16 @@ msgstr ""
 msgid "read-only"
 msgstr ""
 
+msgid "remove"
+msgstr ""
+
 msgid "removed"
 msgstr ""
 
 msgid "reviewer"
 msgstr ""
 
-msgid "role"
+msgid "save"
 msgstr ""
 
 msgid "saved"
@@ -2782,10 +2745,16 @@ msgstr ""
 msgid "unanswered questions"
 msgstr ""
 
+msgid "unpublish"
+msgstr ""
+
+msgid "update"
+msgstr ""
+
 msgid "updated"
 msgstr ""
 
-msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+msgid "upgrade cannot be carried out since there is no published template of its current funder"
 msgstr ""
 
 msgid "upgrade_customization! requires a customised template"

--- a/config/locale/es/app.po
+++ b/config/locale/es/app.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2018-06-20 16:23:24-0700\n"
+"PO-Revision-Date: 2018-10-19 11:10:55-0700\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -49,12 +49,19 @@ msgstr ""
 msgid "#{text}"
 msgstr ""
 
+#, fuzzy
+msgid "%{affiliation}"
+msgstr ""
+
 msgid "%{application_name}"
 msgstr "DMPonline"
 
 #, fuzzy
-msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
-msgstr "DMPonline"
+msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website <em class=\"sr-only\">(new window)</em></a>. If you would like to contact us about %{application_name}, please fill out the form below."
+msgstr ""
+
+#msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#msgstr "DMPonline"
 
 #, fuzzy
 msgid "%{application_name}: %{user_name} requested feedback on a plan"
@@ -68,6 +75,10 @@ msgstr "DMPonline"
 msgid "%{application_name}: Your plan has been submitted for feedback"
 msgstr "DMPonline"
 
+#, fuzzy
+msgid "%{authors}"
+msgstr ""
+
 msgid "%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don't want to accept the invitation, please ignore this email."
 msgstr ""
 
@@ -75,9 +86,24 @@ msgstr ""
 msgid "%{commenter_name} has commented on the plan %{plan_title}. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
 msgstr "Comentario"
 
+#msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgstr "Comentario"
+
 #, fuzzy
-msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
-msgstr "Comentario"
+msgid "%{date}"
+msgstr ""
+
+#, fuzzy
+msgid "%{description}"
+msgstr ""
+
+#, fuzzy
+msgid "%{funder}"
+msgstr ""
+
+#, fuzzy
+msgid "%{grant_number}"
+msgstr ""
 
 #, fuzzy
 msgid "%{org_name} Plans"
@@ -95,9 +121,8 @@ msgstr "plans"
 msgid "%{org} Example Answer"
 msgstr "Respuesta de ejemplo"
 
-#, fuzzy
-msgid "%{org} Guidance"
-msgstr "Guía"
+#msgid "%{org} Guidance"
+#msgstr "Guía"
 
 #, fuzzy
 msgid "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
@@ -107,9 +132,12 @@ msgstr "Pregunta"
 msgid "%{plan_owner} has been notified that you have finished providing feedback"
 msgstr "plans"
 
+#msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgstr "DMPonline"
+
 #, fuzzy
-msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
-msgstr "DMPonline"
+msgid "%{template}"
+msgstr ""
 
 #, fuzzy
 msgid "%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}"
@@ -119,12 +147,11 @@ msgstr "plans"
 msgid "%{tool_name}: A new comment was added to %{plan_title}"
 msgstr "Comentario"
 
-#, fuzzy
-msgid "%{username}'s profile"
-msgstr "user"
+#msgid "%{username}'s profile"
+#msgstr "user"
 
-msgid "%{value} is not a valid format"
-msgstr ""
+#msgid "%{value} is not a valid format"
+#msgstr ""
 
 #, fuzzy
 msgid "'Download' allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application."
@@ -194,8 +221,12 @@ msgid "A Data Management Plan in %{application_name} has been shared with you"
 msgstr "DMPonline"
 
 #, fuzzy
-msgid "A Data Management Plan in %{tool_name} has been shared with you"
-msgstr "DMPonline"
+msgid "A Data Management Plan in %{tool_name} has been shared \"\"
+"                   \"with you"
+msgstr ""
+
+#msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#msgstr "DMPonline"
 
 #, fuzzy
 msgid "A colleague has invited you to contribute to their Data Management Plan in %{tool_name}"
@@ -247,8 +278,8 @@ msgstr ""
 msgid "Access removed"
 msgstr ""
 
-msgid "Accessibility"
-msgstr ""
+#msgid "Accessibility"
+#msgstr ""
 
 msgid "Actions"
 msgstr "Acciones"
@@ -373,6 +404,10 @@ msgstr "Organización"
 msgid "An error has occurred while saving/resetting your export settings."
 msgstr ""
 
+#, fuzzy
+msgid "An error occurred when requesting feedback for this plan."
+msgstr ""
+
 msgid "Annotations"
 msgstr ""
 
@@ -467,8 +502,13 @@ msgstr "Preguntas"
 msgid "Begin typing to see a filtered list"
 msgstr ""
 
-msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
-msgstr "Debajo tiene la lista de usuarios registrados en su entidad. Puede ordenar los datos por campo."
+#, fuzzy
+msgid "Below is a list of users registered for your organisation. You can"
+"        sort the data by each field."
+msgstr ""
+
+#msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#msgstr "Debajo tiene la lista de usuarios registrados en su entidad. Puede ordenar los datos por campo."
 
 msgid "Body"
 msgstr ""
@@ -589,17 +629,14 @@ msgstr "templates"
 msgid "Copyright information:"
 msgstr ""
 
-#, fuzzy
-msgid "Could not create your %{o}."
-msgstr ""
+#msgid "Could not create your %{o}."
+#msgstr ""
 
-#, fuzzy
-msgid "Could not delete the %{o}."
-msgstr ""
+#msgid "Could not delete the %{o}."
+#msgstr ""
 
-#, fuzzy
-msgid "Could not update your %{o}."
-msgstr ""
+#msgid "Could not update your %{o}."
+#msgstr ""
 
 #, fuzzy
 msgid "Create Organisation"
@@ -651,15 +688,18 @@ msgstr "Creado el"
 msgid "Created date"
 msgstr "Creado el"
 
-#, fuzzy
-msgid "Created using the %{application_name} service. Last modified %{date}"
-msgstr "DMPonline"
+#msgid "Created using the %{application_name} service. Last modified %{date}"
+#msgstr "DMPonline"
 
 #, fuzzy
 msgid "Created using the %{application_name}. Last modified %{date}"
 msgstr "DMPonline"
 
 msgid "Creator:"
+msgstr ""
+
+#, fuzzy
+msgid "Creators:"
 msgstr ""
 
 msgid "Creators: "
@@ -671,8 +711,24 @@ msgstr ""
 msgid "Current password"
 msgstr "Clave actual"
 
+#, fuzzy
+msgid "Customisable Templates"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are published"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are unpublished"
+msgstr ""
+
 msgid "Customise"
 msgstr "Personalizar"
+
+#, fuzzy
+msgid "Customise phase"
+msgstr ""
 
 #, fuzzy
 msgid "Customising for your Organisation"
@@ -682,15 +738,14 @@ msgstr "Organización"
 msgid "Customizable Templates"
 msgstr "Plantillas"
 
-msgid "Customizations are published"
-msgstr ""
+#msgid "Customizations are published"
+#msgstr ""
 
-msgid "Customizations are unpublished"
-msgstr ""
+#msgid "Customizations are unpublished"
+#msgstr ""
 
-#, fuzzy
-msgid "Customize phase"
-msgstr "Fase"
+#msgid "Customize phase"
+#msgstr "Fase"
 
 #, fuzzy
 msgid "DMP Background"
@@ -711,7 +766,11 @@ msgstr ""
 msgid "DMPRoadmap ('the tool', 'the system"
 msgstr ""
 
-msgid "DOCX"
+#msgid "DOCX"
+#msgstr ""
+
+#, fuzzy
+msgid "DOCX <em class=\"sr-only\">(new window)</em>"
 msgstr ""
 
 msgid "Data Contact Person"
@@ -771,18 +830,37 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
+#msgid "Download Plan"
+#msgstr "plans"
+
 #, fuzzy
-msgid "Download Plan"
-msgstr "plans"
+msgid "Download Plan <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
+msgid "Download global usage"
+msgstr ""
 
 #, fuzzy
 msgid "Download plans"
 msgstr "plans"
 
+#, fuzzy
+msgid "Download plans <em class=\"sr-only\">(new window)</span>"
+msgstr ""
+
 msgid "Download settings"
 msgstr ""
 
+#, fuzzy
+msgid "Download users"
+msgstr ""
+
 msgid "Draft"
+msgstr ""
+
+#, fuzzy
+msgid "Drag arrows to rearrange sections."
 msgstr ""
 
 msgid "Edit"
@@ -792,9 +870,8 @@ msgstr "Editar"
 msgid "Edit Profile"
 msgstr "Editar perfil"
 
-#, fuzzy
-msgid "Edit Theme"
-msgstr "Editar"
+#msgid "Edit Theme"
+#msgstr "Editar"
 
 msgid "Edit User Privileges"
 msgstr ""
@@ -876,16 +953,18 @@ msgstr "Introduzca la guía concreta para esta pregunta. Si también tiene guía
 msgid "Enter your guidance here. You can include links where needed."
 msgstr "Introduzca sus orientaciones aquí. Puede incluir enlaces si lo cree necesario."
 
-#, fuzzy
-msgid "Error parsing links for a #{template_type(template)}"
-msgstr "templates"
+#msgid "Error parsing links for a #{template_type(template)}"
+#msgstr "templates"
 
-msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#, fuzzy
+msgid "Error parsing links for a %{template}"
 msgstr ""
 
-#, fuzzy
-msgid "Error raised while saving the visibility for plan id %{plan_id}"
-msgstr "plans"
+#msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#msgstr ""
+
+#msgid "Error raised while saving the visibility for plan id %{plan_id}"
+#msgstr "plans"
 
 msgid "Error:"
 msgstr ""
@@ -1155,8 +1234,11 @@ msgid "Invalid maximum pages"
 msgstr "Número de páginas inválido"
 
 #, fuzzy
-msgid "Invitation to %{email} issued successfully. \n"
+msgid "Invitation to %{email} issued successfully."
 msgstr ""
+
+#msgid "Invitation to %{email} issued successfully. \n"
+#msgstr ""
 
 msgid "Invite collaborators"
 msgstr ""
@@ -1298,6 +1380,10 @@ msgid "Name"
 msgstr "Nombre"
 
 #, fuzzy
+msgid "New Notification"
+msgstr ""
+
+#, fuzzy
 msgid "New Question"
 msgstr "Pregunta"
 
@@ -1305,8 +1391,8 @@ msgstr "Pregunta"
 msgid "New Template"
 msgstr "Nueva plantilla"
 
-msgid "New Theme"
-msgstr ""
+#msgid "New Theme"
+#msgstr ""
 
 msgid "New notification"
 msgstr ""
@@ -1325,6 +1411,10 @@ msgstr "plans"
 #, fuzzy
 msgid "New question:"
 msgstr "Pregunta"
+
+#, fuzzy
+msgid "New theme"
+msgstr ""
 
 #, fuzzy
 msgid "New users"
@@ -1413,12 +1503,11 @@ msgstr "Nota"
 msgid "Notification Preferences"
 msgstr ""
 
-#, fuzzy
-msgid "Notification created successfully"
-msgstr "Creación"
+#msgid "Notification created successfully"
+#msgstr "Creación"
 
-msgid "Notification updated successfully"
-msgstr ""
+#msgid "Notification updated successfully"
+#msgstr ""
 
 msgid "Notifications"
 msgstr ""
@@ -1565,6 +1654,10 @@ msgid "PDF"
 msgstr ""
 
 #, fuzzy
+msgid "PDF <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
 msgid "PDF formatting"
 msgstr "Dando formato al PDF"
 
@@ -1610,9 +1703,8 @@ msgstr "Datos de contacto del proyecto"
 msgid "Plan Description"
 msgstr "Descripción"
 
-#, fuzzy
-msgid "Plan Guidance Configuration"
-msgstr "Guía"
+#msgid "Plan Guidance Configuration"
+#msgstr "Guía"
 
 msgid "Plan ID"
 msgstr "Identificador del Proyecto"
@@ -1637,44 +1729,51 @@ msgstr ""
 msgid "Plans"
 msgstr "plans"
 
-msgid "Please check the box to continue."
-msgstr ""
+#msgid "Please check the box to continue."
+#msgstr ""
 
 #, fuzzy
 msgid "Please choose an organisation"
 msgstr "Organización"
 
-msgid "Please choose one of the options."
-msgstr ""
+#msgid "Please choose one of the options."
+#msgstr ""
 
 msgid "Please do not reply to this email."
 msgstr ""
 
-#, fuzzy
-msgid "Please enter a First name."
-msgstr "Por favor, introduzca su nombre."
+#msgid "Please enter a First name."
+#msgstr "Por favor, introduzca su nombre."
 
 #, fuzzy
-msgid "Please enter a Last name."
-msgstr "Por favor, introduzca su nombre."
+msgid "Please enter a First name. "
+msgstr ""
+
+#msgid "Please enter a Last name."
+#msgstr "Por favor, introduzca su nombre."
+
+#, fuzzy
+msgid "Please enter a Last name. "
+msgstr ""
 
 msgid "Please enter a password confirmation"
 msgstr ""
 
-#, fuzzy
-msgid "Please enter a valid number."
-msgstr "Por favor, introduzca su nombre."
+#msgid "Please enter a valid number."
+#msgstr "Por favor, introduzca su nombre."
 
-#, fuzzy
-msgid "Please enter a valid value."
-msgstr "Por favor, introduzca su nombre."
+#msgid "Please enter a valid value."
+#msgstr "Por favor, introduzca su nombre."
 
 msgid "Please enter an email address"
 msgstr ""
 
+#msgid "Please enter an email address."
+#msgstr "Por favor, introduzca una dirección web válida."
+
 #, fuzzy
-msgid "Please enter an email address."
-msgstr "Por favor, introduzca una dirección web válida."
+msgid "Please enter an email address. "
+msgstr ""
 
 #, fuzzy
 msgid "Please enter the name of your organisation"
@@ -1719,8 +1818,8 @@ msgstr "Organización"
 msgid "Please select a valid research organisation from the list."
 msgstr "Organización"
 
-msgid "Please select a value from the list."
-msgstr ""
+#msgid "Please select a value from the list."
+#msgstr ""
 
 msgid "Please select an item from the list."
 msgstr ""
@@ -1894,6 +1993,10 @@ msgstr "Texto de la pregunta"
 msgid "Questions"
 msgstr "Preguntas"
 
+#, fuzzy
+msgid "Re-order sections"
+msgstr ""
+
 msgid "Read only"
 msgstr "Sólo lectura"
 
@@ -1923,9 +2026,12 @@ msgstr "Borrar"
 msgid "Remove this link"
 msgstr "Borrar"
 
+#msgid "Request Expert Feedback - Automated Email:"
+#msgstr "Correo electrónico"
+
 #, fuzzy
-msgid "Request Expert Feedback - Automated Email:"
-msgstr "Correo electrónico"
+msgid "Request Expert Feedback - Message Displayed on Share Plan Tab:"
+msgstr ""
 
 msgid "Request Feedback"
 msgstr ""
@@ -1954,6 +2060,12 @@ msgid "Run your own filter"
 msgstr ""
 
 #, fuzzy
+msgid "SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48"
+"       hours. If you have questions pertaining to this action please contact us"
+"       at %{organisation_email}."
+msgstr ""
+
+#, fuzzy
 msgid "Same as Principal Investigator"
 msgstr ""
 
@@ -1972,9 +2084,12 @@ msgstr "Organización"
 msgid "Save"
 msgstr "Guardar"
 
+#msgid "Save Unsuccessful."
+#msgstr "Guardar"
+
 #, fuzzy
-msgid "Save Unsuccessful."
-msgstr "Guardar"
+msgid "Save Unsuccessful. "
+msgstr ""
 
 msgid "Saving..."
 msgstr "Guardando..."
@@ -2017,6 +2132,10 @@ msgstr ""
 msgid "Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s)."
 msgstr "Editar la personalización"
 
+#, fuzzy
+msgid "Select Guidance"
+msgstr ""
+
 msgid "Select all"
 msgstr ""
 
@@ -2025,12 +2144,15 @@ msgid "Select an organisation from the list."
 msgstr "Organización"
 
 #, fuzzy
+msgid "Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+msgstr ""
+
+#, fuzzy
 msgid "Select one or more themes that are relevant to this question. This will allow similarly themed organisation-level guidance to appear alongside your question."
 msgstr "Organización"
 
-#, fuzzy
-msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
-msgstr ""
+#msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+#msgstr ""
 
 #, fuzzy
 msgid "Select phase to download"
@@ -2078,20 +2200,20 @@ msgstr ""
 msgid "Shibboleth Entity Id"
 msgstr ""
 
-msgid "Should be after start date"
-msgstr ""
+#msgid "Should be after start date"
+#msgstr ""
 
-msgid "Should be before expiration date"
-msgstr ""
+#msgid "Should be before expiration date"
+#msgstr ""
 
-msgid "Should be today or later"
-msgstr ""
+#msgid "Should be today or later"
+#msgstr ""
 
-msgid "Should be tomorrow or later"
-msgstr ""
+#msgid "Should be tomorrow or later"
+#msgstr ""
 
-msgid "Show"
-msgstr ""
+#msgid "Show"
+#msgstr ""
 
 #, fuzzy
 msgid "Show password"
@@ -2128,6 +2250,10 @@ msgid "Someone has requested a link to change your %{tool_name} password. You ca
 msgstr "Clave"
 
 #, fuzzy
+msgid "Sort by %{sort_field}"
+msgstr ""
+
+#, fuzzy
 msgid "Start"
 msgstr "Compartir"
 
@@ -2148,19 +2274,21 @@ msgid "Successfully %{action} %{username}'s account."
 msgstr "user"
 
 #, fuzzy
-msgid "Successfully %{action} your %{object}."
+msgid "Successfully %{action} the %{object}."
 msgstr ""
+
+#msgid "Successfully %{action} your %{object}."
+#msgstr ""
 
 #, fuzzy
 msgid "Successfully changed the permissions for #{@role.user.email}. They have been notified via email."
 msgstr ""
 
-#, fuzzy
-msgid "Successfully deleted your theme"
-msgstr "Borrar"
+#msgid "Successfully deleted your theme"
+#msgstr "Borrar"
 
-msgid "Successfully destroyed your notification"
-msgstr ""
+#msgid "Successfully destroyed your notification"
+#msgstr ""
 
 msgid "Successfully signed in"
 msgstr ""
@@ -2172,9 +2300,8 @@ msgstr ""
 msgid "Successfully unpublished your #{template_type(template)}"
 msgstr "templates"
 
-#, fuzzy
-msgid "Successfully updated %{username}"
-msgstr "user"
+#msgid "Successfully updated %{username}"
+#msgstr "user"
 
 msgid "Super Admin"
 msgstr ""
@@ -2258,6 +2385,15 @@ msgid "The Digital Curation Centre and UC3 team at the California Digital Librar
 msgstr "am"
 
 #, fuzzy
+msgid "The above plan creator(s) have agreed that others may use as"
+"             much of the text of this plan as they would like in their own plans,"
+"             and customise it as necessary. You do not need to credit the creator(s)"
+"             as the source of the language used, but using any of the plan's text"
+"             does not imply that the creator(s) endorse, or have any relationship to,"
+"             your project or proposal"
+msgstr ""
+
+#, fuzzy
 msgid "The current #{scheme.description} iD has been already linked to a user with email #{identifier.user.email}"
 msgstr "user"
 
@@ -2282,13 +2418,11 @@ msgstr ""
 msgid "The new platform will be separate from the services each of our teams runs on top of it. Our shared goal: provide a combined DMPRoadmap platform as a core infrastructure for DMPs. Future enhancements will focus on making DMPs machine actionable so please continue sharing your use cases."
 msgstr "am"
 
-#, fuzzy
-msgid "The password must be between 8 and 128 characters."
-msgstr "Clave"
+#msgid "The password must be between 8 and 128 characters."
+#msgstr "Clave"
 
-#, fuzzy
-msgid "The passwords must match."
-msgstr "Clave"
+#msgid "The passwords must match."
+#msgstr "Clave"
 
 #, fuzzy
 msgid "The plan %{plan_title} had its visibility changed to %{plan_visibility}."
@@ -2316,19 +2450,18 @@ msgstr "Organización"
 msgid "The table below lists the plans that you have created, and that have been shared with you by others. You can edit, share, download, make a copy, or remove these plans at any time."
 msgstr "Creación"
 
-msgid "The theme with id %{id} could not be destroyed"
-msgstr ""
+#msgid "The theme with id %{id} could not be destroyed"
+#msgstr ""
 
 #, fuzzy
 msgid "The ‘Share’ tab is also where you can set your plan visibility."
 msgstr ""
 
-#, fuzzy
-msgid "Theme created successfully"
-msgstr "Creación"
+#msgid "Theme created successfully"
+#msgstr "Creación"
 
-msgid "Theme updated successfully"
-msgstr ""
+#msgid "Theme updated successfully"
+#msgstr ""
 
 msgid "Themes"
 msgstr "Temas"
@@ -2367,8 +2500,8 @@ msgstr "plans"
 msgid "There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer"
 msgstr ""
 
-msgid "There is no theme associated with id %{id}"
-msgstr ""
+#msgid "There is no theme associated with id %{id}"
+#msgstr ""
 
 #, fuzzy
 msgid "There may also be an option to request feedback on your plan. This is available when research support staff at your organisation have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
@@ -2377,8 +2510,8 @@ msgstr ""
 msgid "There seems to be a problem with your logo. Please upload it again."
 msgstr ""
 
-msgid "This allows you to order sections."
-msgstr "Le permite ordenar las secciones."
+#msgid "This allows you to order sections."
+#msgstr "Le permite ordenar las secciones."
 
 msgid "This allows you to order the phases of your template."
 msgstr "Esto le permite ordenar las fases de su plantilla."
@@ -2483,6 +2616,10 @@ msgid "Unable to %{action} %{username}"
 msgstr "user"
 
 #, fuzzy
+msgid "Unable to %{action} the %{object}.%{errors}"
+msgstr ""
+
+#, fuzzy
 msgid "Unable to change the plan's status since it is needed at least %{percentage} percentage responded"
 msgstr "plans"
 
@@ -2494,13 +2631,20 @@ msgstr "plans"
 msgid "Unable to change your organisation affiliation at this time."
 msgstr "Organización"
 
+#msgid "Unable to create a new section because the phase you specified does not exist."
+#msgstr "Sección"
+
 #, fuzzy
-msgid "Unable to create a new section because the phase you specified does not exist."
-msgstr "Sección"
+msgid "Unable to create a new section. The phase you specified does not exist."
+msgstr ""
 
 #, fuzzy
 msgid "Unable to create a new version of this template."
 msgstr "templates"
+
+#, fuzzy
+msgid "Unable to create your account.#{errors_for_display(resource)}"
+msgstr ""
 
 #, fuzzy
 msgid "Unable to customize that template."
@@ -2545,11 +2689,11 @@ msgstr "templates"
 msgid "Unable to remove the plan"
 msgstr "plans"
 
-msgid "Unable to save since notification parameter is missing"
-msgstr ""
+#msgid "Unable to save since notification parameter is missing"
+#msgstr ""
 
-msgid "Unable to save since theme parameter is missing"
-msgstr ""
+#msgid "Unable to save since theme parameter is missing"
+#msgstr ""
 
 msgid "Unable to submit your request"
 msgstr ""
@@ -2557,8 +2701,8 @@ msgstr ""
 msgid "Unable to submit your request for feedback at this time."
 msgstr ""
 
-msgid "Unable to transfer your customizations."
-msgstr ""
+#msgid "Unable to transfer your customizations."
+#msgstr ""
 
 msgid "Unable to unlink your account from %{is}."
 msgstr ""
@@ -2567,9 +2711,8 @@ msgstr ""
 msgid "Unable to unpublish your #{template_type(template)}."
 msgstr "templates"
 
-#, fuzzy
-msgid "Unable to update %{username}"
-msgstr "user"
+#msgid "Unable to update %{username}"
+#msgstr "user"
 
 msgid "Unknown"
 msgstr ""
@@ -2641,8 +2784,8 @@ msgstr "Organización"
 msgid "User accounts"
 msgstr ""
 
-msgid "User not found."
-msgstr ""
+#msgid "User not found."
+#msgstr ""
 
 msgid "Users"
 msgstr "Usuarios"
@@ -2661,6 +2804,10 @@ msgid "View all guidance"
 msgstr "Ver todas las orientaciones"
 
 #, fuzzy
+msgid "View all notifications"
+msgstr ""
+
+#, fuzzy
 msgid "View all organisations"
 msgstr "Organización"
 
@@ -2670,6 +2817,10 @@ msgstr "Ver"
 
 msgid "View all templates"
 msgstr "Ver todas las plantillas"
+
+#, fuzzy
+msgid "View all themes"
+msgstr ""
 
 #, fuzzy
 msgid "View all users"
@@ -2701,9 +2852,8 @@ msgstr "templates"
 msgid "We invite you to peruse the DMPRoadmap GitHub wiki to learn how to "
 msgstr ""
 
-#, fuzzy
-msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
-msgstr ""
+#msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
+#msgstr ""
 
 #, fuzzy
 msgid "We will hold the personal data you provided us for as long as you continue using the %{application_name} service. Your personal data can be removed from this service upon request to the %{application_name} team within a period of 30 days."
@@ -2860,19 +3010,29 @@ msgstr "Acciones"
 msgid "You may change your notification preferences on your profile page."
 msgstr ""
 
+#, fuzzy
+msgid "You may change your notification preferences on your profile page. "
+msgstr ""
+
+#, fuzzy
+msgid "You may place them before or after the main template sections."
+msgstr ""
+
 msgid "You must accept the terms and conditions to register."
 msgstr ""
 
+#msgid "You must agree to the term and conditions."
+#msgstr ""
+
+#msgid "You must enter a valid URL (e.g. https://organisation.org)."
+#msgstr "Organización"
+
+#msgid "You must enter a valid email address."
+#msgstr "Debe introducir una dirección de correo electrónico válida."
+
 #, fuzzy
-msgid "You must agree to the term and conditions."
+msgid "You must provide a valid email address and select a permission level."
 msgstr ""
-
-#, fuzzy
-msgid "You must enter a valid URL (e.g. https://organisation.org)."
-msgstr "Organización"
-
-msgid "You must enter a valid email address."
-msgstr "Debe introducir una dirección de correo electrónico válida."
 
 #, fuzzy
 msgid "You must select a funder from the list or click the checkbox."
@@ -2931,6 +3091,11 @@ msgid "Your account has been successfully linked to your institutional credentia
 msgstr ""
 
 #, fuzzy
+msgid "Your colleague %{inviter_name} has invited you to contribute to"
+"            their Data Management Plan in %{tool_name}"
+msgstr ""
+
+#, fuzzy
 msgid "Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change."
 msgstr "Clave"
 
@@ -2969,8 +3134,8 @@ msgstr "plans"
 msgid "Your project is now a test."
 msgstr ""
 
-msgid "Your request for feedback has been submitted."
-msgstr ""
+#msgid "Your request for feedback has been submitted."
+#msgstr ""
 
 msgid "account has been locked due to an excessive number of unsuccessful sign in attempts."
 msgstr ""
@@ -3021,8 +3186,8 @@ msgstr ""
 msgid "can't be less than zero"
 msgstr ""
 
-msgid "changed"
-msgstr ""
+#msgid "changed"
+#msgstr ""
 
 #, fuzzy
 msgid "co-owner"
@@ -3040,6 +3205,14 @@ msgid "completed_plans"
 msgstr ""
 
 msgid "copied"
+msgstr ""
+
+#, fuzzy
+msgid "copy"
+msgstr ""
+
+#, fuzzy
+msgid "create"
 msgstr ""
 
 #, fuzzy
@@ -3062,6 +3235,10 @@ msgid "deactivate"
 msgstr ""
 
 msgid "deactivated"
+msgstr ""
+
+#, fuzzy
+msgid "delete"
 msgstr ""
 
 #, fuzzy
@@ -3090,8 +3267,12 @@ msgstr "Organización"
 msgid "generate_version! requires a published template"
 msgstr "templates"
 
-msgid "guidance"
+#, fuzzy
+msgid "get involved<em class=\"sr-only\"> (new window)</em>"
 msgstr ""
+
+#msgid "guidance"
+#msgstr ""
 
 #, fuzzy
 msgid "guidance group"
@@ -3103,6 +3284,10 @@ msgstr ""
 msgid "into your browser"
 msgstr ""
 
+#, fuzzy
+msgid "isn't a valid value"
+msgstr ""
+
 msgid "locals should be a Hash object"
 msgstr ""
 
@@ -3112,6 +3297,10 @@ msgstr ""
 
 #, fuzzy
 msgid "mock project for testing, practice, or educational purposes"
+msgstr ""
+
+#, fuzzy
+msgid "must be after %{date}"
 msgstr ""
 
 #, fuzzy
@@ -3132,9 +3321,8 @@ msgstr "guidances"
 msgid "must have access to plans api"
 msgstr "guidances"
 
-#, fuzzy
-msgid "note"
-msgstr "Nota"
+#msgid "note"
+#msgstr "Nota"
 
 #, fuzzy
 msgid "obj should be a Phase, Section, Question, or Annotation"
@@ -3164,28 +3352,28 @@ msgstr "Organización"
 msgid "page for guidance."
 msgstr ""
 
-#, fuzzy
-msgid "password"
-msgstr "Clave"
+#msgid "password"
+#msgstr "Clave"
 
 msgid "path_params should be a Hash object"
 msgstr ""
 
 #, fuzzy
-msgid "permissions"
-msgstr "Permisos"
+msgid "permission"
+msgstr ""
 
-#, fuzzy
-msgid "phase"
-msgstr "Fase"
+#msgid "permissions"
+#msgstr "Permisos"
+
+#msgid "phase"
+#msgstr "Fase"
 
 #, fuzzy
 msgid "plan"
 msgstr "plans"
 
-#, fuzzy
-msgid "plan's visibility"
-msgstr "Visibilidad"
+#msgid "plan's visibility"
+#msgstr "Visibilidad"
 
 #, fuzzy
 msgid "plans"
@@ -3202,10 +3390,18 @@ msgid "profile"
 msgstr ""
 
 #, fuzzy
+msgid "profile for %{username}"
+msgstr ""
+
+#, fuzzy
 msgid "project details coversheet"
 msgstr ""
 
 msgid "public"
+msgstr ""
+
+#, fuzzy
+msgid "publish"
 msgstr ""
 
 msgid "query_params should be a Hash object"
@@ -3236,6 +3432,10 @@ msgid "read-only"
 msgstr "Sólo lectura"
 
 #, fuzzy
+msgid "remove"
+msgstr ""
+
+#, fuzzy
 msgid "removed"
 msgstr "Borrar"
 
@@ -3243,9 +3443,12 @@ msgstr "Borrar"
 msgid "reviewer"
 msgstr "Previsualización"
 
+#msgid "role"
+#msgstr "Función"
+
 #, fuzzy
-msgid "role"
-msgstr "Función"
+msgid "save"
+msgstr ""
 
 #, fuzzy
 msgid "saved"
@@ -3294,12 +3497,23 @@ msgid "unanswered questions"
 msgstr ""
 
 #, fuzzy
+msgid "unpublish"
+msgstr ""
+
+#, fuzzy
+msgid "update"
+msgstr ""
+
+#, fuzzy
 msgid "updated"
 msgstr "Editar"
 
 #, fuzzy
-msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
-msgstr "templates"
+msgid "upgrade cannot be carried out since there is no published template of its current funder"
+msgstr ""
+
+#msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#msgstr "templates"
 
 #, fuzzy
 msgid "upgrade_customization! requires a customised template"

--- a/config/locale/fr_FR/app.po
+++ b/config/locale/fr_FR/app.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-06-14 15:10+0100\n"
-"PO-Revision-Date: 2018-06-20 16:23:24-0700\n"
+"PO-Revision-Date: 2018-10-19 11:10:55-0700\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: fr_FR\n"
@@ -41,11 +41,19 @@ msgstr " dans le projet. Vous pouvez également signaler les bugs et demander de
 msgid "#{text}"
 msgstr "#{text}"
 
+#, fuzzy
+msgid "%{affiliation}"
+msgstr ""
+
 msgid "%{application_name}"
 msgstr "%{application_name}"
 
-msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
-msgstr "%{application_name} est mis à disposition par %{organisation_name}.<br /> Vous pouvez trouver plus d'informations sur notre <a href=\"%{organisation_url}\" target=\"_blank\">site internet</a>. Si vous souhaitez nous contacter à propos de %{application_name}, remplissez le formulaire ci dessous."
+#, fuzzy
+msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website <em class=\"sr-only\">(new window)</em></a>. If you would like to contact us about %{application_name}, please fill out the form below."
+msgstr ""
+
+#msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#msgstr "%{application_name} est mis à disposition par %{organisation_name}.<br /> Vous pouvez trouver plus d'informations sur notre <a href=\"%{organisation_url}\" target=\"_blank\">site internet</a>. Si vous souhaitez nous contacter à propos de %{application_name}, remplissez le formulaire ci dessous."
 
 msgid "%{application_name}: %{user_name} requested feedback on a plan"
 msgstr "%{application_name} : %{user_name} a demandé de l'assistance conseil pour un plan."
@@ -56,14 +64,34 @@ msgstr "%{application_name} : Une assistance conseil a été fournie pour %{plan
 msgid "%{application_name}: Your plan has been submitted for feedback"
 msgstr "%{application_name} : Une assistance conseil a a été demandée pour votre plan"
 
+#, fuzzy
+msgid "%{authors}"
+msgstr ""
+
 msgid "%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don't want to accept the invitation, please ignore this email."
 msgstr "%{click_here} pour accepter l'invitation, (ou copier %{link} dans votre navigateur). Si vous ne souhaitez pas accepter cette invitation, ignorez ce message."
 
 msgid "%{commenter_name} has commented on the plan %{plan_title}. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
 msgstr "%{commenter_name} a laissé un commentaire sur le plan %{plan_title}. Pour voir les commentaires, allez sur le Tableau de Bord sur %{tool_name} et ouvrez votre plan."
 
-msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
-msgstr "%{commenter} a fourni une assistance conseil sur le plan \"%{plan_title}\". Pour voir les commentaires, consultez le Tableau de Bord sur %{tool_name} et ouvrez votre plan."
+#msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgstr "%{commenter} a fourni une assistance conseil sur le plan \"%{plan_title}\". Pour voir les commentaires, consultez le Tableau de Bord sur %{tool_name} et ouvrez votre plan."
+
+#, fuzzy
+msgid "%{date}"
+msgstr ""
+
+#, fuzzy
+msgid "%{description}"
+msgstr ""
+
+#, fuzzy
+msgid "%{funder}"
+msgstr ""
+
+#, fuzzy
+msgid "%{grant_number}"
+msgstr ""
 
 msgid "%{org_name} Plans"
 msgstr "%{org_name} Plans"
@@ -77,8 +105,8 @@ msgstr "%{org_title} Plans"
 msgid "%{org} Example Answer"
 msgstr "Exemple de réponse %{org}"
 
-msgid "%{org} Guidance"
-msgstr "Recommandation %{org}"
+#msgid "%{org} Guidance"
+#msgstr "Recommandation %{org}"
 
 msgid "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
 msgstr "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
@@ -86,8 +114,12 @@ msgstr "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questi
 msgid "%{plan_owner} has been notified that you have finished providing feedback"
 msgstr "%{plan_owner} a été informé que vous avez finalisé l'assistance conseil"
 
-msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
-msgstr "%{requestor} a demandé de l'assistance conseil pour le plan \"%{plan_name}.\" Pour ajouter des commentaires, consultez la page 'Plans' dans le menu Administration de %{application_name} et ouvrez le plan."
+#msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgstr "%{requestor} a demandé de l'assistance conseil pour le plan \"%{plan_name}.\" Pour ajouter des commentaires, consultez la page 'Plans' dans le menu Administration de %{application_name} et ouvrez le plan."
+
+#, fuzzy
+msgid "%{template}"
+msgstr ""
 
 msgid "%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}"
 msgstr "%{tool_name} vous aidera à élaborer votre DMP. Si vous avez des questions ou suggestions, contactez nous à %{helpdesk_email} ou par %{contact_us}"
@@ -95,11 +127,11 @@ msgstr "%{tool_name} vous aidera à élaborer votre DMP. Si vous avez des questi
 msgid "%{tool_name}: A new comment was added to %{plan_title}"
 msgstr "%{tool_name}: Un nouveau commentaire a été ajouté à %{plan_title}"
 
-msgid "%{username}'s profile"
-msgstr "profile de {username}"
+#msgid "%{username}'s profile"
+#msgstr "profile de {username}"
 
-msgid "%{value} is not a valid format"
-msgstr "%{value} n'est pas un format valide"
+#msgid "%{value} is not a valid format"
+#msgstr "%{value} n'est pas un format valide"
 
 msgid "'Download' allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application."
 msgstr "'Télécharger' vous permet de télécharger votre plan dans différents formats. Cela peut être utile si vous avez besoin de partager votre plan lors d'une demande de financement."
@@ -158,8 +190,13 @@ msgstr "Plan de gestion de données créé à l'aide de %{application_name}"
 msgid "A Data Management Plan in %{application_name} has been shared with you"
 msgstr "Un plan de gestion de données a été partagé avec vous sur %{application_name}"
 
-msgid "A Data Management Plan in %{tool_name} has been shared with you"
-msgstr "Un plan de gestion de données a été partagé avec vous sur %{tool_name}"
+#, fuzzy
+msgid "A Data Management Plan in %{tool_name} has been shared \"\"
+"                   \"with you"
+msgstr ""
+
+#msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#msgstr "Un plan de gestion de données a été partagé avec vous sur %{tool_name}"
 
 msgid "A colleague has invited you to contribute to their Data Management Plan in %{tool_name}"
 msgstr "Un collègue vous a invité à contribuer à son plan de gestion de données sur %{tool_name}"
@@ -206,8 +243,8 @@ msgstr "A propos de %{application_name}"
 msgid "Access removed"
 msgstr "Accès retiré"
 
-msgid "Accessibility"
-msgstr "Accessibilité"
+#msgid "Accessibility"
+#msgstr "Accessibilité"
 
 msgid "Actions"
 msgstr "Actions"
@@ -311,6 +348,10 @@ msgstr "Permet à l'utilisateur de gérer l'affiliation à l'organisme"
 msgid "An error has occurred while saving/resetting your export settings."
 msgstr "Une erreur s'est produite lors de la sauvegarde/réinitialisation de vos paramètres d'export."
 
+#, fuzzy
+msgid "An error occurred when requesting feedback for this plan."
+msgstr ""
+
 msgid "Annotations"
 msgstr "Annotations"
 
@@ -389,8 +430,13 @@ msgstr "Avant de commencer, nous avons besoin de quelques informations concernan
 msgid "Begin typing to see a filtered list"
 msgstr "Commencez à saisir du texte pour afficher une liste déroulante"
 
-msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
-msgstr "La liste ci-dessous indique les utilisateurs de votre organisme. Ces informations peuvent être triées par champ."
+#, fuzzy
+msgid "Below is a list of users registered for your organisation. You can"
+"        sort the data by each field."
+msgstr ""
+
+#msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#msgstr "La liste ci-dessous indique les utilisateurs de votre organisme. Ces informations peuvent être triées par champ."
 
 msgid "Body"
 msgstr "Contenu"
@@ -494,14 +540,14 @@ msgstr "Copie de %{template}"
 msgid "Copyright information:"
 msgstr "Droits d'auteur"
 
-msgid "Could not create your %{o}."
-msgstr "Impossible de créer %{o}."
+#msgid "Could not create your %{o}."
+#msgstr "Impossible de créer %{o}."
 
-msgid "Could not delete the %{o}."
-msgstr "Impossible de supprimer %{o}."
+#msgid "Could not delete the %{o}."
+#msgstr "Impossible de supprimer %{o}."
 
-msgid "Could not update your %{o}."
-msgstr "Impossible de mettre à jour %{o}."
+#msgid "Could not update your %{o}."
+#msgstr "Impossible de mettre à jour %{o}."
 
 msgid "Create Organisation"
 msgstr "Créer une organisation"
@@ -545,14 +591,18 @@ msgstr "Créé à"
 msgid "Created date"
 msgstr "Date de création"
 
-msgid "Created using the %{application_name} service. Last modified %{date}"
-msgstr "Créé avec %{application_name}. Dernière modification %{date}"
+#msgid "Created using the %{application_name} service. Last modified %{date}"
+#msgstr "Créé avec %{application_name}. Dernière modification %{date}"
 
 msgid "Created using the %{application_name}. Last modified %{date}"
 msgstr "Créé avec %{application_name}. Dernière modification %{date}"
 
 msgid "Creator:"
 msgstr "Créateur : "
+
+#, fuzzy
+msgid "Creators:"
+msgstr ""
 
 msgid "Creators: "
 msgstr "Créateurs : "
@@ -563,8 +613,24 @@ msgstr "Droits"
 msgid "Current password"
 msgstr "Mot de passe actuel"
 
+#, fuzzy
+msgid "Customisable Templates"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are published"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are unpublished"
+msgstr ""
+
 msgid "Customise"
 msgstr "Personnaliser"
+
+#, fuzzy
+msgid "Customise phase"
+msgstr ""
 
 msgid "Customising for your Organisation"
 msgstr "Personnalisation pour votre organisme"
@@ -572,14 +638,14 @@ msgstr "Personnalisation pour votre organisme"
 msgid "Customizable Templates"
 msgstr "Modèles personnalisables"
 
-msgid "Customizations are published"
-msgstr "Les personnalisations sont publiées"
+#msgid "Customizations are published"
+#msgstr "Les personnalisations sont publiées"
 
-msgid "Customizations are unpublished"
-msgstr "Les personnalisations ne sont pas publiées"
+#msgid "Customizations are unpublished"
+#msgstr "Les personnalisations ne sont pas publiées"
 
-msgid "Customize phase"
-msgstr "Personnaliser la phase"
+#msgid "Customize phase"
+#msgstr "Personnaliser la phase"
 
 msgid "DMP Background"
 msgstr "Contexte du DMP"
@@ -596,8 +662,12 @@ msgstr "DMPRoadmap"
 msgid "DMPRoadmap ('the tool', 'the system"
 msgstr "DMPRoadmap ('l'outil', 'le système'"
 
-msgid "DOCX"
-msgstr "DOCX"
+#msgid "DOCX"
+#msgstr "DOCX"
+
+#, fuzzy
+msgid "DOCX <em class=\"sr-only\">(new window)</em>"
+msgstr ""
 
 msgid "Data Contact Person"
 msgstr "Personne-contact pour les données"
@@ -653,17 +723,37 @@ msgstr "N'oubliez pas de sauvegarder vos changements après avoir fait vos séle
 msgid "Download"
 msgstr "Télécharger"
 
-msgid "Download Plan"
-msgstr "Télécharger le plan"
+#msgid "Download Plan"
+#msgstr "Télécharger le plan"
+
+#, fuzzy
+msgid "Download Plan <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
+msgid "Download global usage"
+msgstr ""
 
 msgid "Download plans"
 msgstr "Télécharger les plans"
 
+#, fuzzy
+msgid "Download plans <em class=\"sr-only\">(new window)</span>"
+msgstr ""
+
 msgid "Download settings"
 msgstr "Paramètres de téléchargement"
 
+#, fuzzy
+msgid "Download users"
+msgstr ""
+
 msgid "Draft"
 msgstr "Brouillon"
+
+#, fuzzy
+msgid "Drag arrows to rearrange sections."
+msgstr ""
 
 msgid "Edit"
 msgstr "Modifier"
@@ -671,8 +761,8 @@ msgstr "Modifier"
 msgid "Edit Profile"
 msgstr "Editer le profil"
 
-msgid "Edit Theme"
-msgstr "Modifier le thème"
+#msgid "Edit Theme"
+#msgstr "Modifier le thème"
 
 msgid "Edit User Privileges"
 msgstr "Modifier les droits utilisateur"
@@ -743,14 +833,18 @@ msgstr "Saisissez des instructions spécifiques pour accompagner cette question.
 msgid "Enter your guidance here. You can include links where needed."
 msgstr "Entrez ici vos conseils. Vous pouvez ajouter des liens là où il faut."
 
-msgid "Error parsing links for a #{template_type(template)}"
-msgstr "Erreur lors de l'analyse des liens pour un #{@template.template_type}"
+#msgid "Error parsing links for a #{template_type(template)}"
+#msgstr "Erreur lors de l'analyse des liens pour un #{@template.template_type}"
 
-msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
-msgstr "Erreur lors de votre enregistrement. Vérifiez que vous avez fourni une adresse électronique valide et que vous avez choisi un mot de passe d'au moins 8 caractères. "
+#, fuzzy
+msgid "Error parsing links for a %{template}"
+msgstr ""
 
-msgid "Error raised while saving the visibility for plan id %{plan_id}"
-msgstr "Un erreur s'est produite lors de la sauvegarde de la visibilité d'un identifiant de plan %{plan_id}"
+#msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#msgstr "Erreur lors de votre enregistrement. Vérifiez que vous avez fourni une adresse électronique valide et que vous avez choisi un mot de passe d'au moins 8 caractères. "
+
+#msgid "Error raised while saving the visibility for plan id %{plan_id}"
+#msgstr "Un erreur s'est produite lors de la sauvegarde de la visibilité d'un identifiant de plan %{plan_id}"
 
 msgid "Error:"
 msgstr "Erreur :"
@@ -986,8 +1080,12 @@ msgstr "Taille de police non valide"
 msgid "Invalid maximum pages"
 msgstr "Nombre de pages maxi non valide"
 
-msgid "Invitation to %{email} issued successfully. \n"
-msgstr "L'invitation a bien été envoyée à %{email}. \n"
+#, fuzzy
+msgid "Invitation to %{email} issued successfully."
+msgstr ""
+
+#msgid "Invitation to %{email} issued successfully. \n"
+#msgstr "L'invitation a bien été envoyée à %{email}. \n"
 
 msgid "Invite collaborators"
 msgstr "Inviter des collaborateurs"
@@ -1112,14 +1210,18 @@ msgstr "N/D"
 msgid "Name"
 msgstr "Prénom"
 
+#, fuzzy
+msgid "New Notification"
+msgstr ""
+
 msgid "New Question"
 msgstr "Nouvelle question"
 
 msgid "New Template"
 msgstr "Nouveau modèle"
 
-msgid "New Theme"
-msgstr "Nouveau thème"
+#msgid "New Theme"
+#msgstr "Nouveau thème"
 
 msgid "New notification"
 msgstr "Nouvelle notification"
@@ -1135,6 +1237,10 @@ msgstr "Nouveaux plans"
 
 msgid "New question:"
 msgstr "Nouvelle question :"
+
+#, fuzzy
+msgid "New theme"
+msgstr ""
 
 msgid "New users"
 msgstr "Nouveaux utilisateurs"
@@ -1208,11 +1314,11 @@ msgstr "Note :"
 msgid "Notification Preferences"
 msgstr "Préférences des notifications"
 
-msgid "Notification created successfully"
-msgstr "Notification créée avec succès"
+#msgid "Notification created successfully"
+#msgstr "Notification créée avec succès"
 
-msgid "Notification updated successfully"
-msgstr "Notification mise à jour avec succès"
+#msgid "Notification updated successfully"
+#msgstr "Notification mise à jour avec succès"
 
 msgid "Notifications"
 msgstr "Notifications"
@@ -1328,6 +1434,10 @@ msgstr "Nom du propriétaire"
 msgid "PDF"
 msgstr "PDF"
 
+#, fuzzy
+msgid "PDF <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
 msgid "PDF formatting"
 msgstr "Mise en forme du PDF"
 
@@ -1367,8 +1477,8 @@ msgstr "Contact pour les données du plan"
 msgid "Plan Description"
 msgstr "Description"
 
-msgid "Plan Guidance Configuration"
-msgstr "Sélection des recommandations du plan"
+#msgid "Plan Guidance Configuration"
+#msgstr "Sélection des recommandations du plan"
 
 msgid "Plan ID"
 msgstr "Identifiant du projet"
@@ -1391,38 +1501,50 @@ msgstr "Plan partagé avec %{email}."
 msgid "Plans"
 msgstr "Plans"
 
-msgid "Please check the box to continue."
-msgstr "Veuillez cocher la case pour continuer."
+#msgid "Please check the box to continue."
+#msgstr "Veuillez cocher la case pour continuer."
 
 msgid "Please choose an organisation"
 msgstr "Veuillez choisir un organisme"
 
-msgid "Please choose one of the options."
-msgstr "Veuillez choisir l'une des options."
+#msgid "Please choose one of the options."
+#msgstr "Veuillez choisir l'une des options."
 
 msgid "Please do not reply to this email."
 msgstr "Merci de ne pas répondre à ce mail."
 
-msgid "Please enter a First name."
-msgstr "Veuillez entrer un prénom."
+#msgid "Please enter a First name."
+#msgstr "Veuillez entrer un prénom."
 
-msgid "Please enter a Last name."
-msgstr "Veuillez entrer un nom."
+#, fuzzy
+msgid "Please enter a First name. "
+msgstr ""
+
+#msgid "Please enter a Last name."
+#msgstr "Veuillez entrer un nom."
+
+#, fuzzy
+msgid "Please enter a Last name. "
+msgstr ""
 
 msgid "Please enter a password confirmation"
 msgstr "Veuillez confirmer votre mot de passe"
 
-msgid "Please enter a valid number."
-msgstr "Merci de saisir un nombre valide."
+#msgid "Please enter a valid number."
+#msgstr "Merci de saisir un nombre valide."
 
-msgid "Please enter a valid value."
-msgstr "Merci de saisir une valeur valide."
+#msgid "Please enter a valid value."
+#msgstr "Merci de saisir une valeur valide."
 
 msgid "Please enter an email address"
 msgstr "Veuillez entrer une adresse électronique"
 
-msgid "Please enter an email address."
-msgstr "Veuillez entrer une adresse électronique."
+#msgid "Please enter an email address."
+#msgstr "Veuillez entrer une adresse électronique."
+
+#, fuzzy
+msgid "Please enter an email address. "
+msgstr ""
 
 msgid "Please enter the name of your organisation"
 msgstr "Merci de saisir le nom de votre organisme"
@@ -1460,8 +1582,8 @@ msgstr "Merci de sélectionner un organisme de financement valide de la liste."
 msgid "Please select a valid research organisation from the list."
 msgstr "Merci de sélectionner un organisme de recherche valide de la liste."
 
-msgid "Please select a value from the list."
-msgstr "Merci de sélectionner une valeur de la liste."
+#msgid "Please select a value from the list."
+#msgstr "Merci de sélectionner une valeur de la liste."
 
 msgid "Please select an item from the list."
 msgstr "Merci de sélectionner un item de la liste."
@@ -1610,6 +1732,10 @@ msgstr "Texte de la question"
 msgid "Questions"
 msgstr "Questions"
 
+#, fuzzy
+msgid "Re-order sections"
+msgstr ""
+
 msgid "Read only"
 msgstr "Lecture seule"
 
@@ -1634,8 +1760,12 @@ msgstr "Supprimer le filtre"
 msgid "Remove this link"
 msgstr "Supprimer ce lien"
 
-msgid "Request Expert Feedback - Automated Email:"
-msgstr "Demande d'assistance conseil - mail automatique :"
+#msgid "Request Expert Feedback - Automated Email:"
+#msgstr "Demande d'assistance conseil - mail automatique :"
+
+#, fuzzy
+msgid "Request Expert Feedback - Message Displayed on Share Plan Tab:"
+msgstr ""
 
 msgid "Request Feedback"
 msgstr "Demande d'assistance conseil"
@@ -1661,6 +1791,12 @@ msgstr "Rôle"
 msgid "Run your own filter"
 msgstr "Filtrer"
 
+#, fuzzy
+msgid "SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48"
+"       hours. If you have questions pertaining to this action please contact us"
+"       at %{organisation_email}."
+msgstr ""
+
 msgid "Same as Principal Investigator"
 msgstr "Identique au Chercheur Principal"
 
@@ -1676,8 +1812,12 @@ msgstr "Des exemples de plans sont fournis par un financeur, un organisme ou un 
 msgid "Save"
 msgstr "Enregistrer"
 
-msgid "Save Unsuccessful."
-msgstr "Sauvegarde non effectuée."
+#msgid "Save Unsuccessful."
+#msgstr "Sauvegarde non effectuée."
+
+#, fuzzy
+msgid "Save Unsuccessful. "
+msgstr ""
 
 msgid "Saving..."
 msgstr "Enregistrement en cours..."
@@ -1716,17 +1856,25 @@ msgstr "Voir la liste des institutions partenaires."
 msgid "Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s)."
 msgstr "Sélectionnez 'Transférer la personnalisation' dans le menu Actions afin de vérifier vos personnalisations et appliquer les changements nécessaires. Lorsque que vous avez terminé, vous devez retourner au menu Actions et publier vos personnalisations."
 
+#, fuzzy
+msgid "Select Guidance"
+msgstr ""
+
 msgid "Select all"
 msgstr "Tout sélectionner"
 
 msgid "Select an organisation from the list."
 msgstr "Sélectionner un organisme dans la liste."
 
+#, fuzzy
+msgid "Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+msgstr ""
+
 msgid "Select one or more themes that are relevant to this question. This will allow similarly themed organisation-level guidance to appear alongside your question."
 msgstr "Choisir un ou plusieurs thèmes concernant cette question. Cela permettra d'afficher des recommandations similaires au niveau des organismes à côté de votre question."
 
-msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
-msgstr "Sélectionnez un thème pertinent pour cette recommandation. Cela affichera votre guide générique au niveau de l'organisation, ou toutes les écoles/départements pour lesquels vous créez des groupes de guidage, parmi tous les modèles qui ont des questions avec les tags de thème correspondants."
+#msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+#msgstr "Sélectionnez un thème pertinent pour cette recommandation. Cela affichera votre guide générique au niveau de l'organisation, ou toutes les écoles/départements pour lesquels vous créez des groupes de guidage, parmi tous les modèles qui ont des questions avec les tags de thème correspondants."
 
 msgid "Select phase to download"
 msgstr "Sélectionner la phase à télécharger"
@@ -1767,20 +1915,20 @@ msgstr "Domaine Shibboleth"
 msgid "Shibboleth Entity Id"
 msgstr "Identifiant de l'entité Shibboleth"
 
-msgid "Should be after start date"
-msgstr "Doit être après la date de début"
+#msgid "Should be after start date"
+#msgstr "Doit être après la date de début"
 
-msgid "Should be before expiration date"
-msgstr "Doit être avant la date d'expiration"
+#msgid "Should be before expiration date"
+#msgstr "Doit être avant la date d'expiration"
 
-msgid "Should be today or later"
-msgstr "Doit être aujourd'hui ou plus tard"
+#msgid "Should be today or later"
+#msgstr "Doit être aujourd'hui ou plus tard"
 
-msgid "Should be tomorrow or later"
-msgstr "Doit être demain ou plus tard"
+#msgid "Should be tomorrow or later"
+#msgstr "Doit être demain ou plus tard"
 
-msgid "Show"
-msgstr "Afficher"
+#msgid "Show"
+#msgstr "Afficher"
 
 msgid "Show password"
 msgstr "Afficher le mot de passe"
@@ -1809,6 +1957,10 @@ msgstr "Passer le contenu principal"
 msgid "Someone has requested a link to change your %{tool_name} password. You can do this through the link below."
 msgstr "Quelqu'un a demandé un lien pour modifier votre mot de passe %{tool_name}. Vous pouvez le faire via le lien ci-dessous."
 
+#, fuzzy
+msgid "Sort by %{sort_field}"
+msgstr ""
+
 msgid "Start"
 msgstr "Début"
 
@@ -1827,18 +1979,22 @@ msgstr "Envoyer"
 msgid "Successfully %{action} %{username}'s account."
 msgstr "Compte de %{username} %{action} avec succès."
 
-msgid "Successfully %{action} your %{object}."
-msgstr "%{object} %{action} avec succès."
+#, fuzzy
+msgid "Successfully %{action} the %{object}."
+msgstr ""
+
+#msgid "Successfully %{action} your %{object}."
+#msgstr "%{object} %{action} avec succès."
 
 #, fuzzy
 msgid "Successfully changed the permissions for #{@role.user.email}. They have been notified via email."
 msgstr ""
 
-msgid "Successfully deleted your theme"
-msgstr "Votre thème a bien été supprimé"
+#msgid "Successfully deleted your theme"
+#msgstr "Votre thème a bien été supprimé"
 
-msgid "Successfully destroyed your notification"
-msgstr "Notification supprimée avec succès"
+#msgid "Successfully destroyed your notification"
+#msgstr "Notification supprimée avec succès"
 
 msgid "Successfully signed in"
 msgstr "Vous êtes connecté"
@@ -1849,8 +2005,8 @@ msgstr "Compte délié de %{is} avec succès."
 msgid "Successfully unpublished your #{template_type(template)}"
 msgstr "#{template_type(template)} dépublié avec succès."
 
-msgid "Successfully updated %{username}"
-msgstr "%{username} mis à jour avec succès"
+#msgid "Successfully updated %{username}"
+#msgstr "%{username} mis à jour avec succès"
 
 msgid "Super Admin"
 msgstr "Super Administration"
@@ -1921,6 +2077,15 @@ msgstr "L'équipe %{tool_name}"
 msgid "The Digital Curation Centre and UC3 team at the California Digital Library have developed and delivered tools for data management planning since the advent of open data policies in 2011. "
 msgstr "Le Digital Curation Center et l'équipe UC3 de la California Digital Library ont développé et fourni des outils pour la planification de la gestion des données depuis l'avènement des politiques de données ouvertes en 2011. "
 
+#, fuzzy
+msgid "The above plan creator(s) have agreed that others may use as"
+"             much of the text of this plan as they would like in their own plans,"
+"             and customise it as necessary. You do not need to credit the creator(s)"
+"             as the source of the language used, but using any of the plan's text"
+"             does not imply that the creator(s) endorse, or have any relationship to,"
+"             your project or proposal"
+msgstr ""
+
 msgid "The current #{scheme.description} iD has been already linked to a user with email #{identifier.user.email}"
 msgstr "L'identifiant #{scheme.description} actuel a déjà été lié à l'utilisateur avec l'adresse #{identifier.user.email}"
 
@@ -1942,11 +2107,11 @@ msgstr "La clé %{key} n'a pas un ensemble valide d'objets \"liens\""
 msgid "The new platform will be separate from the services each of our teams runs on top of it. Our shared goal: provide a combined DMPRoadmap platform as a core infrastructure for DMPs. Future enhancements will focus on making DMPs machine actionable so please continue sharing your use cases."
 msgstr "La nouvelle plateforme sera distincte des services que chacune de nos équipes utilise. Notre objectif commun : fournir une plate-forme DMPRoadmap combinée en tant qu'infrastructure de base pour les DMPs. Les améliorations futures viseront à rendre le DMP « machine actionable », donc continuez à partager vos cas d'utilisation."
 
-msgid "The password must be between 8 and 128 characters."
-msgstr "Le mot de passe doit comporter entre 8 et 128 caractères."
+#msgid "The password must be between 8 and 128 characters."
+#msgstr "Le mot de passe doit comporter entre 8 et 128 caractères."
 
-msgid "The passwords must match."
-msgstr "Les mots de passe doivent correspondre."
+#msgid "The passwords must match."
+#msgstr "Les mots de passe doivent correspondre."
 
 msgid "The plan %{plan_title} had its visibility changed to %{plan_visibility}."
 msgstr "La visibilité du plan %{plan_title} a changé pour %{plan_visibility}."
@@ -1969,17 +2134,17 @@ msgstr "Le tableau ci-dessous répertorie les plans que les utilisateurs de votr
 msgid "The table below lists the plans that you have created, and that have been shared with you by others. You can edit, share, download, make a copy, or remove these plans at any time."
 msgstr "Dans le tableau ci-dessous figurent les plans que vous avez créés, ainsi que ceux que vous partagez avec d'autres. Vous pouvez à tout moment les modifier, les partager, les télécharger, en faire une copie ou les supprimer."
 
-msgid "The theme with id %{id} could not be destroyed"
-msgstr "Le thème avec l'identifiant %{id} ne peut pas être supprimé"
+#msgid "The theme with id %{id} could not be destroyed"
+#msgstr "Le thème avec l'identifiant %{id} ne peut pas être supprimé"
 
 msgid "The ‘Share’ tab is also where you can set your plan visibility."
 msgstr "L'onglet ‘Partager’ permet également de modifier la visibilité de votre plan."
 
-msgid "Theme created successfully"
-msgstr "Le thème a été créé avec succès"
+#msgid "Theme created successfully"
+#msgstr "Le thème a été créé avec succès"
 
-msgid "Theme updated successfully"
-msgstr "Le thème a bien été mis à jour"
+#msgid "Theme updated successfully"
+#msgstr "Le thème a bien été mis à jour"
 
 msgid "Themes"
 msgstr "Thèmes"
@@ -2011,8 +2176,8 @@ msgstr "Il n'existe aucun plan avec l'identifiant %{id} pour lequel une réponse
 msgid "There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer"
 msgstr "Il n'existe aucune question avec l'identifiant %{question_id} associée à l'identifiant de plan %{plan_id} pour laquelle une réponse peut être créée ou modifiée"
 
-msgid "There is no theme associated with id %{id}"
-msgstr "Il n'y a pas de thème associé à l'identifiant %{id}"
+#msgid "There is no theme associated with id %{id}"
+#msgstr "Il n'y a pas de thème associé à l'identifiant %{id}"
 
 msgid "There may also be an option to request feedback on your plan. This is available when research support staff at your organisation have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
 msgstr "Une option de demande d'assistance/conseil peut également être disponible pour votre plan. Elle est disponible lorsque l'équipe de support de votre organisation a activé ce service. Cliquer sur 'Demander une assistance/conseil', votre administrateur sera alors informé de votre demande. Leurs commentaires seront visibles dans le champ 'Commentaires' adjacent à chaque question. Vous serez notifié par email lorsque qu'un administrateur fourni une assistance/conseil."
@@ -2020,8 +2185,8 @@ msgstr "Une option de demande d'assistance/conseil peut également être disponi
 msgid "There seems to be a problem with your logo. Please upload it again."
 msgstr "Il y a un problème avec votre logo. Veuillez le télécharger à nouveau."
 
-msgid "This allows you to order sections."
-msgstr "Cette fonction vous permet de classer des sections."
+#msgid "This allows you to order sections."
+#msgstr "Cette fonction vous permet de classer des sections."
 
 msgid "This allows you to order the phases of your template."
 msgstr "Cette fonction vous permet de classer les phases de votre modèle."
@@ -2107,6 +2272,10 @@ msgstr "URL"
 msgid "Unable to %{action} %{username}"
 msgstr "Impossible de %{action} %{username}"
 
+#, fuzzy
+msgid "Unable to %{action} the %{object}.%{errors}"
+msgstr ""
+
 msgid "Unable to change the plan's status since it is needed at least %{percentage} percentage responded"
 msgstr "Impossible de changer le statut du plan, au moins %{percentage} % de questions répondues sont nécessaires"
 
@@ -2116,11 +2285,19 @@ msgstr "Impossible de changer le statut du plan"
 msgid "Unable to change your organisation affiliation at this time."
 msgstr "Impossible de changer l'affiliation de votre organisme pour le moment."
 
-msgid "Unable to create a new section because the phase you specified does not exist."
-msgstr "Impossible de créer une nouvelle secton car la phase spécifiée n'existe pas."
+#msgid "Unable to create a new section because the phase you specified does not exist."
+#msgstr "Impossible de créer une nouvelle secton car la phase spécifiée n'existe pas."
+
+#, fuzzy
+msgid "Unable to create a new section. The phase you specified does not exist."
+msgstr ""
 
 msgid "Unable to create a new version of this template."
 msgstr "Impossible de créer une nouvelle version de ce modèle."
+
+#, fuzzy
+msgid "Unable to create your account.#{errors_for_display(resource)}"
+msgstr ""
 
 msgid "Unable to customize that template."
 msgstr "Impossible de personnaliser ce modèle."
@@ -2155,11 +2332,11 @@ msgstr "Impossible de publier votre #{template_type(template)}."
 msgid "Unable to remove the plan"
 msgstr "Impossible de supprimer le plan"
 
-msgid "Unable to save since notification parameter is missing"
-msgstr "Impossible d'enregistrer car un paramètre de notification est manquant"
+#msgid "Unable to save since notification parameter is missing"
+#msgstr "Impossible d'enregistrer car un paramètre de notification est manquant"
 
-msgid "Unable to save since theme parameter is missing"
-msgstr "Impossible d'enregistrer car le paramètre de thème est manquant"
+#msgid "Unable to save since theme parameter is missing"
+#msgstr "Impossible d'enregistrer car le paramètre de thème est manquant"
 
 msgid "Unable to submit your request"
 msgstr "Impossible de soumettre votre demande"
@@ -2167,8 +2344,8 @@ msgstr "Impossible de soumettre votre demande"
 msgid "Unable to submit your request for feedback at this time."
 msgstr "Impossible de soumettre votre demande d'assistance conseil pour le moment."
 
-msgid "Unable to transfer your customizations."
-msgstr "Impossible de transférer vos personnalisations."
+#msgid "Unable to transfer your customizations."
+#msgstr "Impossible de transférer vos personnalisations."
 
 msgid "Unable to unlink your account from %{is}."
 msgstr "Impossible de délier votre compte de %{is}."
@@ -2176,8 +2353,8 @@ msgstr "Impossible de délier votre compte de %{is}."
 msgid "Unable to unpublish your #{template_type(template)}."
 msgstr "Impossible de dépublier votre #{template_type(template)}."
 
-msgid "Unable to update %{username}"
-msgstr "Impossible de mettre à jour %{username}"
+#msgid "Unable to update %{username}"
+#msgstr "Impossible de mettre à jour %{username}"
 
 msgid "Unknown"
 msgstr "Inconnu"
@@ -2239,8 +2416,8 @@ msgstr "Utilisez les filtres pour générer des statistiques d'utilisation d'un 
 msgid "User accounts"
 msgstr "Comptes utilisateurs"
 
-msgid "User not found."
-msgstr "Utilisateur non trouvé."
+#msgid "User not found."
+#msgstr "Utilisateur non trouvé."
 
 msgid "Users"
 msgstr "Utilisateurs"
@@ -2257,6 +2434,10 @@ msgstr "Voir tout"
 msgid "View all guidance"
 msgstr "Voir toutes les recommandations"
 
+#, fuzzy
+msgid "View all notifications"
+msgstr ""
+
 msgid "View all organisations"
 msgstr "Voir tous les organismes"
 
@@ -2265,6 +2446,10 @@ msgstr "Voir tous les résultats de la recherche"
 
 msgid "View all templates"
 msgstr "Voir tous les modèles"
+
+#, fuzzy
+msgid "View all themes"
+msgstr ""
 
 msgid "View all users"
 msgstr "Voir tous les utilisateurs"
@@ -2290,8 +2475,8 @@ msgstr "Nous avons trouvé plusieurs modèles correspondants à votre financeur.
 msgid "We invite you to peruse the DMPRoadmap GitHub wiki to learn how to "
 msgstr "Nous vous invitons à lire attentivement le wiki du GitHub de DMPRoadmap pour apprendre à "
 
-msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
-msgstr "Impossible de valider votre compte. Veuillez utilisez le formulaire ci-dessous pour créer un nouveau compte. Vous pourrez lier votre nouveau compte plus tard."
+#msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
+#msgstr "Impossible de valider votre compte. Veuillez utilisez le formulaire ci-dessous pour créer un nouveau compte. Vous pourrez lier votre nouveau compte plus tard."
 
 msgid "We will hold the personal data you provided us for as long as you continue using the %{application_name} service. Your personal data can be removed from this service upon request to the %{application_name} team within a period of 30 days."
 msgstr "Nous stockerons les données personnelles que vous avez fournies aussi longtemps que vous utiliserez %{application_name}. Vos données personnelles peuvent être supprimées de ce service suite à tout demande à l'équipe %{application_name}, dans un délai de 30 jours."
@@ -2422,17 +2607,29 @@ msgstr "Vos avez des modifications non publiées ! Sélectionner \"Publier les m
 msgid "You may change your notification preferences on your profile page."
 msgstr "Vous pouvez changer vos préférences de notifications dans votre profil."
 
+#, fuzzy
+msgid "You may change your notification preferences on your profile page. "
+msgstr ""
+
+#, fuzzy
+msgid "You may place them before or after the main template sections."
+msgstr ""
+
 msgid "You must accept the terms and conditions to register."
 msgstr "Vous devez accepter les conditions générales d'utilisation pour vous enregistrer."
 
-msgid "You must agree to the term and conditions."
-msgstr "Vous devez accepter les conditions générales d'utilisation."
+#msgid "You must agree to the term and conditions."
+#msgstr "Vous devez accepter les conditions générales d'utilisation."
 
-msgid "You must enter a valid URL (e.g. https://organisation.org)."
-msgstr "Vous devez saisir une URL valide (par ex. : https://organisme.org)."
+#msgid "You must enter a valid URL (e.g. https://organisation.org)."
+#msgstr "Vous devez saisir une URL valide (par ex. : https://organisme.org)."
 
-msgid "You must enter a valid email address."
-msgstr "Vous devez entrer une adresse valide."
+#msgid "You must enter a valid email address."
+#msgstr "Vous devez entrer une adresse valide."
+
+#, fuzzy
+msgid "You must provide a valid email address and select a permission level."
+msgstr ""
 
 msgid "You must select a funder from the list or click the checkbox."
 msgstr "You devez sélectionner un financeur dans la liste ou cliquer sur la case à cocher."
@@ -2482,6 +2679,11 @@ msgstr "Votre compte a été lié à %{scheme} avec succès."
 msgid "Your account has been successfully linked to your institutional credentials. You will now be able to sign in with them."
 msgstr "Votre compte a été lié avec succès à vos identifiants institutionnels. Vous pouvez à présent vous connecter avec ceux-ci."
 
+#, fuzzy
+msgid "Your colleague %{inviter_name} has invited you to contribute to"
+"            their Data Management Plan in %{tool_name}"
+msgstr ""
+
 msgid "Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change."
 msgstr "Votre adresse électronique est également votre identifiant de connexion, c'est une information importante de votre compte. Pour votre sécurité, nous vous demandons de confirmer votre mot de passe avant d'effectuer ce changement."
 
@@ -2512,8 +2714,8 @@ msgstr "Votre projet n'est plus un test."
 msgid "Your project is now a test."
 msgstr "Votre projet est maintenant un test."
 
-msgid "Your request for feedback has been submitted."
-msgstr "Votre demande d'assistance conseil a été envoyée."
+#msgid "Your request for feedback has been submitted."
+#msgstr "Votre demande d'assistance conseil a été envoyée."
 
 msgid "account has been locked due to an excessive number of unsuccessful sign in attempts."
 msgstr "compte a été bloqué suite à un nombre de tentatives de connexions excessif "
@@ -2557,8 +2759,8 @@ msgstr "ne peut peser plus de 500ko"
 msgid "can't be less than zero"
 msgstr "ne peut être inférieur à zéro"
 
-msgid "changed"
-msgstr "modifié"
+#msgid "changed"
+#msgstr "modifié"
 
 msgid "co-owner"
 msgstr "Copropriétaire"
@@ -2574,6 +2776,14 @@ msgstr "completed_plans"
 
 msgid "copied"
 msgstr "copié"
+
+#, fuzzy
+msgid "copy"
+msgstr ""
+
+#, fuzzy
+msgid "create"
+msgstr ""
 
 msgid "created"
 msgstr "créé"
@@ -2592,6 +2802,10 @@ msgstr "désactiver"
 
 msgid "deactivated"
 msgstr "désactivé"
+
+#, fuzzy
+msgid "delete"
+msgstr ""
 
 msgid "deleted"
 msgstr "supprimé"
@@ -2614,8 +2828,12 @@ msgstr "generate_copy! nécessite un organisme cible"
 msgid "generate_version! requires a published template"
 msgstr "generate_version! nécessite un modèle publie"
 
-msgid "guidance"
-msgstr "recommandation"
+#, fuzzy
+msgid "get involved<em class=\"sr-only\"> (new window)</em>"
+msgstr ""
+
+#msgid "guidance"
+#msgstr "recommandation"
 
 msgid "guidance group"
 msgstr "Groupe de recommandations"
@@ -2626,6 +2844,10 @@ msgstr "recommandation concernant"
 msgid "into your browser"
 msgstr "dans votre navigateur"
 
+#, fuzzy
+msgid "isn't a valid value"
+msgstr ""
+
 msgid "locals should be a Hash object"
 msgstr "locals doit être un objet de type Hash"
 
@@ -2634,6 +2856,10 @@ msgstr "logo"
 
 msgid "mock project for testing, practice, or educational purposes"
 msgstr "projet de test, d'entrainement ou à des fins de formation"
+
+#, fuzzy
+msgid "must be after %{date}"
+msgstr ""
 
 msgid "must be logged in"
 msgstr "doit être connecté à"
@@ -2650,8 +2876,8 @@ msgstr "doit avoir accès à l'API des recommandations"
 msgid "must have access to plans api"
 msgstr "doit avoir accès à l'API des plans"
 
-msgid "note"
-msgstr "note"
+#msgid "note"
+#msgstr "note"
 
 msgid "obj should be a Phase, Section, Question, or Annotation"
 msgstr "obj doit être une Phase, Section, Question ou Annotation"
@@ -2677,23 +2903,27 @@ msgstr "organisme"
 msgid "page for guidance."
 msgstr "page de recommandations."
 
-msgid "password"
-msgstr "mot de passe"
+#msgid "password"
+#msgstr "mot de passe"
 
 msgid "path_params should be a Hash object"
 msgstr "path_params doit être un objet de type Hash"
 
-msgid "permissions"
-msgstr "Autorisations"
+#, fuzzy
+msgid "permission"
+msgstr ""
 
-msgid "phase"
-msgstr "Phase"
+#msgid "permissions"
+#msgstr "Autorisations"
+
+#msgid "phase"
+#msgstr "Phase"
 
 msgid "plan"
 msgstr "plan"
 
-msgid "plan's visibility"
-msgstr "Visibilité du plan"
+#msgid "plan's visibility"
+#msgstr "Visibilité du plan"
 
 msgid "plans"
 msgstr "plans"
@@ -2707,11 +2937,19 @@ msgstr "privé"
 msgid "profile"
 msgstr "profil"
 
+#, fuzzy
+msgid "profile for %{username}"
+msgstr ""
+
 msgid "project details coversheet"
 msgstr "page de renseignements sur le projet"
 
 msgid "public"
 msgstr "public"
+
+#, fuzzy
+msgid "publish"
+msgstr ""
 
 msgid "query_params should be a Hash object"
 msgstr "query_params doit être un objet de type Hash"
@@ -2734,14 +2972,22 @@ msgstr "lire le plan et fournir une assistance conseil."
 msgid "read-only"
 msgstr "lecture seule"
 
+#, fuzzy
+msgid "remove"
+msgstr ""
+
 msgid "removed"
 msgstr "supprimé(e)"
 
 msgid "reviewer"
 msgstr "reviewer"
 
-msgid "role"
-msgstr "rôle"
+#msgid "role"
+#msgstr "rôle"
+
+#, fuzzy
+msgid "save"
+msgstr ""
 
 msgid "saved"
 msgstr "enregistré"
@@ -2779,11 +3025,23 @@ msgstr "plan de test"
 msgid "unanswered questions"
 msgstr "questions non répondues"
 
+#, fuzzy
+msgid "unpublish"
+msgstr ""
+
+#, fuzzy
+msgid "update"
+msgstr ""
+
 msgid "updated"
 msgstr "mis à jour"
 
-msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
-msgstr "upgrade_customization! ne peut executé car il n'existe aucun modèle personnalisé pour le financeur courant"
+#, fuzzy
+msgid "upgrade cannot be carried out since there is no published template of its current funder"
+msgstr ""
+
+#msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#msgstr "upgrade_customization! ne peut executé car il n'existe aucun modèle personnalisé pour le financeur courant"
 
 msgid "upgrade_customization! requires a customised template"
 msgstr "upgrade_customization! nécessite un modèle personnalisé"

--- a/config/locale/pt_BR/app.po
+++ b/config/locale/pt_BR/app.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: app 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2018-06-20 16:23:24-0700\n"
+"PO-Revision-Date: 2018-10-19 11:10:54-0700\n"
 "Last-Translator: Benilton de Sá Carvalho benilton@unicamp.br\n"
 "Language-Team: Portugues do Brasil\n"
 "Language: pt_BR\n"
@@ -45,11 +45,19 @@ msgstr " no projeto. Você também pode reportar bugs e solicitar novos recursos
 msgid "#{text}"
 msgstr "#{text}"
 
+#, fuzzy
+msgid "%{affiliation}"
+msgstr ""
+
 msgid "%{application_name}"
 msgstr "%{application_name}"
 
-msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
-msgstr "%{application_name} é fornecido pelo %{organisation_name}. Pode saber mais sobre nós no nosso <a href=\"%{organisation_url}\" target=\"_blank\">website</a>.<br/>Se pretender contactar-nos acerca de %{application_name}, Por favor, preencha o formulário abaixo"
+#, fuzzy
+msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website <em class=\"sr-only\">(new window)</em></a>. If you would like to contact us about %{application_name}, please fill out the form below."
+msgstr ""
+
+#msgid "%{application_name} is provided by the %{organisation_name}.<br /> You can find out more about us on our <a href=\"%{organisation_url}\" target=\"_blank\">website</a>. If you would like to contact us about %{application_name}, please fill out the form below."
+#msgstr "%{application_name} é fornecido pelo %{organisation_name}. Pode saber mais sobre nós no nosso <a href=\"%{organisation_url}\" target=\"_blank\">website</a>.<br/>Se pretender contactar-nos acerca de %{application_name}, Por favor, preencha o formulário abaixo"
 
 msgid "%{application_name}: %{user_name} requested feedback on a plan"
 msgstr "%{application_name}: %{user_name} solicitado feedback sobre um plano."
@@ -60,14 +68,34 @@ msgstr "%{application_name}: Feedback especializado fornecido para %{plan_title}
 msgid "%{application_name}: Your plan has been submitted for feedback"
 msgstr "%{application_name}: Seu plano foi submetido para feedback."
 
+#, fuzzy
+msgid "%{authors}"
+msgstr ""
+
 msgid "%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don't want to accept the invitation, please ignore this email."
 msgstr "%{click_here} para aceitar o convite, (ou copie %{link} em seu navegador). Se não quiser aceitar o convite, por favor, ignore esta mensagem."
 
 msgid "%{commenter_name} has commented on the plan %{plan_title}. To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
 msgstr "%{commenter_name} fez comentários sobre o plano %{plan_title}. Para ver os comentários, por favor, visite a página Meu Painel de Controle em %{tool_name} e abra seu plano."
 
-msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
-msgstr "%{commenter} concluiu o feedback sobre o plano \"%{plan_title}\". Para ver seus comentários, por favor, visite a página Meu Painel de Controle em %{tool_name} e abra seu plano."
+#msgid "%{commenter} has finished providing feedback on the plan \"%{plan_title}\". To view the comments, please visit the My Dashboard page in %{tool_name} and open your plan."
+#msgstr "%{commenter} concluiu o feedback sobre o plano \"%{plan_title}\". Para ver seus comentários, por favor, visite a página Meu Painel de Controle em %{tool_name} e abra seu plano."
+
+#, fuzzy
+msgid "%{date}"
+msgstr ""
+
+#, fuzzy
+msgid "%{description}"
+msgstr ""
+
+#, fuzzy
+msgid "%{funder}"
+msgstr ""
+
+#, fuzzy
+msgid "%{grant_number}"
+msgstr ""
 
 msgid "%{org_name} Plans"
 msgstr "%{org_name} Planos"
@@ -81,8 +109,8 @@ msgstr "%{org_title} Planos"
 msgid "%{org} Example Answer"
 msgstr "%{org} Exemplo de Resposta"
 
-msgid "%{org} Guidance"
-msgstr "%{org} Instruções"
+#msgid "%{org} Guidance"
+#msgstr "%{org} Instruções"
 
 msgid "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
 msgstr "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questions})"
@@ -90,8 +118,12 @@ msgstr "%{phase_title} (%{sections_size} %{sections}, %{questions_size} %{questi
 msgid "%{plan_owner} has been notified that you have finished providing feedback"
 msgstr "%{plan_owner} foi avisado de que você terminou de dar feedback"
 
-msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
-msgstr "%{requestor} solicitou feedback sobre um plano \"%{plan_name}.\" Para adicionar comentários, visite a página 'Planos' no menu Admin em %{application_name} e abra o plano."
+#msgid "%{requestor} has requested feedback on a plan \"%{plan_name}.\" To add comments, please visit the 'Plans' page under the Admin menu in %{application_name} and open the plan."
+#msgstr "%{requestor} solicitou feedback sobre um plano \"%{plan_name}.\" Para adicionar comentários, visite a página 'Planos' no menu Admin em %{application_name} e abra o plano."
+
+#, fuzzy
+msgid "%{template}"
+msgstr ""
 
 msgid "%{tool_name} will help you to develop your Data Management Plan. If you have any queries or feedback as you use the tool, please contact us at %{helpdesk_email} or visit %{contact_us}"
 msgstr "%{tool_name} vai ajudá-lo a desenvolver seu Plano de Gestão de Dados. Se você tiver dúvidas ou quiser enviar-nos algum feedback enquanto estiver usando a ferramenta, por favor, entre em contato conosco em %{helpdesk_email} ou visite %{contact_us}"
@@ -99,11 +131,11 @@ msgstr "%{tool_name} vai ajudá-lo a desenvolver seu Plano de Gestão de Dados. 
 msgid "%{tool_name}: A new comment was added to %{plan_title}"
 msgstr "%{tool_name}: Um novo comentário foi adicionado a %{plan_title}"
 
-msgid "%{username}'s profile"
-msgstr "%{username}'s perfil"
+#msgid "%{username}'s profile"
+#msgstr "%{username}'s perfil"
 
-msgid "%{value} is not a valid format"
-msgstr "%{value} não é um formato válido"
+#msgid "%{value} is not a valid format"
+#msgstr "%{value} não é um formato válido"
 
 msgid "'Download' allows you to download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application."
 msgstr "'Download' permite que você baixe seu plano em vários formatos. Isso pode ser útil se você precisar enviar seu plano como parte de um pedido de subsídio."
@@ -162,8 +194,13 @@ msgstr "Um Plano de Gestão de Dados criado usando %{application_name}"
 msgid "A Data Management Plan in %{application_name} has been shared with you"
 msgstr "Um Plano de Gestão de Dados em %{application_name} foi compartilhado com você"
 
-msgid "A Data Management Plan in %{tool_name} has been shared with you"
-msgstr "Um Plano de Gestão de Dados em %{tool_name} foi compartilhado com você"
+#, fuzzy
+msgid "A Data Management Plan in %{tool_name} has been shared \"\"
+"                   \"with you"
+msgstr ""
+
+#msgid "A Data Management Plan in %{tool_name} has been shared with you"
+#msgstr "Um Plano de Gestão de Dados em %{tool_name} foi compartilhado com você"
 
 msgid "A colleague has invited you to contribute to their Data Management Plan in %{tool_name}"
 msgstr "Um colega convidou você para contribuir com seu Plano de Gestão de Dados em %{tool_name}"
@@ -210,8 +247,8 @@ msgstr "Sobre o %{application_name}"
 msgid "Access removed"
 msgstr "Acesso retirado"
 
-msgid "Accessibility"
-msgstr "Acessibilidade"
+#msgid "Accessibility"
+#msgstr "Acessibilidade"
 
 msgid "Actions"
 msgstr "Ações"
@@ -315,6 +352,10 @@ msgstr "Permite ao usuário gerenciar a afiliação à organização"
 msgid "An error has occurred while saving/resetting your export settings."
 msgstr "Ocorreu um erro ao salvar/redefinir seus parâmetros de exportação."
 
+#, fuzzy
+msgid "An error occurred when requesting feedback for this plan."
+msgstr ""
+
 msgid "Annotations"
 msgstr "Anotações"
 
@@ -393,8 +434,13 @@ msgstr "Antes de você começar, precisamos de algumas informações sobre seu p
 msgid "Begin typing to see a filtered list"
 msgstr "Comece a digitar para ver uma lista filtrada"
 
-msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
-msgstr "Veja abaixo a lista de usuários registrados para sua organização. Você pode ordenar os dados segundo os diversos campos."
+#, fuzzy
+msgid "Below is a list of users registered for your organisation. You can"
+"        sort the data by each field."
+msgstr ""
+
+#msgid "Below is a list of users registered for your organisation. You can sort the data by each field."
+#msgstr "Veja abaixo a lista de usuários registrados para sua organização. Você pode ordenar os dados segundo os diversos campos."
 
 msgid "Body"
 msgstr "Corpo"
@@ -498,14 +544,14 @@ msgstr "Cópia do %{template}"
 msgid "Copyright information:"
 msgstr "Informação de copyright"
 
-msgid "Could not create your %{o}."
-msgstr "Não foi possível crio seu %{object}."
+#msgid "Could not create your %{o}."
+#msgstr "Não foi possível crio seu %{object}."
 
-msgid "Could not delete the %{o}."
-msgstr "Não foi possível excluir seu %{object}."
+#msgid "Could not delete the %{o}."
+#msgstr "Não foi possível excluir seu %{object}."
 
-msgid "Could not update your %{o}."
-msgstr "Não foi possível atualizar seu %{object}."
+#msgid "Could not update your %{o}."
+#msgstr "Não foi possível atualizar seu %{object}."
 
 msgid "Create Organisation"
 msgstr "Criar Organização"
@@ -549,14 +595,18 @@ msgstr "Criado em"
 msgid "Created date"
 msgstr "Data de criação"
 
-msgid "Created using the %{application_name} service. Last modified %{date}"
-msgstr "Criado usando %{application_name}. Última modificação %{date}"
+#msgid "Created using the %{application_name} service. Last modified %{date}"
+#msgstr "Criado usando %{application_name}. Última modificação %{date}"
 
 msgid "Created using the %{application_name}. Last modified %{date}"
 msgstr "Criado usando %{application_name}. Última modificação %{date}"
 
 msgid "Creator:"
 msgstr "Criador:"
+
+#, fuzzy
+msgid "Creators:"
+msgstr ""
 
 msgid "Creators: "
 msgstr "Criadores:"
@@ -567,8 +617,24 @@ msgstr "Privilégios atuais"
 msgid "Current password"
 msgstr "Senha atual"
 
+#, fuzzy
+msgid "Customisable Templates"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are published"
+msgstr ""
+
+#, fuzzy
+msgid "Customisations are unpublished"
+msgstr ""
+
 msgid "Customise"
 msgstr "Customizar"
+
+#, fuzzy
+msgid "Customise phase"
+msgstr ""
 
 msgid "Customising for your Organisation"
 msgstr "Customizing para sua organização"
@@ -576,14 +642,14 @@ msgstr "Customizing para sua organização"
 msgid "Customizable Templates"
 msgstr "Modelos customizáveis"
 
-msgid "Customizations are published"
-msgstr "As customizações são publicadas"
+#msgid "Customizations are published"
+#msgstr "As customizações são publicadas"
 
-msgid "Customizations are unpublished"
-msgstr "As customizações não são publicadas"
+#msgid "Customizations are unpublished"
+#msgstr "As customizações não são publicadas"
 
-msgid "Customize phase"
-msgstr "Customizar Fase"
+#msgid "Customize phase"
+#msgstr "Customizar Fase"
 
 msgid "DMP Background"
 msgstr "fundo do PGD"
@@ -600,8 +666,12 @@ msgstr "DMPRoadmap"
 msgid "DMPRoadmap ('the tool', 'the system"
 msgstr "DMPRoadmap ('a ferramenta', 'o sistema"
 
-msgid "DOCX"
-msgstr "DOCX"
+#msgid "DOCX"
+#msgstr "DOCX"
+
+#, fuzzy
+msgid "DOCX <em class=\"sr-only\">(new window)</em>"
+msgstr ""
 
 msgid "Data Contact Person"
 msgstr "Pessoa a contatar sobre os dados"
@@ -657,17 +727,37 @@ msgstr "Não esqueça de salvar suas mudanças após fazer suas seleções."
 msgid "Download"
 msgstr "Baixar"
 
-msgid "Download Plan"
-msgstr "Baixar plano"
+#msgid "Download Plan"
+#msgstr "Baixar plano"
+
+#, fuzzy
+msgid "Download Plan <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
+#, fuzzy
+msgid "Download global usage"
+msgstr ""
 
 msgid "Download plans"
 msgstr "Baixar planos"
 
+#, fuzzy
+msgid "Download plans <em class=\"sr-only\">(new window)</span>"
+msgstr ""
+
 msgid "Download settings"
 msgstr "Baixar parâmetros"
 
+#, fuzzy
+msgid "Download users"
+msgstr ""
+
 msgid "Draft"
 msgstr "Rascunho"
+
+#, fuzzy
+msgid "Drag arrows to rearrange sections."
+msgstr ""
 
 msgid "Edit"
 msgstr "Editar"
@@ -675,8 +765,8 @@ msgstr "Editar"
 msgid "Edit Profile"
 msgstr "Editar perfil"
 
-msgid "Edit Theme"
-msgstr "Editar Tema"
+#msgid "Edit Theme"
+#msgstr "Editar Tema"
 
 msgid "Edit User Privileges"
 msgstr "Editar Privilégios do Usuário"
@@ -747,14 +837,18 @@ msgstr "Insira instruções específicas para acompanhar esta pergunta. Se você
 msgid "Enter your guidance here. You can include links where needed."
 msgstr "Insira suas instruções aqui. Você pode incluir links onde necessário."
 
-msgid "Error parsing links for a #{template_type(template)}"
-msgstr "Erro ao analisar links para um #{template_type(template)}"
+#msgid "Error parsing links for a #{template_type(template)}"
+#msgstr "Erro ao analisar links para um #{template_type(template)}"
 
-msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
-msgstr "Erro ao processar o registro. Por favor, verifique se você usou um endereço de email válido e que a senha escolhida tenha pelo menos 8 caracteres."
+#, fuzzy
+msgid "Error parsing links for a %{template}"
+msgstr ""
 
-msgid "Error raised while saving the visibility for plan id %{plan_id}"
-msgstr "Erro levantado ao salvar a visibilidade para o plano com id %{plan_id}"
+#msgid "Error processing registration. Please check that you have entered a valid email address and that your chosen password is at least 8 characters long."
+#msgstr "Erro ao processar o registro. Por favor, verifique se você usou um endereço de email válido e que a senha escolhida tenha pelo menos 8 caracteres."
+
+#msgid "Error raised while saving the visibility for plan id %{plan_id}"
+#msgstr "Erro levantado ao salvar a visibilidade para o plano com id %{plan_id}"
 
 msgid "Error:"
 msgstr "Erro"
@@ -990,8 +1084,12 @@ msgstr "Tamanho de fonte inválido"
 msgid "Invalid maximum pages"
 msgstr "Máximo de páginas inválido"
 
-msgid "Invitation to %{email} issued successfully. \n"
-msgstr "Convite para %{email} emitido com sucesso. \n"
+#, fuzzy
+msgid "Invitation to %{email} issued successfully."
+msgstr ""
+
+#msgid "Invitation to %{email} issued successfully. \n"
+#msgstr "Convite para %{email} emitido com sucesso. \n"
 
 msgid "Invite collaborators"
 msgstr "Convidar colaboradores"
@@ -1116,14 +1214,18 @@ msgstr "N/A"
 msgid "Name"
 msgstr "Nome"
 
+#, fuzzy
+msgid "New Notification"
+msgstr ""
+
 msgid "New Question"
 msgstr "Novo Pergunta"
 
 msgid "New Template"
 msgstr "Novo modelo"
 
-msgid "New Theme"
-msgstr "Novo Tema"
+#msgid "New Theme"
+#msgstr "Novo Tema"
 
 msgid "New notification"
 msgstr "Novo Notificações"
@@ -1139,6 +1241,10 @@ msgstr "Novos planos"
 
 msgid "New question:"
 msgstr "Novo perguntas"
+
+#, fuzzy
+msgid "New theme"
+msgstr ""
 
 msgid "New users"
 msgstr "Novos usuários"
@@ -1212,11 +1318,11 @@ msgstr "Nota:"
 msgid "Notification Preferences"
 msgstr "Preferências de Notificação"
 
-msgid "Notification created successfully"
-msgstr "Notificação criada com sucesso"
+#msgid "Notification created successfully"
+#msgstr "Notificação criada com sucesso"
 
-msgid "Notification updated successfully"
-msgstr "Notificação atualizada com sucesso"
+#msgid "Notification updated successfully"
+#msgstr "Notificação atualizada com sucesso"
 
 msgid "Notifications"
 msgstr "Notificações"
@@ -1332,6 +1438,10 @@ msgstr "Nome do proprietário"
 msgid "PDF"
 msgstr "PDF"
 
+#, fuzzy
+msgid "PDF <em class=\"sr-only\">(new window)</em>"
+msgstr ""
+
 msgid "PDF formatting"
 msgstr "Formatação de PDF"
 
@@ -1371,8 +1481,8 @@ msgstr "Contato para Dados do Plano"
 msgid "Plan Description"
 msgstr "Descrição do Plano"
 
-msgid "Plan Guidance Configuration"
-msgstr "Configuração de Instruções do Plano"
+#msgid "Plan Guidance Configuration"
+#msgstr "Configuração de Instruções do Plano"
 
 msgid "Plan ID"
 msgstr "ID do Plano"
@@ -1395,38 +1505,50 @@ msgstr "Plano compartilhado com %{email}."
 msgid "Plans"
 msgstr "Planos"
 
-msgid "Please check the box to continue."
-msgstr "Por favor, selecione a caixa para continuar."
+#msgid "Please check the box to continue."
+#msgstr "Por favor, selecione a caixa para continuar."
 
 msgid "Please choose an organisation"
 msgstr "Por favor, escolha uma organização."
 
-msgid "Please choose one of the options."
-msgstr "Por favor, escolha uma das opções."
+#msgid "Please choose one of the options."
+#msgstr "Por favor, escolha uma das opções."
 
 msgid "Please do not reply to this email."
 msgstr "Por favor, não responda esta mensagem."
 
-msgid "Please enter a First name."
-msgstr "Por favor, insira o Primeiro Nome."
+#msgid "Please enter a First name."
+#msgstr "Por favor, insira o Primeiro Nome."
 
-msgid "Please enter a Last name."
-msgstr "Por favor, insira o Sobrenome"
+#, fuzzy
+msgid "Please enter a First name. "
+msgstr ""
+
+#msgid "Please enter a Last name."
+#msgstr "Por favor, insira o Sobrenome"
+
+#, fuzzy
+msgid "Please enter a Last name. "
+msgstr ""
 
 msgid "Please enter a password confirmation"
 msgstr "Por favor, insira a confirmação de senha."
 
-msgid "Please enter a valid number."
-msgstr "Por favor, insira um número válido."
+#msgid "Please enter a valid number."
+#msgstr "Por favor, insira um número válido."
 
-msgid "Please enter a valid value."
-msgstr "Por favor, insira um valor válido."
+#msgid "Please enter a valid value."
+#msgstr "Por favor, insira um valor válido."
 
 msgid "Please enter an email address"
 msgstr "Por favor, insira um endereço de email."
 
-msgid "Please enter an email address."
-msgstr "Por favor, insira um endereço de email."
+#msgid "Please enter an email address."
+#msgstr "Por favor, insira um endereço de email."
+
+#, fuzzy
+msgid "Please enter an email address. "
+msgstr ""
 
 msgid "Please enter the name of your organisation"
 msgstr "Por favor, insira o nome de sua organização."
@@ -1464,8 +1586,8 @@ msgstr "Por favor, selecione um órgão financiador válido na lista."
 msgid "Please select a valid research organisation from the list."
 msgstr "Por favor, selecione uma instituição de pesquisa válida na lista."
 
-msgid "Please select a value from the list."
-msgstr "Por favor, selecione um valor na lista."
+#msgid "Please select a value from the list."
+#msgstr "Por favor, selecione um valor na lista."
 
 msgid "Please select an item from the list."
 msgstr "Por favor, selecione um item na lista."
@@ -1614,6 +1736,10 @@ msgstr "Texto da pergunta"
 msgid "Questions"
 msgstr "Perguntas"
 
+#, fuzzy
+msgid "Re-order sections"
+msgstr ""
+
 msgid "Read only"
 msgstr "Somente leitura"
 
@@ -1638,8 +1764,12 @@ msgstr "Remover o filtro"
 msgid "Remove this link"
 msgstr "Remover este link"
 
-msgid "Request Expert Feedback - Automated Email:"
-msgstr "Solicitar feedback de especialista - Email automático"
+#msgid "Request Expert Feedback - Automated Email:"
+#msgstr "Solicitar feedback de especialista - Email automático"
+
+#, fuzzy
+msgid "Request Expert Feedback - Message Displayed on Share Plan Tab:"
+msgstr ""
 
 msgid "Request Feedback"
 msgstr "Solicitar feedback"
@@ -1665,6 +1795,12 @@ msgstr "Papel"
 msgid "Run your own filter"
 msgstr "Use seu próprio filtro"
 
+#, fuzzy
+msgid "SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48"
+"       hours. If you have questions pertaining to this action please contact us"
+"       at %{organisation_email}."
+msgstr ""
+
 msgid "Same as Principal Investigator"
 msgstr "O mesmo que Investigador Principal"
 
@@ -1680,8 +1816,12 @@ msgstr "As amostras de planos são fornecidas por um órgão financiador, uma or
 msgid "Save"
 msgstr "Salvar"
 
-msgid "Save Unsuccessful."
-msgstr "Não foi possível salvar."
+#msgid "Save Unsuccessful."
+#msgstr "Não foi possível salvar."
+
+#, fuzzy
+msgid "Save Unsuccessful. "
+msgstr ""
 
 msgid "Saving..."
 msgstr "Salvando"
@@ -1720,17 +1860,25 @@ msgstr "Veja a lista completa de instituições parceiras"
 msgid "Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s)."
 msgstr "Selecione 'Transferir customização' no menu Ações para rever sua (s) customização(ões) e fazer as alterações necessárias. Quando estiver pronto, você deve retornar ao menu Ações e publicar suas Customização(oes)."
 
+#, fuzzy
+msgid "Select Guidance"
+msgstr ""
+
 msgid "Select all"
 msgstr "Selecionar tudo"
 
 msgid "Select an organisation from the list."
 msgstr "Selecione uma organização da lista."
 
+#, fuzzy
+msgid "Select one or more themes that are relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+msgstr ""
+
 msgid "Select one or more themes that are relevant to this question. This will allow similarly themed organisation-level guidance to appear alongside your question."
 msgstr "Selecione um ou mais temas relevantes para esta pergunta. Isso permitirá que sejam exibidas, junto com sua pergunta, instruções com temas similares no âmbito de sua organização."
 
-msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
-msgstr "Selecione um tema relevante para esta instruções. Isso exibirá sua instruções genérica em nível de organização ou quaisquer Escolas/Departamentos para os quais você criar grupos de instruções em todos os modelos que tiverem perguntas com as tags de tema correspondentes."
+#msgid "Select one theme that is relevant to this guidance. This will display your generic organisation-level guidance, or any Schools/Departments for which you create guidance groups, across all templates that have questions with the corresponding theme tags."
+#msgstr "Selecione um tema relevante para esta instruções. Isso exibirá sua instruções genérica em nível de organização ou quaisquer Escolas/Departamentos para os quais você criar grupos de instruções em todos os modelos que tiverem perguntas com as tags de tema correspondentes."
 
 msgid "Select phase to download"
 msgstr "Selecione a fase a ser baixada"
@@ -1771,20 +1919,20 @@ msgstr "Domínio Shibboleth"
 msgid "Shibboleth Entity Id"
 msgstr "Id de Entidade Shibboleth"
 
-msgid "Should be after start date"
-msgstr "Deve ser após a data de início"
+#msgid "Should be after start date"
+#msgstr "Deve ser após a data de início"
 
-msgid "Should be before expiration date"
-msgstr "Deve ser antes da data de validade"
+#msgid "Should be before expiration date"
+#msgstr "Deve ser antes da data de validade"
 
-msgid "Should be today or later"
-msgstr "Deve ser hoje ou mais tarde"
+#msgid "Should be today or later"
+#msgstr "Deve ser hoje ou mais tarde"
 
-msgid "Should be tomorrow or later"
-msgstr "Deve ser amanhã ou mais tarde"
+#msgid "Should be tomorrow or later"
+#msgstr "Deve ser amanhã ou mais tarde"
 
-msgid "Show"
-msgstr "Mostrar"
+#msgid "Show"
+#msgstr "Mostrar"
 
 msgid "Show password"
 msgstr "Mostrar senha"
@@ -1813,6 +1961,10 @@ msgstr "Ir para o conteúdo principal"
 msgid "Someone has requested a link to change your %{tool_name} password. You can do this through the link below."
 msgstr "Alguém solicitou um link para mudar sua senha em %{tool_name} password. Você pode fazer isso usando o link abaixo."
 
+#, fuzzy
+msgid "Sort by %{sort_field}"
+msgstr ""
+
 msgid "Start"
 msgstr "Compartilhar"
 
@@ -1831,18 +1983,22 @@ msgstr "Submeter"
 msgid "Successfully %{action} %{username}'s account."
 msgstr "Successo ao %{action} conta do %{username}"
 
-msgid "Successfully %{action} your %{object}."
-msgstr "Sucesso ao %{action} seu %{object}."
+#, fuzzy
+msgid "Successfully %{action} the %{object}."
+msgstr ""
+
+#msgid "Successfully %{action} your %{object}."
+#msgstr "Sucesso ao %{action} seu %{object}."
 
 #, fuzzy
 msgid "Successfully changed the permissions for #{@role.user.email}. They have been notified via email."
 msgstr ""
 
-msgid "Successfully deleted your theme"
-msgstr "Seu tema foi apagado com sucesso"
+#msgid "Successfully deleted your theme"
+#msgstr "Seu tema foi apagado com sucesso"
 
-msgid "Successfully destroyed your notification"
-msgstr "Destruiu com sucesso sua notificação"
+#msgid "Successfully destroyed your notification"
+#msgstr "Destruiu com sucesso sua notificação"
 
 msgid "Successfully signed in"
 msgstr "Entrada bem sucedida"
@@ -1853,8 +2009,8 @@ msgstr "Sua conta em %{is} foi desvinculada com sucesso."
 msgid "Successfully unpublished your #{template_type(template)}"
 msgstr "Seu modelo não publicado com sucesso"
 
-msgid "Successfully updated %{username}"
-msgstr "Successo ao atualizado %{username}"
+#msgid "Successfully updated %{username}"
+#msgstr "Successo ao atualizado %{username}"
 
 msgid "Super Admin"
 msgstr "Super Administrador"
@@ -1925,6 +2081,15 @@ msgstr "A equipe %{tool_name}"
 msgid "The Digital Curation Centre and UC3 team at the California Digital Library have developed and delivered tools for data management planning since the advent of open data policies in 2011. "
 msgstr "O Digital Curation Centre e a equipe de UC3 da California Digital Library desenvolveram e forneceram ferramentas para o planejamento de gerenciamento de dados desde o advento das políticas de dados abertos em 2011. "
 
+#, fuzzy
+msgid "The above plan creator(s) have agreed that others may use as"
+"             much of the text of this plan as they would like in their own plans,"
+"             and customise it as necessary. You do not need to credit the creator(s)"
+"             as the source of the language used, but using any of the plan's text"
+"             does not imply that the creator(s) endorse, or have any relationship to,"
+"             your project or proposal"
+msgstr ""
+
 msgid "The current #{scheme.description} iD has been already linked to a user with email #{identifier.user.email}"
 msgstr "A iD do #{scheme.description} atual já foi vinculada a um usuário com email #{identifier.user.email}"
 
@@ -1946,11 +2111,11 @@ msgstr "A chave %{key} não possui um conjunto válido de links de objeto"
 msgid "The new platform will be separate from the services each of our teams runs on top of it. Our shared goal: provide a combined DMPRoadmap platform as a core infrastructure for DMPs. Future enhancements will focus on making DMPs machine actionable so please continue sharing your use cases."
 msgstr "A nova plataforma será separada dos serviços que cada uma de nossas equipes executa em cima dela. Nosso objetivo em comum: fornecer uma plataforma DMPRoadmap combinada como uma infraestrutura básica para DMPs. Futuros aprimoramentos se concentrarão em tornar a máquina DMPs acionável, portanto, continue compartilhando seus casos de uso."
 
-msgid "The password must be between 8 and 128 characters."
-msgstr "A senha deve ter entre 8 e 128 caracteres."
+#msgid "The password must be between 8 and 128 characters."
+#msgstr "A senha deve ter entre 8 e 128 caracteres."
 
-msgid "The passwords must match."
-msgstr "As senhas devem coincidir."
+#msgid "The passwords must match."
+#msgstr "As senhas devem coincidir."
 
 msgid "The plan %{plan_title} had its visibility changed to %{plan_visibility}."
 msgstr "O plano %{plan_title} teve sua visibilidade modificad para %{plan_visibility}."
@@ -1973,17 +2138,17 @@ msgstr "A tabela abaixo lista os planos que os usuários em sua organização cr
 msgid "The table below lists the plans that you have created, and that have been shared with you by others. You can edit, share, download, make a copy, or remove these plans at any time."
 msgstr "A tabela abaixo lista os planos que você criou e os que foram compartilhados com  você por outras pessoas. Você pode editar, compartilhar, baixar, copiar ou remover esses planos a qualquer momento."
 
-msgid "The theme with id %{id} could not be destroyed"
-msgstr "O tema com id %{id} não pôde ser destruído"
+#msgid "The theme with id %{id} could not be destroyed"
+#msgstr "O tema com id %{id} não pôde ser destruído"
 
 msgid "The ‘Share’ tab is also where you can set your plan visibility."
 msgstr "A guia ‘Compartilhar’ também é onde você pode definir a visibilidade do seu plano."
 
-msgid "Theme created successfully"
-msgstr "Tema criado com sucesso"
+#msgid "Theme created successfully"
+#msgstr "Tema criado com sucesso"
 
-msgid "Theme updated successfully"
-msgstr "Tema atualizado com sucesso"
+#msgid "Theme updated successfully"
+#msgstr "Tema atualizado com sucesso"
 
 msgid "Themes"
 msgstr "Temas"
@@ -2015,8 +2180,8 @@ msgstr "Não há nenhum plano com id %{id} para o qual criar ou atualizar uma re
 msgid "There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer"
 msgstr "Não há dúvidas com o id %{question_id} associado ao id do plano %{plan_id} para o qual criar ou atualizar uma resposta"
 
-msgid "There is no theme associated with id %{id}"
-msgstr "Não há nenhum tema associado com a id %{id}"
+#msgid "There is no theme associated with id %{id}"
+#msgstr "Não há nenhum tema associado com a id %{id}"
 
 msgid "There may also be an option to request feedback on your plan. This is available when research support staff at your organisation have enabled this service. Click to ‘Request feedback’ and your local administrators will be alerted to your request. Their comments will be visible in the ‘Comments’ field adjacent to each question. You will be notified by email when an administrator provides feedback."
 msgstr "Também pode haver uma opção para solicitar feedback sobre seu plano. Isso está disponível quando a equipe de suporte de pesquisa da sua organização habilitou esse serviço. Clique para ‘Solicitar comentários’ e seus administradores locais serão alertados sobre sua solicitação. Seus comentários ficarão visíveis no campo ‘Comentários’ ao lado de cada pergunta. Você será notificado por e-mail quando um administrador fornecer feedback."
@@ -2024,8 +2189,8 @@ msgstr "Também pode haver uma opção para solicitar feedback sobre seu plano. 
 msgid "There seems to be a problem with your logo. Please upload it again."
 msgstr "Parece haver um problema com seu logo. Por favor, suba-o novamente."
 
-msgid "This allows you to order sections."
-msgstr "Isto lhe permite ordenar as seções."
+#msgid "This allows you to order sections."
+#msgstr "Isto lhe permite ordenar as seções."
 
 msgid "This allows you to order the phases of your template."
 msgstr "Isto lhe permite ordenar as fases de seu modelo."
@@ -2111,6 +2276,10 @@ msgstr "URL"
 msgid "Unable to %{action} %{username}"
 msgstr "Incapaz de %{action} %{username}"
 
+#, fuzzy
+msgid "Unable to %{action} the %{object}.%{errors}"
+msgstr ""
+
 msgid "Unable to change the plan's status since it is needed at least %{percentage} percentage responded"
 msgstr "Não conseguimos mudar o status do plano. É preciso pelo menos %{percentage} de respostas."
 
@@ -2120,11 +2289,19 @@ msgstr "Não conseguimos mudar o status de teste do plano"
 msgid "Unable to change your organisation affiliation at this time."
 msgstr "Não conseguimos mudar sua afiliação organizacional neste momento."
 
-msgid "Unable to create a new section because the phase you specified does not exist."
-msgstr "Não criar uma nova seção porque a fase que você especificou não existe."
+#msgid "Unable to create a new section because the phase you specified does not exist."
+#msgstr "Não criar uma nova seção porque a fase que você especificou não existe."
+
+#, fuzzy
+msgid "Unable to create a new section. The phase you specified does not exist."
+msgstr ""
 
 msgid "Unable to create a new version of this template."
 msgstr "Não criar uma nova versão deste modelo."
+
+#, fuzzy
+msgid "Unable to create your account.#{errors_for_display(resource)}"
+msgstr ""
 
 msgid "Unable to customize that template."
 msgstr "Não customização esse modelo."
@@ -2159,11 +2336,11 @@ msgstr "Não publicar seu #{template_type(template)}."
 msgid "Unable to remove the plan"
 msgstr "Não conseguimos remover o plano"
 
-msgid "Unable to save since notification parameter is missing"
-msgstr "Não conseguimos salvar. Falta o parâmetro tema."
+#msgid "Unable to save since notification parameter is missing"
+#msgstr "Não conseguimos salvar. Falta o parâmetro tema."
 
-msgid "Unable to save since theme parameter is missing"
-msgstr "Não conseguimos salvar. Falta o parâmetro tema."
+#msgid "Unable to save since theme parameter is missing"
+#msgstr "Não conseguimos salvar. Falta o parâmetro tema."
 
 msgid "Unable to submit your request"
 msgstr "Não é possível enviar sua solicitação"
@@ -2171,8 +2348,8 @@ msgstr "Não é possível enviar sua solicitação"
 msgid "Unable to submit your request for feedback at this time."
 msgstr "Não conseguimos submeter seu pedido de feedback neste momento."
 
-msgid "Unable to transfer your customizations."
-msgstr "Não é possível transferir suas customizações."
+#msgid "Unable to transfer your customizations."
+#msgstr "Não é possível transferir suas customizações."
 
 msgid "Unable to unlink your account from %{is}."
 msgstr "Não conseguimos desvincular sua conta de %{is}."
@@ -2180,8 +2357,8 @@ msgstr "Não conseguimos desvincular sua conta de %{is}."
 msgid "Unable to unpublish your #{template_type(template)}."
 msgstr "Não cancelar a publicação do seu #{template_type(template)}."
 
-msgid "Unable to update %{username}"
-msgstr "Incapaz de atualizar %{username}"
+#msgid "Unable to update %{username}"
+#msgstr "Incapaz de atualizar %{username}"
 
 msgid "Unknown"
 msgstr "Desconhecido"
@@ -2243,8 +2420,8 @@ msgstr "Use os filtros para gerar estatísticas de uso organizacional para uma f
 msgid "User accounts"
 msgstr "Contas de usuários"
 
-msgid "User not found."
-msgstr "Usuário não encontrado."
+#msgid "User not found."
+#msgstr "Usuário não encontrado."
 
 msgid "Users"
 msgstr "Usuários"
@@ -2261,6 +2438,10 @@ msgstr "Ver tudo"
 msgid "View all guidance"
 msgstr "Ver toda a instrução"
 
+#, fuzzy
+msgid "View all notifications"
+msgstr ""
+
 msgid "View all organisations"
 msgstr "Ver todas as organizações"
 
@@ -2269,6 +2450,10 @@ msgstr "Ver todos os resultados da busca"
 
 msgid "View all templates"
 msgstr "Ver todos os modelos"
+
+#, fuzzy
+msgid "View all themes"
+msgstr ""
 
 msgid "View all users"
 msgstr "Ver todos os usuários"
@@ -2294,8 +2479,8 @@ msgstr "Encontramos muitos modelos de PGD correspondentes a seu órgão financia
 msgid "We invite you to peruse the DMPRoadmap GitHub wiki to learn how to "
 msgstr "Nós convidamos você a ler o wiki do DMPRoadmap GitHub para aprender como "
 
-msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
-msgstr "Não confirmar sua conta. Por favor use o seguinte formulário para criar uma nova conta. Você poderá vincular sua nova conta posteriormente."
+#msgid "We were unable to verify your account. Please use the following form to create a new account. You will be able to link your new account afterward."
+#msgstr "Não confirmar sua conta. Por favor use o seguinte formulário para criar uma nova conta. Você poderá vincular sua nova conta posteriormente."
 
 msgid "We will hold the personal data you provided us for as long as you continue using the %{application_name} service. Your personal data can be removed from this service upon request to the %{application_name} team within a period of 30 days."
 msgstr "Nós manteremos os dados pessoais fornecidos por você enquanto você continuar usando o serviço %{application_name}. Seus dados pessoais podem ser removidos deste serviço mediante solicitação para a equipe %{application_name} dentro de um período de 30 dias."
@@ -2426,17 +2611,29 @@ msgstr "Você tem alterações não publicadas! Selecione \"Publicar alteraçõe
 msgid "You may change your notification preferences on your profile page."
 msgstr "Você pode modificar suas preferências de notificação na página com seu perfil."
 
+#, fuzzy
+msgid "You may change your notification preferences on your profile page. "
+msgstr ""
+
+#, fuzzy
+msgid "You may place them before or after the main template sections."
+msgstr ""
+
 msgid "You must accept the terms and conditions to register."
 msgstr "Você deve aceitar os termos e condições para registrar-se."
 
-msgid "You must agree to the term and conditions."
-msgstr "Você deve concordar com o termo e condições."
+#msgid "You must agree to the term and conditions."
+#msgstr "Você deve concordar com o termo e condições."
 
-msgid "You must enter a valid URL (e.g. https://organisation.org)."
-msgstr "Você deve inserir uma URL válida (e.g. https://organizacao.org)."
+#msgid "You must enter a valid URL (e.g. https://organisation.org)."
+#msgstr "Você deve inserir uma URL válida (e.g. https://organizacao.org)."
 
-msgid "You must enter a valid email address."
-msgstr "Você deve inserir um email válido."
+#msgid "You must enter a valid email address."
+#msgstr "Você deve inserir um email válido."
+
+#, fuzzy
+msgid "You must provide a valid email address and select a permission level."
+msgstr ""
 
 msgid "You must select a funder from the list or click the checkbox."
 msgstr "Você deve selecionar um financiador na lista ou clicar na caixa de seleção."
@@ -2486,6 +2683,11 @@ msgstr "Sua conta foi vinculada a %{scheme}."
 msgid "Your account has been successfully linked to your institutional credentials. You will now be able to sign in with them."
 msgstr "Sua conta foi vinculada às suas credenciais institucionais. Agora você poderá entrar com eles."
 
+#, fuzzy
+msgid "Your colleague %{inviter_name} has invited you to contribute to"
+"            their Data Management Plan in %{tool_name}"
+msgstr ""
+
 msgid "Your email address is also your login id and therefore an important part of your account information. For your safety we require you to confirm your password to make this change."
 msgstr "Seu email é também sua id para entrar no sistema. É portanto uma parte importante das informações de sua conta. Para sua segurança, solicitamos que confirme sua senha para realizar essa mudança."
 
@@ -2516,8 +2718,8 @@ msgstr "Seu projeto não é mais um teste."
 msgid "Your project is now a test."
 msgstr "Seu projeto agora é um teste."
 
-msgid "Your request for feedback has been submitted."
-msgstr "Seu pedido de feedback foi submetido."
+#msgid "Your request for feedback has been submitted."
+#msgstr "Seu pedido de feedback foi submetido."
 
 msgid "account has been locked due to an excessive number of unsuccessful sign in attempts."
 msgstr "conta foi bloqueada devido a um número execessivos de tentativas de entrar fracassadas."
@@ -2561,8 +2763,8 @@ msgstr "não pode ser maior que 500KB"
 msgid "can't be less than zero"
 msgstr "não pode ser menor que zero"
 
-msgid "changed"
-msgstr "modificado"
+#msgid "changed"
+#msgstr "modificado"
 
 msgid "co-owner"
 msgstr "coproprietário"
@@ -2578,6 +2780,14 @@ msgstr "completed_plans"
 
 msgid "copied"
 msgstr "copieado"
+
+#, fuzzy
+msgid "copy"
+msgstr ""
+
+#, fuzzy
+msgid "create"
+msgstr ""
 
 msgid "created"
 msgstr "criado"
@@ -2596,6 +2806,10 @@ msgstr "desativar"
 
 msgid "deactivated"
 msgstr "desativado"
+
+#, fuzzy
+msgid "delete"
+msgstr ""
 
 msgid "deleted"
 msgstr "apagado"
@@ -2618,8 +2832,12 @@ msgstr "generate_copy! requer uma meta de organização"
 msgid "generate_version! requires a published template"
 msgstr "generate_version! requer um modelo publicado"
 
-msgid "guidance"
-msgstr "instruções"
+#, fuzzy
+msgid "get involved<em class=\"sr-only\"> (new window)</em>"
+msgstr ""
+
+#msgid "guidance"
+#msgstr "instruções"
 
 msgid "guidance group"
 msgstr "grupo de instruções"
@@ -2630,6 +2848,10 @@ msgstr "instruções sobre"
 msgid "into your browser"
 msgstr "em seu navegador"
 
+#, fuzzy
+msgid "isn't a valid value"
+msgstr ""
+
 msgid "locals should be a Hash object"
 msgstr "locals deve ser um objeto Hash"
 
@@ -2638,6 +2860,10 @@ msgstr "logo"
 
 msgid "mock project for testing, practice, or educational purposes"
 msgstr "projeto simulado para testes, prática ou propósitos educacionais"
+
+#, fuzzy
+msgid "must be after %{date}"
+msgstr ""
 
 msgid "must be logged in"
 msgstr "deve estar logado"
@@ -2654,8 +2880,8 @@ msgstr "deve ter acesso à api de instruções"
 msgid "must have access to plans api"
 msgstr "deve ter acesso à api de planos"
 
-msgid "note"
-msgstr "nota"
+#msgid "note"
+#msgstr "nota"
 
 msgid "obj should be a Phase, Section, Question, or Annotation"
 msgstr "obj deve ser uma fase, seção, pergunta ou anotação"
@@ -2681,23 +2907,27 @@ msgstr "organizacional"
 msgid "page for guidance."
 msgstr "página para orientação."
 
-msgid "password"
-msgstr "senha"
+#msgid "password"
+#msgstr "senha"
 
 msgid "path_params should be a Hash object"
 msgstr "path_params deve ser um objeto hash"
 
-msgid "permissions"
-msgstr "permissões"
+#, fuzzy
+msgid "permission"
+msgstr ""
 
-msgid "phase"
-msgstr "fase"
+#msgid "permissions"
+#msgstr "permissões"
+
+#msgid "phase"
+#msgstr "fase"
 
 msgid "plan"
 msgstr "plano"
 
-msgid "plan's visibility"
-msgstr "visibiliadade do plano"
+#msgid "plan's visibility"
+#msgstr "visibiliadade do plano"
 
 msgid "plans"
 msgstr "planos"
@@ -2711,11 +2941,19 @@ msgstr "privado"
 msgid "profile"
 msgstr "perfil"
 
+#, fuzzy
+msgid "profile for %{username}"
+msgstr ""
+
 msgid "project details coversheet"
 msgstr "capa com detalhes do projeto"
 
 msgid "public"
 msgstr "público"
+
+#, fuzzy
+msgid "publish"
+msgstr ""
 
 msgid "query_params should be a Hash object"
 msgstr "query_params deve ser um objeto hash"
@@ -2738,14 +2976,22 @@ msgstr "ler o plano e dar feedback."
 msgid "read-only"
 msgstr "somente leitura"
 
+#, fuzzy
+msgid "remove"
+msgstr ""
+
 msgid "removed"
 msgstr "removido"
 
 msgid "reviewer"
 msgstr "revisor"
 
-msgid "role"
-msgstr "papel"
+#msgid "role"
+#msgstr "papel"
+
+#, fuzzy
+msgid "save"
+msgstr ""
 
 msgid "saved"
 msgstr "salvo"
@@ -2783,11 +3029,23 @@ msgstr "plano de teste"
 msgid "unanswered questions"
 msgstr "questões não respondida"
 
+#, fuzzy
+msgid "unpublish"
+msgstr ""
+
+#, fuzzy
+msgid "update"
+msgstr ""
+
 msgid "updated"
 msgstr "Atualizado"
 
-msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
-msgstr "upgrade_customization! não pode ser realizado, uma vez que não existe um modelo publicado do seu financiador atual"
+#, fuzzy
+msgid "upgrade cannot be carried out since there is no published template of its current funder"
+msgstr ""
+
+#msgid "upgrade_customization! cannot be carried out since there is no published template of its current funder"
+#msgstr "upgrade_customization! não pode ser realizado, uma vez que não existe um modelo publicado do seu financiador atual"
 
 msgid "upgrade_customization! requires a customised template"
 msgstr "upgrade_customization! requer um modelo customizado"

--- a/lib/tasks/translatable.rake
+++ b/lib/tasks/translatable.rake
@@ -69,14 +69,12 @@ namespace :translatable do
 
   desc 'Find all translatable text and update all pot/po files'
   task :find, [:domain] => [:environment] do |t, args|
-    if args[:domain].blank?
-      args[:domain] = 'app' # default domain is app
-    end
-    pot_filename = "config/locale/#{args[:domain]}.pot"
+    domain = args.fetch(:domain, 'app')
+    pot_filename = "config/locale/#{domain}.pot"
     translatables = []
 
-    puts "Scanning files for translatable text"
-    files_to_translate(args[:domain]).each do |file|
+    puts "Scanning files for translatable text for domain: #{domain}"
+    files_to_translate(domain).each do |file|
       # Ignore node_modules files
       unless file.include?('node_modules')
         puts "    scanning #{file}"
@@ -89,7 +87,7 @@ namespace :translatable do
       process_po_file(pot_filename, translatables)
 
       puts "Searching for localization files"
-      localization_files(args[:domain]).each do |domain_po|
+      localization_files(domain).each do |domain_po|
         process_po_file(domain_po, translatables)
       end
     else
@@ -103,6 +101,7 @@ namespace :translatable do
   CONTEXTUALIZED_TRANSLATABLE = /(n_\([\'\"](.*?)[\'\"]\,\s*[\'\"](.*?)[\'\"])/
   UNESCAPED_QUOTE = /(?<!\\)\"/
   FUZZY = /#, fuzzy/
+  NEWLINE_FOR_PO = "\"\n\""
 
   # Open the PO/POT file and update its translatation entries
   def process_po_file(file_name, translatable_text)
@@ -151,15 +150,19 @@ namespace :translatable do
     hash.keys.sort{ |a,b| a <=> b }.each do |key|
       if key != ''
         if hash[key][:obsolete]
-          lines += "\n#msgid \"#{key.gsub(UNESCAPED_QUOTE, '\"')}\"\n#msgstr \"#{hash[key][:text].gsub(UNESCAPED_QUOTE, '\"')}\"\n"
+          lines += "\n#msgid \"#{sanitize_po_string(key)}\"\n#msgstr \"#{sanitize_po_string(hash[key][:text])}\"\n"
         elsif hash[key][:fuzzy]
-          lines += "\n#, fuzzy\nmsgid \"#{key.gsub(UNESCAPED_QUOTE, '\"')}\"\nmsgstr \"#{hash[key][:text].gsub(UNESCAPED_QUOTE, '\"')}\"\n"
+          lines += "\n#, fuzzy\nmsgid \"#{sanitize_po_string(key)}\"\nmsgstr \"#{sanitize_po_string(hash[key][:text])}\"\n"
         else
-          lines += "\nmsgid \"#{key.gsub(UNESCAPED_QUOTE, '\"')}\"\nmsgstr \"#{hash[key][:text].gsub(UNESCAPED_QUOTE, '\"')}\"\n"
+          lines += "\nmsgid \"#{sanitize_po_string(key)}\"\nmsgstr \"#{sanitize_po_string(hash[key][:text])}\"\n"
         end
       end
     end
     lines
+  end
+
+  def sanitize_po_string(val)
+    val.gsub(UNESCAPED_QUOTE, '\"').gsub("\n", NEWLINE_FOR_PO)
   end
 
   # Scan the file contents for translatable text


### PR DESCRIPTION
- Fixed issues with `translatable:find` rake task.
- Also fixed a few issues with translation strings
- Ran translatable:find to update pot/po files
- reviewed and updated `en_US/app.po` and `pt_BR/app.po` (new strings need to be sent off for translation)
