### PR TITLE
refactoring css variables to be more descriptive when re-branding the site

### DIFF
--- a/app/assets/stylesheets/blocks/_buttons.scss
+++ b/app/assets/stylesheets/blocks/_buttons.scss
@@ -12,7 +12,7 @@
 .btn-primary:visited,
 .btn-primary:active:hover,
 .btn-primary.active:hover {
-  background-color: $color-background-grey;
+  background-color: $color-primary-background;
   border-color: $color-border-default;
   outline: none;
   margin-top: 5px;
@@ -27,7 +27,7 @@
 .btn-default:visited,
 .btn-default:active:hover,
 .btn-default.active:hover {
-  background-color: $color-background-grey;
+  background-color: $color-primary-background;
   border-color: $color-border-default;
   outline: none;
   margin-top: 5px;
@@ -41,9 +41,14 @@
 .btn-default:active[data-toggle=tooltip],
 .btn-default:visited[data-toggle=tooltip],
 .btn-default:active:hover[data-toggle=tooltip] {
-  color: $color-text-grey;
-  background-color: $color-white;
+  color: $color-seccondary-text;
+  background-color: $color-seccondary-background;
   border: none;
   padding-left: -10px;
   font-size: .8rem;
+}
+
+/* link button */
+.btn-link {
+  color: $color-link-text;
 }

--- a/app/assets/stylesheets/blocks/_combobox.scss
+++ b/app/assets/stylesheets/blocks/_combobox.scss
@@ -19,11 +19,11 @@
   position: absolute;
   left: 0;
   width: 100%;
-  background: $color-white;
+  background: $color-seccondary-background;
   z-index: 1100;
 }
 .combobox-suggestion {
-  color: $color-text-grey;
+  color: $color-seccondary-text;
   border-bottom: 1px solid $color-border-default;
   border-left: 1px solid $color-border-default;
   border-right: 1px solid $color-border-default;
@@ -36,8 +36,8 @@
 }
 .combobox-suggestion:hover,
 .combobox-suggestion:focus {
-  color: $color-white;
-  background-color: $color-background-grey;
+  color: $color-primary-text;
+  background-color: $color-primary-background;
 }
 
 .combobox-clear-button, .combobox-clear-button:hover, .combobox-clear-button:focus {
@@ -48,7 +48,7 @@
   right: 5px;
   border: none;
   background: transparent;
-  color: $color-text-grey;
+  color: $color-seccondary-text;
 }
 
 /* http://geektnt.com/how-to-remove-x-from-search-input-field-on-chrome-and-ie.html */

--- a/app/assets/stylesheets/blocks/_font_awesomes.scss
+++ b/app/assets/stylesheets/blocks/_font_awesomes.scss
@@ -5,10 +5,15 @@
   font-size: 2rem;
 }
 .fa-reverse {
-  color: $color-text-grey;
+  color: $color-seccondary-text;
 }
 .fa-sort, .fa-sort-asc, .fa-sort-desc {
-  color: $color-white;
+  color: $color-primary-text;
+}
+
+/* change color of search icon */
+.fa-search {
+  color: $color-primary-text;
 }
 
 /* adjust the position of the 'remove - X' button for links */
@@ -21,12 +26,12 @@
 a {
    i {
      &.fa {
-       
+
        &.fa-file-pdf-o,
        &.fa-file-word-o {
-         color: $color-black;
+         color: $color-fa;
          margin: 5px;
-         
+
          &:not(.small) {
            font-size: 2.3em;
          }

--- a/app/assets/stylesheets/blocks/_html.scss
+++ b/app/assets/stylesheets/blocks/_html.scss
@@ -24,7 +24,7 @@ body{
 
 /* footer */
 footer {
-  position: absolute;
+  position: static;
   bottom: 0;
   margin-top: 20px;
   margin-bottom: -20px;
@@ -54,4 +54,13 @@ legend {
   font-weight: bold;
   margin-bottom: 5px;
   text-transform: capitalize;
+}
+
+a {
+  color: $color-link-text;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  /* font-family: "GillSansLight"; */
+  color: $color-heading-text;
 }

--- a/app/assets/stylesheets/blocks/_input_groups.scss
+++ b/app/assets/stylesheets/blocks/_input_groups.scss
@@ -1,3 +1,4 @@
 .input-group-addon {
   border-radius: 0px;
+  background-color: $color-primary-background;
 }

--- a/app/assets/stylesheets/blocks/_inverse_dropdowns.scss
+++ b/app/assets/stylesheets/blocks/_inverse_dropdowns.scss
@@ -3,14 +3,14 @@
   background-color: $dropdown-inverse-bg !important;
   border-color: $dropdown-inverse-border !important;
   & > li > a {
-    color: #999 !important;
+    color: $dropdown-inverse-text !important;
     &:hover {
-      color: #fff !important;
-      background-color: $color-background-black !important;
+      color: $dropdown-inverse-text-hoover !important;
+      background-color: $dropdown-inverse-bg-hoover !important;
     }
   }
   .active a {
-    color: #fff !important;
-    background-color: $color-background-black !important;
+    color: $dropdown-inverse-text-hoover !important;
+    background-color: $dropdown-inverse-bg-hoover !important;
   }
 }

--- a/app/assets/stylesheets/blocks/_modal_dialogs.scss
+++ b/app/assets/stylesheets/blocks/_modal_dialogs.scss
@@ -1,7 +1,7 @@
 // Overrides Bootstrap 3.0's Modals
 
 .modal-dialog {
-  background-color: $color-white;
+  background-color: $color-seccondary-background;
 }
 
 

--- a/app/assets/stylesheets/blocks/_navbars.scss
+++ b/app/assets/stylesheets/blocks/_navbars.scss
@@ -30,6 +30,11 @@
     line-height: 102px;
     height: 102px;
     padding-top: 0;
+    color: $navbar-org-link-color;
+    &:hover,
+    &:focus {
+      color: darken($navbar-org-link-hover-color,10%)
+    }
   }
   #org-navbar .org-links {
     padding-top: $grid-gutter-width / 2;
@@ -143,13 +148,6 @@
           }
         }
       }
-    }
-  }
-
-  .navbar-link {
-    color: $navbar-branding-link-color;
-    &:hover {
-      color: $navbar-branding-link-hover-color;
     }
   }
 

--- a/app/assets/stylesheets/blocks/_navs.scss
+++ b/app/assets/stylesheets/blocks/_navs.scss
@@ -2,20 +2,20 @@
 
 /* nav-tabs and nav-pills styling */
 .nav-tabs, .nav-pills {
-  background-color: $color-background-grey;
-  color: $color-white;
+  background-color: $color-primary-background;
+  color: $color-primary-text;
   border-bottom: 0px;
 }
 .nav-tabs > li > a, .nav-pills > li > a {
-  color: $color-white;
+  color: $color-primary-text;
 }
 .nav-tabs > li > a:hover,
 .nav-tabs > li > a:focus,
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:focus,
 .nav-tabs > li.active > a:hover {
-  background-color: $color-white;
-  color: $color-text-grey;
+  background-color: $color-seccondary-background;
+  color: $color-seccondary-text;
   border: 1px solid $color-border-default;
   border-bottom-color: transparent; /* Only nav-tabs have a transparent border-bottom */
 }
@@ -24,8 +24,8 @@
 .nav-pills > li.active > a,
 .nav-pills > li.active > a:focus,
 .nav-pills > li.active > a:hover {
-  background-color: $color-white;
-  color: $color-text-grey;
+  background-color: $color-seccondary-background;
+  color: $color-seccondary-text;
   border: 1px solid $color-border-default;
 }
 .nav-pills > li:last-child > a:hover,

--- a/app/assets/stylesheets/blocks/_panels.scss
+++ b/app/assets/stylesheets/blocks/_panels.scss
@@ -4,8 +4,8 @@
   border-color: $color-border-default;
 }
 .heading-button > .panel-heading, .panel-default > .panel-heading {
-  background-color: $color-background-grey;
-  color: $color-white;
+  background-color: $color-primary-background;
+  color: $color-primary-text;
   border-top-right-radius: 0px;
   border-top-left-radius: 0px;
 }
@@ -14,10 +14,10 @@
   display: block;
   padding: 8px $grid-gutter-width / 2;
   margin: -10px $grid-gutter-width / -2;
-  background-color: $color-background-grey;
-  color: $color-white;
+  background-color: $color-primary-background;
+  color: $color-primary-text;
 }
 .panel-title > a.reverse {
-  background-color: $color-white;
-  color: $color-text-grey;
+  background-color: $color-seccondary-background;
+  color: $color-seccondary-text;
 }

--- a/app/assets/stylesheets/blocks/_tables.scss
+++ b/app/assets/stylesheets/blocks/_tables.scss
@@ -5,21 +5,21 @@
 
 thead th {
   background-color: $color-border-default;
-  color: $color-white;
+  color: $color-primary-text;
 }
 
 thead th.table-scope {
-  background-color: $color-white;
+  background-color: $color-seccondary-background;
   font-weight: normal;
 
   a {
-    color: $color-text-grey;
+    color: $color-seccondary-text;
     padding: 2px ($grid-gutter-width / 2) 2px 2px;
   }
 }
 
 .table-hover tbody tr:hover td, .table-hover tbody tr:hover th {
-  background-color: $color-background-muted;
+  background-color: $color-muted-background;
 }
 
 th.date-column {
@@ -56,7 +56,7 @@ th.download-column {
 
     thead > tr > th {
       border: none;
-      background-color: $color-background-white;
+      background-color: $color-seccondary-background;
       color: $color-text-black;
     }
     tbody > tr > td { border: none; }

--- a/app/assets/stylesheets/blocks/_template_filters.scss
+++ b/app/assets/stylesheets/blocks/_template_filters.scss
@@ -1,4 +1,4 @@
 .template-table-filters .navbar-nav > li > a {
-  color: $color-text-grey;
+  color: $color-seccondary-text;
   padding: 5px ($grid-gutter-width / 2) 5px 5px;
 }

--- a/app/assets/stylesheets/variables/_bootstrap.scss
+++ b/app/assets/stylesheets/variables/_bootstrap.scss
@@ -20,9 +20,40 @@ $navbar-border-radius: 0px !default;
 // Buttons
 $btn-border-radius-base: 0px !default;
 
-$btn-primary-color: $color-text-white !default;
+$btn-primary-color: $color-primary-text !default;
 
-$btn-default-color: $color-text-white !default;
+$btn-default-color: $color-primary-text !default;
 
 // Panels
 $panel-border-radius: 0px !default;
+
+
+// from colors:
+
+$dropdown-inverse-bg: $color-navbar-background;
+$dropdown-inverse-border: $color-dropdown-inverse-border;
+$dropdown-inverse-text: $color-dropdown-inverse-text;
+$dropdown-inverse-text-hoover: $color-dropdown-inverse-text-hover;
+$dropdown-inverse-bg-hoover: $color-navbar-background-active;
+
+// Navbar branding colours
+$navbar-branding-color: $color-navbar-text !default;
+$navbar-branding-bg: $color-navbar-background !default;
+$navbar-branding-border: $color-navbar-border !default;
+$navbar-branding-link-color: $color-navbar-link-text !default;
+$navbar-branding-link-hover-color: $color-navbar-text-hover !default;
+$navbar-branding-link-hover-bg: transparent !default;
+$navbar-branding-link-active-color: $navbar-branding-link-hover-color !default;
+$navbar-branding-link-active-bg: $color-navbar-background-active !default;
+$navbar-branding-link-disabled-color: $color-navbar-text-disabled !default;
+$navbar-branding-link-disabled-bg: transparent !default;
+$navbar-branding-brand-color: $navbar-branding-link-color !default;
+// $navbar-branding-brand-hover-color: #FFFFFF !default;
+// $navbar-branding-brand-hover-bg: transparent !default;
+$navbar-branding-toggle-hover-bg: $color-navbar-background-active !default;
+$navbar-branding-toggle-icon-bar-bg: $color-icon-bar-background !default;
+$navbar-branding-toggle-border-color: $color-navbar-background-active !default;
+
+// org-navbar branding colors
+$navbar-org-link-color: $color-org-navbar-links;
+$navbar-org-link-hover-color: $color-org-navbar-links-hover;

--- a/app/assets/stylesheets/variables/_colours.scss
+++ b/app/assets/stylesheets/variables/_colours.scss
@@ -1,52 +1,59 @@
-// Colors:
+/*
+  Colors
+  - to be used as utilities within this file to define text+bg colors
+*/
 $color-black: #000;
 $color-white: #FFF;
 $color-red: #b94a48;
 $color-grey: #4F5253;
+$color-grey-darkest: #222;
+$color-grey-darker: #333;
+$color-grey-light: #777;
+$color-grey-lighter: #999;
+$color-blue: #337ab7;
 $color-muted: #CCC;
 
-// Text colors
-$color-text-white: $color-white;
+/*
+  Variables to define look and feel
+*/
+// Backgrounds
+$color-primary-background: $color-grey;
+$color-seccondary-background: $color-white;
+$color-muted-background: $color-muted;
+$color-navbar-background: $color-grey-darkest;
+$color-navbar-background-active: darken($color-navbar-background, 10%) ;
+$color-footer-background: $color-navbar-background;
+$color-tooltip-background: $color-primary-background;
+$color-icon-bar-background: $color-white;
+
+// Text
+$color-primary-text: $color-white;
+$color-seccondary-text: $color-grey;
+$color-heading-text: $color-black;
+$color-navbar-text: $color-grey-light;
+$color-navbar-text-hover: $color-white;
+$color-navbar-text-disabled: $color-grey-darker;
+$color-link-text: $color-blue;
+$color-navbar-link-text: lighten($color-navbar-text, 15%);
+$color-org-navbar-links: $color-grey-light;
+$color-org-navbar-links-hover: $color-grey-darker;
+$color-dropdown-inverse-text: $color-grey-lighter;
+$color-dropdown-inverse-text-hover: $color-white;
+// $color-footer-links:;
+// $color-footer-links-hover:;
+// $color-tooltip-text:;
 $color-text-red: $color-red;
 $color-text-grey: $color-grey;
 $color-text-black: $color-black;
 
-// Background colors
-$color-background-white: $color-white;
-$color-background-grey: $color-grey;
-$color-background-black: $color-black;
-$color-background-muted: $color-muted;
-
-
 // Borders colors
 $color-border-default: $color-grey;
 $color-border-light: #ddd;
+$color-dropdown-inverse-border: #080808;
+$color-navbar-border: darken($color-navbar-background, 10%);
 
 // Shadow colors
 $color-shadow-dark: $color-black;
 
-// Tooltips
-$tooltip-color: $color-white;
-$tooltip-background: $color-text-grey;
-
-$dropdown-inverse-bg: #222222;
-$dropdown-inverse-border: #080808;
-
-// Navbar branding colours
-
-$navbar-branding-color: #777777 !default;
-$navbar-branding-bg: #222 !default;
-$navbar-branding-border: darken($navbar-branding-bg, 10%) !default;
-$navbar-branding-link-color: lighten(#777777, 15%) !default;
-$navbar-branding-link-hover-color: #fff !default;
-$navbar-branding-link-hover-bg: transparent !default;
-$navbar-branding-link-active-color: $navbar-branding-link-hover-color !default;
-$navbar-branding-link-active-bg: darken($navbar-branding-bg, 10%) !default;
-$navbar-branding-link-disabled-color: #444 !default;
-$navbar-branding-link-disabled-bg: transparent !default;
-$navbar-branding-brand-color: $navbar-branding-link-color !default;
-$navbar-branding-brand-hover-color: #FFFFFF !default;
-$navbar-branding-brand-hover-bg: transparent !default;
-$navbar-branding-toggle-hover-bg: #333 !default;
-$navbar-branding-toggle-icon-bar-bg: #fff !default;
-$navbar-branding-toggle-border-color: #333 !default;
+// FontAwesome Colors
+$color-fa: $color-grey;


### PR DESCRIPTION
A first pass at making the new CSS organisation friendlier to ajdust to branding.

I refactored the bootstrap overrides out of colors and into _bootstrap.
I removed references to the base css color text/background and attempted to group thest into categories.  

This should make it easier for us and our collaborators to re-brand their sites after the refactor, with the goal being to limit branding changes to just the _colors.scss.

@briri, let me know your thoughts on the approach