### PR TITLE
Fix rollbar loading when optionally included

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
-#require 'devise'
 require 'recaptcha/rails'
 require 'csv'
 
@@ -16,6 +15,13 @@ require 'csv'
 #Bundler.require(:default, Rails.env)
 #Changed when migrated to rails 4.0.0
 Bundler.require(*Rails.groups)
+
+begin
+  # If Rollbar has been included in the Bundle, load it here.
+  require "rollbar"
+rescue LoadError => e
+  # noop
+end
 
 module DMPRoadmap
   class Application < Rails::Application

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-begin
-  # If Rollbar has been included in the Bundle, load it here.
-  require "rollbar"
-rescue LoadError => e
-  # noop
-end
-
 if defined?(Rollbar)
   Rollbar.configure do |config|
     # Without configuration, Rollbar is enabled in all environments.


### PR DESCRIPTION
This hasn't been working on our dev server. I think Rollbar needs to be loaded earlier than the initializer for the middleware to be included.