### PR TITLE
Add ActiveRecord Session storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -151,6 +151,9 @@ group :development, :test do
 
   # Guard gem for RSpec (https://github.com/guard/guard-rspec)
   gem "guard-rspec"
+
+  gem "dotenv-rails"
+
 end
 
 group :test do
@@ -234,7 +237,5 @@ group :development do
 
   # TomDoc for YARD (http://rubyworks.github.com/yard-tomdoc)
   gem "yard-tomdoc"
-
-  gem "dotenv-rails"
 
 end

--- a/Gemfile
+++ b/Gemfile
@@ -122,6 +122,8 @@ gem 'gettext', require: false, group: :development
 # A pagination engine plugin for Rails 4+ and other modern frameworks (https://github.com/kaminari/kaminari)
 gem 'kaminari'
 
+gem 'activerecord-session_store'
+
 # ------------------------------------------------
 # ENVIRONMENT SPECIFIC DEPENDENCIES
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,12 @@ GEM
       activemodel (= 4.2.10)
       activesupport (= 4.2.10)
       arel (~> 6.0)
+    activerecord-session_store (1.1.1)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activesupport (4.2.10)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -401,6 +407,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   annotate
   annotate_gem
   better_errors
@@ -468,4 +475,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.3
+   1.16.6

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_dmproadmap_session'
+Rails.application.config.session_store :active_record_store, key: '_dmproadmap_session'

--- a/db/migrate/20181024120747_add_sessions_table.rb
+++ b/db/migrate/20181024120747_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/migrate/20181024120747_add_sessions_table.rb
+++ b/db/migrate/20181024120747_add_sessions_table.rb
@@ -1,7 +1,7 @@
 class AddSessionsTable < ActiveRecord::Migration
   def change
     create_table :sessions do |t|
-      t.string :session_id, :null => false
+      t.string :session_id, null: false, limit: 255
       t.text :data
       t.timestamps
     end

--- a/db/migrate/20181024120747_add_sessions_table.rb
+++ b/db/migrate/20181024120747_add_sessions_table.rb
@@ -1,7 +1,7 @@
 class AddSessionsTable < ActiveRecord::Migration
   def change
     create_table :sessions do |t|
-      t.string :session_id, null: false, limit: 255
+      t.string :session_id, null: false, limit: 64
       t.text :data
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180903131335) do
+ActiveRecord::Schema.define(version: 20181024120747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -299,6 +299,16 @@ ActiveRecord::Schema.define(version: 20180903131335) do
 
   add_index "sections", ["phase_id"], name: "index_sections_on_phase_id", using: :btree
   add_index "sections", ["versionable_id"], name: "index_sections_on_versionable_id", using: :btree
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", null: false
+    t.text     "data"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "settings", force: :cascade do |t|
     t.string   "var",         null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -301,7 +301,7 @@ ActiveRecord::Schema.define(version: 20181024120747) do
   add_index "sections", ["versionable_id"], name: "index_sections_on_versionable_id", using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", null: false
+    t.string   "session_id", limit: 255, null: false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -301,7 +301,7 @@ ActiveRecord::Schema.define(version: 20181024120747) do
   add_index "sections", ["versionable_id"], name: "index_sections_on_versionable_id", using: :btree
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", limit: 255, null: false
+    t.string   "session_id", limit: 64, null: false
     t.text     "data"
     t.datetime "created_at"
     t.datetime "updated_at"


### PR DESCRIPTION
Fixes #1968

Changes proposed in this PR:
- Add ActiveRecord Session Storage for managing sessions instead.

Developers should add to their own deployment, the following cron job:

`SESSION_DAYS_TRIM_THRESHOLD=2  RAILS_ENV=production rake db:sessions:trim`

This will help to keep the sessions table small, and automatically sign out all users after 48 hours (2 days)