### PR TITLE
Issue #1161 - Display tooltip below form fields on Create plan page.

### DIFF
--- a/app/javascript/utils/tooltipHelper.js
+++ b/app/javascript/utils/tooltipHelper.js
@@ -6,8 +6,14 @@ $(() => {
   // uses an iframe and we can't detect when the editor window gains focus. It only works on hover.
   //
   // If the content of the tooltip contains HTML, then add `data-html="true"` to the element
-  $('[data-toggle="tooltip"]').tooltip({
+  // Default behaviour for all tootips, when attribute data-placement not set
+  $('[data-toggle="tooltip"]:not([data-placement])').tooltip({
     animated: 'fade',
     placement: 'right',
+  });
+
+  // Don't set placement property if data-placement present
+  $('[data-toggle="tooltip"][data-placement]').tooltip({
+    animated: 'fade',
   });
 });

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -18,6 +18,7 @@
         <div class="form-group col-xs-6">
           <%= f.text_field(:title, class: 'form-control', 'aria-describedby': 'project-title', 'aria-required': 'true', 'aria-label': 'project-title',
                 'data-toggle': 'tooltip',
+                'data-placement': 'bottom',
                 title: _('If applying for funding, state the project title exactly as in the proposal.')) %>
         </div>
         <div class="col-md-1">&nbsp;</div>
@@ -46,7 +47,8 @@
                               attribute: 'name',
                               required: true,
                               error: _('You must select a research organisation from the list.'),
-                              tooltip: _('Please select a valid research organisation from the list.')} %>
+                              tooltip: _('Please select a valid research organisation from the list.'),
+                              placement: 'bottom'} %>
         </div>
         <div class="col-md-1 pad-top-10 create-plan-or"><strong>- <%= _('or') %> -</strong></div>
         <div class="form-group col-md-5 create-plan-checkbox">
@@ -72,7 +74,8 @@
                               attribute: 'name',
                               required: true,
                               error: _('You must select a funding organisation from the list.'),
-                              tooltip: _('Please select a valid funding organisation from the list.')} %>
+                              tooltip: _('Please select a valid funding organisation from the list.'),
+                              placement: 'bottom'} %>
         </div>
         <div class="col-md-1 create-plan-or"><strong>- <%= _('or') %> -</strong></div>
         <div class="form-group col-xs-5 create-plan-checkbox">

--- a/app/views/shared/_accessible_combobox.html.erb
+++ b/app/views/shared/_accessible_combobox.html.erb
@@ -8,14 +8,17 @@
   <% models.map{|m| json["#{m[attribute]}"] = m.id} %>
   <!-- If the incoming name has a namespace prefix, remove it so that the controller can access the params -->
   <% name = name.gsub(name.match(/^.*\[/)[0].split('_')[0] + '_', '') %>
-  <input type="text" name="<%= name %>" id="<%= id %>" 
-         class="js-combobox form-control <%= classes %>" list="<%= id %>_list" 
+  <input type="text" name="<%= name %>" id="<%= id %>"
+         class="js-combobox form-control <%= classes %>" list="<%= id %>_list"
          placeholder="<%= _('Begin typing to see a filtered list') %>"
          data-combobox-prefix-class="combobox"
          data-combobox-case-sensitive="no"
          data-combobox-search-option="containing"
          data-combobox-allow-suggestion-on-empty="true"
          data-toggle="<%= title == '' ? '' : 'tooltip' %>"
+         <% if defined?(placement) %>
+           data-placement="<%= placement %>"
+         <% end %>
          title="<%= title %>"
          aria-label= "<%= title %>",
          value="<%= default_selection[attribute] unless default_selection.nil? %>" />


### PR DESCRIPTION
    - Required modification for the intiialization of Bootstrap tooltips in the javascript file
      /utils/tooltipHelper.js. The default behaviour is placement of tooltip to the right of element
      with attribute data-toggle='tooltip'. Now if the attribute data-placement attribute is set,
      then the placement of the tootip will be as specfied in the attribute and not on the right (the default behaviour).
    - The accessible combob-box now takes an optional property 'placement' which if present sets data-placement
      attribute to the value of the placement property.
    - Now all Create Plan page tooltips are below the input as requested.

Fix for #1161.

