### PR TITLE
Add Rollbar gem for catching production errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,10 @@ gem 'railties'
 # A set of Rails responders to dry up your application (http://github.com/plataformatec/responders)
 gem 'responders', '~> 2.0'
 
+group :rollbar, optional: true do
+  gem 'rollbar'
+end
+
 # ------------------------------------------------
 #    DATABASE/SERVER
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,6 +294,8 @@ GEM
       json
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    rollbar (2.18.0)
+      multi_json
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -446,6 +448,7 @@ DEPENDENCIES
   railties
   recaptcha
   responders (~> 2.0)
+  rollbar
   rspec-collection_matchers
   rspec-rails
   rubocop-dmp_roadmap (>= 1.1.0)

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,71 +1,82 @@
-Rollbar.configure do |config|
-  # Without configuration, Rollbar is enabled in all environments.
-  # To disable in specific environments, set config.enabled=false.
+# frozen_string_literal: true
 
-  config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+begin
+  # If Rollbar has been included in the Bundle, load it here.
+  require "rollbar"
+rescue LoadError => e
+  # noop
+end
 
-  # Here we'll disable in 'test':
-  if Rails.env.test?
-    config.enabled = false
+if defined?(Rollbar)
+  Rollbar.configure do |config|
+    # Without configuration, Rollbar is enabled in all environments.
+    # To disable in specific environments, set config.enabled=false.
+
+    config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+
+    # Here we'll disable in 'test':
+    if Rails.env.test?
+      config.enabled = false
+    end
+
+    # By default, Rollbar will try to call the `current_user` controller method
+    # to fetch the logged-in user object, and then call that object's `id`
+    # method to fetch this property. To customize:
+    # config.person_method = "my_current_user"
+    # config.person_id_method = "my_id"
+
+    # Additionally, you may specify the following:
+    config.person_username_method = "name"
+    # config.person_email_method = "email"
+
+    # If you want to attach custom data to all exception and message reports,
+    # provide a lambda like the following. It should return a hash.
+    # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+    # Add exception class names to the exception_level_filters hash to
+    # change the level that exception is reported at. Note that if an exception
+    # has already been reported and logged the level will need to be changed
+    # via the rollbar interface.
+    # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+    # 'ignore' will cause the exception to not be reported at all.
+    # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+    #
+    # You can also specify a callable, which will be called with the exception instance.
+    # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+    # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+    # is not installed)
+    # config.use_async = true
+    # Supply your own async handler:
+    # config.async_handler = Proc.new { |payload|
+    #  Thread.new { Rollbar.process_from_async_handler(payload) }
+    # }
+
+    # Enable asynchronous reporting (using sucker_punch)
+    # config.use_sucker_punch
+
+    # Enable delayed reporting (using Sidekiq)
+    # config.use_sidekiq
+    # You can supply custom Sidekiq options:
+    # config.use_sidekiq 'queue' => 'default'
+
+    # If your application runs behind a proxy server, you can set proxy parameters here.
+    # If https_proxy is set in your environment, that will be used. Settings here have precedence.
+    # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
+    # are optional.
+    #
+    # config.proxy = {
+    #   host: 'http://some.proxy.server',
+    #   port: 80,
+    #   user: 'username_if_auth_required',
+    #   password: 'password_if_auth_required'
+    # }
+
+    # If you run your staging application instance in production environment then
+    # you'll want to override the environment reported by `Rails.env` with an
+    # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+    # setup for Heroku. See:
+    # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+    config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
   end
-
-  # By default, Rollbar will try to call the `current_user` controller method
-  # to fetch the logged-in user object, and then call that object's `id`
-  # method to fetch this property. To customize:
-  # config.person_method = "my_current_user"
-  # config.person_id_method = "my_id"
-
-  # Additionally, you may specify the following:
-  config.person_username_method = "name"
-  # config.person_email_method = "email"
-
-  # If you want to attach custom data to all exception and message reports,
-  # provide a lambda like the following. It should return a hash.
-  # config.custom_data_method = lambda { {:some_key => "some_value" } }
-
-  # Add exception class names to the exception_level_filters hash to
-  # change the level that exception is reported at. Note that if an exception
-  # has already been reported and logged the level will need to be changed
-  # via the rollbar interface.
-  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
-  # 'ignore' will cause the exception to not be reported at all.
-  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
-  #
-  # You can also specify a callable, which will be called with the exception instance.
-  # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
-
-  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
-  # is not installed)
-  # config.use_async = true
-  # Supply your own async handler:
-  # config.async_handler = Proc.new { |payload|
-  #  Thread.new { Rollbar.process_from_async_handler(payload) }
-  # }
-
-  # Enable asynchronous reporting (using sucker_punch)
-  # config.use_sucker_punch
-
-  # Enable delayed reporting (using Sidekiq)
-  # config.use_sidekiq
-  # You can supply custom Sidekiq options:
-  # config.use_sidekiq 'queue' => 'default'
-
-  # If your application runs behind a proxy server, you can set proxy parameters here.
-  # If https_proxy is set in your environment, that will be used. Settings here have precedence.
-  # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
-  # are optional.
-  #
-  # config.proxy = {
-  #   host: 'http://some.proxy.server',
-  #   port: 80,
-  #   user: 'username_if_auth_required',
-  #   password: 'password_if_auth_required'
-  # }
-
-  # If you run your staging application instance in production environment then
-  # you'll want to override the environment reported by `Rails.env` with an
-  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
-  # setup for Heroku. See:
-  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
-  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
-end if defined?(Rollbar)
+end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,71 @@
+Rollbar.configure do |config|
+  # Without configuration, Rollbar is enabled in all environments.
+  # To disable in specific environments, set config.enabled=false.
+
+  config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+
+  # Here we'll disable in 'test':
+  if Rails.env.test?
+    config.enabled = false
+  end
+
+  # By default, Rollbar will try to call the `current_user` controller method
+  # to fetch the logged-in user object, and then call that object's `id`
+  # method to fetch this property. To customize:
+  # config.person_method = "my_current_user"
+  # config.person_id_method = "my_id"
+
+  # Additionally, you may specify the following:
+  config.person_username_method = "name"
+  # config.person_email_method = "email"
+
+  # If you want to attach custom data to all exception and message reports,
+  # provide a lambda like the following. It should return a hash.
+  # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+  # Add exception class names to the exception_level_filters hash to
+  # change the level that exception is reported at. Note that if an exception
+  # has already been reported and logged the level will need to be changed
+  # via the rollbar interface.
+  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+  # 'ignore' will cause the exception to not be reported at all.
+  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+  #
+  # You can also specify a callable, which will be called with the exception instance.
+  # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+  # is not installed)
+  # config.use_async = true
+  # Supply your own async handler:
+  # config.async_handler = Proc.new { |payload|
+  #  Thread.new { Rollbar.process_from_async_handler(payload) }
+  # }
+
+  # Enable asynchronous reporting (using sucker_punch)
+  # config.use_sucker_punch
+
+  # Enable delayed reporting (using Sidekiq)
+  # config.use_sidekiq
+  # You can supply custom Sidekiq options:
+  # config.use_sidekiq 'queue' => 'default'
+
+  # If your application runs behind a proxy server, you can set proxy parameters here.
+  # If https_proxy is set in your environment, that will be used. Settings here have precedence.
+  # The :host key is mandatory and must include the URL scheme (e.g. 'http://'), all other fields
+  # are optional.
+  #
+  # config.proxy = {
+  #   host: 'http://some.proxy.server',
+  #   port: 80,
+  #   user: 'username_if_auth_required',
+  #   password: 'password_if_auth_required'
+  # }
+
+  # If you run your staging application instance in production environment then
+  # you'll want to override the environment reported by `Rails.env` with an
+  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+  # setup for Heroku. See:
+  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+end if defined?(Rollbar)


### PR DESCRIPTION
Add support for Rollbar gem to catch exceptions from the app.

To include Rollbar in your setup, use the `--with` option when running `bundle install`

`bundle install --with=rollbar`

You'll also need to provide an ENV variable with your rollbar access token:

```
ROLLBAR_ACCESS_TOKEN=73ef49021e064a23b65d637b18997912
```
