### PR TITLE
Fix for ensuring that Questions that are option based must have atlea…

### DIFF
--- a/app/models/concerns/validation_messages.rb
+++ b/app/models/concerns/validation_messages.rb
@@ -6,5 +6,7 @@ module ValidationMessages
   UNIQUENESS_MESSAGE = _("must be unique")
 
   INCLUSION_MESSAGE = _("isn't a valid value")
+  
+  OPTION_PRESENCE_MESSAGE = _("must have at least one option.")
 
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -65,10 +65,11 @@ class Question < ActiveRecord::Base
 
   has_one :template, through: :section
 
-
   # ===============
   # = Validations =
   # ===============
+
+  validate :ensure_has_question_options, if: :option_based?
 
   validates :text, presence: { message: PRESENCE_MESSAGE }
 
@@ -99,7 +100,7 @@ class Question < ActiveRecord::Base
   # = Delegated methods =
   # =====================
 
-  delegate :option_based?, to: :question_format
+  delegate :option_based?, to: :question_format, :allow_nil => true
 
   # ===========================
   # = Public instance methods =
@@ -146,7 +147,7 @@ class Question < ActiveRecord::Base
     end
 
     guidances
-   end
+  end
 
   # get example answer belonging to the currents user for this question
   #
@@ -191,6 +192,14 @@ class Question < ActiveRecord::Base
       guidance = annotations.build(type: :guidance, text: "", org_id: org_id)
     end
     [example_answer, guidance]
+  end
+
+  private
+
+  def ensure_has_question_options
+    if question_options.empty?
+      errors.add :base, OPTION_PRESENCE_MESSAGE
+    end
   end
 
 end

--- a/spec/factories/question_formats.rb
+++ b/spec/factories/question_formats.rb
@@ -26,11 +26,13 @@ FactoryBot.define do
     trait :textarea do
       title { "Text area" }
       formattype { "textarea" }
+      option_based { false }
     end
 
     trait :textfield do
       title { "Text field" }
       formattype { "textfield" }
+      option_based { false }
     end
 
     trait :radiobuttons do
@@ -60,11 +62,21 @@ FactoryBot.define do
     trait :date do
       title { "Date" }
       formattype { "date" }
+      option_based { false }
     end
 
     trait :rda_metadata do
       title { "RDA Metadata" }
       formattype { "rda_metadata" }
+      option_based { false }
+    end
+
+    trait :option_based_true do
+      option_based { true }
+    end
+
+    trait :option_based_false do
+      option_based { false }
     end
 
   end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -37,8 +37,8 @@ FactoryBot.define do
       options { 0 }
     end
 
-    after(:create) do |question, evaluator|
-      create_list(:question_option, evaluator.options, question: question)
+    before(:create) do |question, evaluator|
+      question.question_options = create_list(:question_option, evaluator.options)
     end
 
     trait :textarea do

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true.
 require 'rails_helper'
 
 RSpec.describe Question, type: :model do
@@ -68,13 +69,26 @@ RSpec.describe Question, type: :model do
 
   describe "#option_based?" do
 
-    let!(:question) { create(:question, question_format: question_format) }
-
     subject { question_format.option_based? }
 
-    context "when QuestionFormat is option_based" do
+    context "when QuestionFormat is option_based and has at least one option" do
 
       let!(:question_format) { create(:question_format, option_based: true) }
+      let!(:question) { create(:question, question_format: question_format, options: 1) }
+
+      it { is_expected.to eql(true) }
+
+    end
+
+    context "when QuestionFormat is option_based and has no option" do
+
+      let!(:question_format) { create(:question_format, option_based: true) }
+
+      it {
+        expect {
+          create(:question, question_format: question_format, options: 0)
+        }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: must have at least one option.")
+      }
 
       it { is_expected.to eql(true) }
 
@@ -83,6 +97,7 @@ RSpec.describe Question, type: :model do
     context "when QuestionFormat is not option_based" do
 
       let!(:question_format) { create(:question_format, option_based: false) }
+      let!(:question) { create(:question, question_format: question_format) }
 
       it { is_expected.to eql(false) }
 


### PR DESCRIPTION
…st one non-blank text entry.
Related to previous closed issuehttps://github.com/DMPRoadmap/roadmap/pull/1959#issuecomment-434378252 . Now Rspec tests fixed.

    - Validation added for option based questions to ensure text field non-blank.
    - Validation message OPTION_PRESENCE_MESSAGE added to app/models/concerns/validation_messages.rb.
    - Added ':allow_nil => true' to
            delegate :option_based?, to: :question_format, :allow_nil => true
     in Question model to prevent NoMethodError if question_format is nil.

    Fix for #1725

