### PR TITLE
Add support for AWS file storage with Dragonfly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,13 @@ gem 'recaptcha'
 # Ideal gem for handling attachments in Rails, Sinatra and Rack applications. (http://github.com/markevans/dragonfly)
 gem 'dragonfly'
 
+group :aws, optional: true do
+
+  gem 'dragonfly-s3_data_store'
+
+end
+
+
 # bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right into your Sass powered applications. (https://github.com/twbs/bootstrap-sass)
 gem 'bootstrap-sass', '~> 3.3.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,9 +119,13 @@ GEM
       addressable (~> 2.3)
       multi_json (~> 1.0)
       rack (>= 1.3)
+    dragonfly-s3_data_store (1.3.0)
+      dragonfly (~> 1.0)
+      fog-aws
     erubi (1.7.1)
     erubis (2.7.0)
     eventmachine (1.2.7)
+    excon (0.62.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -142,6 +146,22 @@ GEM
       sax-machine (>= 1.0)
     ffi (1.9.25)
     flag_shih_tzu (0.3.22)
+    fog-aws (3.3.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-sass (4.2.2)
       sass (~> 3.2)
     formatador (0.2.5)
@@ -184,6 +204,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
+    ipaddress (0.8.3)
     jaro_winkler (1.5.1)
     jbuilder (2.6.4)
       activesupport (>= 3.0.0)
@@ -220,6 +241,9 @@ GEM
       mini_mime (>= 0.1.1)
     metaclass (0.0.4)
     method_source (0.9.0)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     mini_racer (0.2.3)
@@ -319,6 +343,8 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rollbar (2.18.0)
+      multi_json
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -472,6 +498,7 @@ DEPENDENCIES
   devise_invitable
   dotenv-rails
   dragonfly
+  dragonfly-s3_data_store
   factory_bot_rails
   faker
   feedjira

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -18,4 +18,15 @@ module OrgsHelper
       org_name: org.name
     }
   end
+
+  # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return
+  # the remote_url, otherwise return the url
+  def logo_url_for_org(org)
+    if ENV['DRAGONFLY_AWS'] == "true"
+      org.logo.remote_url
+    else
+      org.logo.url
+    end
+  end
+
 end

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -10,7 +10,7 @@
       </button>
       <% if user_signed_in? && !current_user.org.nil? %>
         <% if current_user.org.logo.present? %>
-          <%= link_to(image_tag(current_user.org.logo.thumb('100x100%').url,
+          <%= link_to(image_tag(logo_url_for_org(current_user.org),
                                 alt: current_user.org.name,
                                 class: "org-logo",
                                 title: current_user.org.name),

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -18,7 +18,7 @@
 
       <% if org.logo.present? %>
         <div class="clearfix"></div>
-        <%= image_tag org.logo.url, alt: "#{org.name} #{_('logo')}" %>
+        <%= image_tag logo_url_for_org(org), alt: "#{org.name} #{_('logo')}" %>
         <div class="org-logo-controls checkbox">
           <%= f.label :remove_logo do %>
             <%= f.check_box :remove_logo,

--- a/config/initializers/dragonfly.rb
+++ b/config/initializers/dragonfly.rb
@@ -8,9 +8,29 @@ Dragonfly.app.configure do
 
   url_format "/media/:job/:name"
 
-  datastore :file,
-    root_path: Rails.root.join('public/system/dragonfly', Rails.env),
-    server_root: Rails.root.join('public')
+  # If the DRAGONFLY_AWS environment variable is set to 'true', configure the app to
+  # use Amazon S3 for storage:
+  if ENV['DRAGONFLY_AWS'] == 'true'
+    require 'dragonfly/s3_data_store'
+    datastore(:s3, {
+      bucket_name: ENV["AWS_BUCKET_NAME"],
+      access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+      secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: ENV["AWS_REGION"],
+      root_path: Rails.env,
+      url_scheme: "https"
+    })
+
+  # Otherwise, revert to the default:
+  else
+
+    datastore(:file, {
+      root_path: Rails.root.join('public/system/dragonfly', Rails.env),
+      server_root: Rails.root.join('public'),
+    })
+
+  end
+
 end
 
 # Logger


### PR DESCRIPTION
Fixes #1976

Changes proposed in this PR:
- Added optional support for `dragonfly-s3_data_store` gem. To include this, bundle install with group `aws`: `bundle install --with=aws`
- To configure AWS, provide the following ENV variables:
  ```
  AWS_BUCKET_NAME
  AWS_ACCESS_KEY_ID
  AWS_SECRET_ACCESS_KEY
  AWS_REGION
  ```