### PR TITLE
Updated api stats controller to use Org model's  method

### DIFF
--- a/app/controllers/api/v0/statistics_controller.rb
+++ b/app/controllers/api/v0/statistics_controller.rb
@@ -25,9 +25,9 @@ class Api::V0::StatisticsController < Api::V0::BaseController
     if params[:range_dates].present?
       r = {}
       params[:range_dates].each_pair do |k, v|
-        r[k] = scoped.where("created_at >=?", v["start_date"])
-                     .where("created_at <=?", v["end_date"]).count
+        r[k] = scoped.where(created_at: dates_to_range(v)).count
       end
+
       respond_to do |format|
         format.json { render(json: r.to_json) }
         format.csv {
@@ -39,11 +39,8 @@ class Api::V0::StatisticsController < Api::V0::BaseController
           end, filename: "#{_('users_joined')}.csv") }
       end
     else
-      if params[:start_date].present?
-        scoped = scoped.where("created_at >= ?", Date.parse(params[:start_date]))
-      end
-      if params[:end_date].present?
-        scoped = scoped.where("created_at <= ?", Date.parse(params[:end_date]))
+      if params["start_date"].present? || params["end_date"].present?
+        scoped = scoped.where(created_at: dates_to_range(params))
       end
       @users_count = scoped.count
       respond_with @users_count
@@ -57,25 +54,18 @@ class Api::V0::StatisticsController < Api::V0::BaseController
       raise Pundit::NotAuthorizedError
     end
 
-    roles = Role.with_access_flags(:administrator, :creator)
-
-    users = User.unscoped
     if @user.can_super_admin? && params[:org_id].present?
-      users = users.where(org_id: params[:org_id])
+      scoped = Org.find(params[:org_id]).plans.where(complete: true)
     else
-      users = users.where(org_id: @user.org_id)
+      scoped = @user.org.plans.where(complete: true)
     end
 
-    plans = Plan.where(complete: true)
     if params[:range_dates].present?
       r = {}
       params[:range_dates].each_pair do |k, v|
-        range_date_plans = plans
-          .where("plans.updated_at >=?", v["start_date"])
-          .where("plans.updated_at <=?", v["end_date"])
-        r[k] = roles.joins(:user, :plan).merge(users).merge(range_date_plans)
-                    .select(:plan_id).distinct.count
+        r[k] = scoped.where(created_at: dates_to_range(v)).count
       end
+
       respond_to do |format|
         format.json { render(json: r.to_json) }
         format.csv {
@@ -87,15 +77,10 @@ class Api::V0::StatisticsController < Api::V0::BaseController
           end, filename: "#{_('completed_plans')}.csv") }
       end
     else
-      if params[:start_date].present?
-        plans = plans.where("plans.updated_at >= ?", Date.parse(params[:start_date]))
+      if params["start_date"].present? || params["end_date"].present?
+        scoped = scoped.where(created_at: dates_to_range(params))
       end
-      if params[:end_date].present?
-        plans = plans.where("plans.updated_at <= ?", Date.parse(params[:end_date]))
-      end
-      count = roles.joins(:user, :plan).merge(users).merge(plans)
-                   .select(:plan_id).distinct.count
-      render(json: { completed_plans: count })
+      render(json: { completed_plans: scoped.count })
     end
   end
 
@@ -106,33 +91,18 @@ class Api::V0::StatisticsController < Api::V0::BaseController
     unless Api::V0::StatisticsPolicy.new(@user, :statistics).plans?
       raise Pundit::NotAuthorizedError
     end
-    roles = Role.with_access_flags(:administrator, :creator)
 
-    users = User.unscoped
     if @user.can_super_admin? && params[:org_id].present?
-      users = users.where(org_id: params[:org_id])
+      scoped = Org.find(params[:org_id]).plans
     else
-      users = users.where(org_id: @user.org_id)
+      scoped = @user.org.plans
     end
 
-    plans = Plan.all
     if params[:range_dates].present?
       r = {}
       params[:range_dates].each_pair do |k, v|
-        #range_date_plans = plans
-        #  .where("plans.created_at >= ?", v["start_date"])
-        #  .where("plans.created_at <= ?", v["end_date"])
-        start_date = Date.parse(v["start_date"])
-        end_date = Date.parse(v["end_date"])
-        r[k] = current_user.org.plans
-          .where(plans: { created_at: start_date..end_date })
-          .pluck("plans.id")
-          .uniq.count
-        #r[k] = roles.joins(:user, :plan).merge(users).merge(range_date_plans)
-        #            .select(:plan_id).distinct.count
+        r[k] = scoped.where(created_at: dates_to_range(v)).count
       end
-
-p "RANGED FIND: #{r.inspect}"
 
       respond_to do |format|
         format.json { render(json: r.to_json) }
@@ -145,47 +115,30 @@ p "RANGED FIND: #{r.inspect}"
           end, filename: "#{_('plans')}.csv") }
       end
     else
-      if params[:start_date].present?
-        plans = current_user.org.plans
-          .where("plans.created_at >= ?", Date.parse(params[:start_date]))
-          .pluck("plans.id").uniq
-      elsif params[:end_date].present?
-        plans = current_user.org.plans
-          .where("plans.created_at <= ?", Date.parse(params[:end_date]))
-          .pluck("plans.id").uniq
-      else
-        plans = current_user.org.plans.pluck("plans.id").uniq
+      if params["start_date"].present? || params["end_date"].present?
+        scoped = scoped.where(created_at: dates_to_range(params))
       end
-      count = plans.length
-      render(json: { created_plans: count })
+      render(json: { completed_plans: scoped.count })
     end
   end
 
   ##
-  # Displays the number of DMPs using the specified template between the optional
-  # specified dates ensures that the template is owned/created by the caller's
-  # organisation
+  # Displays the number of DMPs using templates owned/create by the caller's Org
+  # between the optional specified dates
   def using_template
-    org_templates = @user.org.templates.where(customization_of: nil)
     unless Api::V0::StatisticsPolicy.new(@user, org_templates.first).using_template?
       raise Pundit::NotAuthorizedError
     end
+    org_templates = @user.org.templates.where(customization_of: nil)
     @templates = {}
     org_templates.each do |template|
       if @templates[template.title].blank?
         @templates[template.title] = {}
         @templates[template.title][:title]  = template.title
         @templates[template.title][:id]     = template.family_id
-        if template.plans.present?
-          @templates[template.title][:uses] = restrict_date_range(template.plans).length
-        else
-          @templates[template.title][:uses] = 0
-        end
-      else
-        if template.plans.present?
-          @templates[template.title][:uses] += restrict_date_range(template.plans).length
-        end
       end
+      scoped = template.plans.where(plans: { created_at: dates_to_range(params) })
+      @templates[template.title][:uses] = scoped.length
     end
     respond_with @templates
   end
@@ -199,17 +152,8 @@ p "RANGED FIND: #{r.inspect}"
     unless Api::V0::StatisticsPolicy.new(@user, :statistics).plans_by_template?
       raise Pundit::NotAuthorizedError
     end
-    org_projects = []
-    @user.org.users.each do |user|
-      user.plans.each do |plan|
-        unless org_projects.include? plan
-          org_projects += [plan]
-        end
-      end
-    end
-    org_projects = restrict_date_range(org_projects)
     @templates = {}
-    org_projects.each do |plan|
+    @user.org.plans.each do |plan|
       # if hash exists
       if @templates[plan.template.title].blank?
         @templates[plan.template.title] = {}
@@ -232,54 +176,18 @@ p "RANGED FIND: #{r.inspect}"
     unless Api::V0::StatisticsPolicy.new(@user, :statistics).plans?
       raise Pundit::NotAuthorizedError
     end
-    @org_plans = []
-    @user.org.users.each do |user|
-      user.plans.each do |plan|
-        unless @org_plans.include? plan
-          @org_plans += [plan]
-        end
-      end
-    end
-    @org_plans = restrict_date_range(@org_plans)
-    respond_with @org_plans
+    respond_with @user.org.plans
   end
 
 
   private
 
-  ##
-  # Takes in an array of active_reccords and restricts the range of dates
-  # to those specified in the params
-  #
-  # objects - any active_reccord reccords which have the "created_at" field specified
-  #
-  # Returns Array
-  def restrict_date_range(objects)
-    # set start_date to either passed param, or beginning of time
-    if params[:start_date].blank?
-      start_date = Date.new(0)
-    else
-      start_date = Date.strptime(params[:start_date], "%Y-%m-%d")
-    end
-    # set end_date to either passed param or now
-    if params[:end_date].blank?
-      end_date = Date.today
-    else
-      end_date = Date.strptime(params[:end_date], "%Y-%m-%d")
-    end
-
-    filtered = []
-    objects.each do |obj|
-      # apperantly things can have nil created_at
-      if obj.created_at.blank?
-        if params[:start_date].blank? && params[:end_date].blank?
-          filtered += [obj]
-        end
-      elsif start_date <= obj.created_at.to_date && end_date >= obj.created_at.to_date
-        filtered += [obj]
-      end
-    end
-    filtered
+  # Convert start/end dates in hash to a range of Dates
+  def dates_to_range(hash)
+    today = Date.today
+    start_date = Date.parse(hash.fetch("start_date", today.prev_month.to_date.to_s))
+    end_date = Date.parse(hash.fetch("end_date", today.to_date.to_s)) + 1.day
+    start_date..end_date
   end
 
 end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -205,8 +205,12 @@ class Org < ActiveRecord::Base
   end
 
   def plans
-    Plan.includes(:template, :phases, :roles, :users).joins(:roles, :users).where('users.org_id = ? AND roles.access IN (?)',
-      self.id, Role.access_values_for(:owner).concat(Role.access_values_for(:administrator)))
+    access_ids = Role.access_values_for(:owner)
+                     .concat(Role.access_values_for(:administrator))
+
+    Plan.includes(:template, :phases, :roles, :users)
+        .joins(:roles, :users)
+        .where(users: { org_id: self.id }, roles: { access: access_ids, active: true })
   end
 
   def grant_api!(token_permission_type)


### PR DESCRIPTION
Fixes #1703 .

The usage statistics page was calling the API controller which had not been updated to use the Org model's `plans` method to calculate the total number of plans. Switched to use the `current_user.org.plans` method so that we are not duplicating query logic