### PR TITLE
Issue #1931 - Share plan emails updated.

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -30,7 +30,7 @@ class RolesController < ApplicationController
         else
           if user.nil?
             registered = false
-            User.invite!(email: params[:user])
+            User.invite!({ email: params[:user] }, current_user)
             message = _("Invitation to %{email} issued successfully.") % {
               email: params[:user]
             }

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -4,13 +4,19 @@
   helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
   contact_us = (Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url)
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
+  user_name = User.find_by(email: @resource.email).nil? ?  @resource.email : User.find_by(email: @resource.email).name(false)
+  inviter_name = @resource.invited_by.name(false)
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>
-    <%= _('Hello %{user_email}') %{ :user_email => @resource.email } %>
+    <%= _('Hello %{user_name}') %{ :user_name => user_name } %>
   </p>
   <p>
-    <%= _('A colleague has invited you to contribute to their Data Management Plan in %{tool_name}') %{ :tool_name => tool_name } %>
+    <%= _("Your colleague %{inviter_name} has invited you to contribute to "\
+            " their Data Management Plan in %{tool_name}") % {
+      tool_name: tool_name,
+      inviter_name: inviter_name
+    } %>
   </p>
   <p>
     <%= sanitize(_('%{click_here} to accept the invitation, (or copy %{link} into your browser). If you don\'t want to accept the invitation, please ignore this email.') % {

--- a/app/views/user_mailer/sharing_notification.html.erb
+++ b/app/views/user_mailer/sharing_notification.html.erb
@@ -2,10 +2,11 @@
   tool_name = Rails.configuration.branding[:application][:name]
   user_email = @user.email
   link = url_for(action: 'show', controller: 'plans', id: @role.plan.id)
+  user_name = User.find_by(email: user_email).nil? ?  user_email : User.find_by(email: user_email).name(false)
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>
-    <%= _('Hello %{user_email}') %{ :user_email => user_email } %>
+    <%= _('Hello %{user_name}') %{ :user_name => user_name } %>
   </p>
   <p>
     <%= _("Your colleague %{inviter_name} has invited you to contribute to "\


### PR DESCRIPTION
- The inviter name is added to the devise file app/views/devise/mailer/invitation_instructions.html.erb
- The name of person invited the plan is shared with is added to the greeting if it exists for both the devise
and non-devise emails (repectively app/views/devise/mailer/invitation_instructions.html.erb and app/views/user_mailer/sharing_notification.html.erb).
Otherwise, the invited person's email is displayed in the greetings.

Fix for #1931

