### PR TITLE
Patch issue with share plans on development

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   # Look for template overrides before rendering
   before_filter :prepend_view_paths
 
@@ -169,4 +171,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:accept_invitation, keys: [:firstname, :surname, :org_id])
+  end
 end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -30,7 +30,11 @@ class RolesController < ApplicationController
         else
           if user.nil?
             registered = false
-            User.invite!({ email: params[:user] }, current_user)
+            User.invite!({email:     params[:user],
+                        firstname:  _("First Name"),
+                        surname:    _("Surname"),
+                        org:        current_user.org },
+                        current_user )
             message = _("Invitation to %{email} issued successfully.") % {
               email: params[:user]
             }

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -11,7 +11,6 @@
     <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: {method: :put, id: "invitation_create_account_form"} do |f| %>
       <%= devise_error_messages! %>
       <%= f.hidden_field :invitation_token %>
-
       <div class="form-group">
         <%= f.label(:password, _('New password'), class: 'control-label') %>
         <%= f.password_field(:password, class: 'form-control', "aria-required": true) %>
@@ -20,9 +19,18 @@
         <%= f.label(:password_confirmation, _('Password confirmation'), class: 'control-label') %>
         <%= f.password_field(:password_confirmation, class: 'form-control', "aria-required": true) %>
       </div>
-
+      <div class="form-group">
+        <%= f.label(:firstname, _('First name'), class: 'control-label') %>
+        <%= f.text_field(:firstname, class: "form-control", "aria-required": true, value: @user.firstname) %>
+      </div>
+      <div class="form-group">
+        <%= f.label(:surname, _('Last name'), class: 'control-label') %>
+        <%= f.text_field(:surname, class: "form-control", "aria-required": true, value: @user.surname) %>
+      </div>
+      <div class="form-group" id="org-controls">
+        <%= render partial: "shared/my_org", locals: {f: f, default_org: @user.org, orgs: Org.all, allow_other_orgs: true, required: true} %>
+      </div>
       <%= f.button(_('Create account'), class: "btn btn-default", type: "submit") %>
     <% end %>
   </div>
 </div>
-

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -30,7 +30,7 @@
   </p>
   <p>
     <%= _('Please do not reply to this email.') %>&nbsp;
-    <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us}') % {
+    <%= sanitize(_('If you have any questions or need help, please contact us at %{helpdesk_email} or visit %{contact_us_url}') % {
       helpdesk_email: mail_to(helpdesk_email, helpdesk_email,
       subject: email_subject),
       contact_us_url: link_to(contact_us, contact_us)


### PR DESCRIPTION
Devise circumvents running validations on the user models when invite! is called.
I updated this call to adhere to validations(by passing a hash of options), and I've updated the form to which they are directed to request the name/org of the user when a plan is shared with them.
This should fix the issue for both newly created share-plan users, and those with previous, bad data in the system.

You may want to consider re-running your validations(or fixup) scripts for users as you can have some invalid ones that you'll need to set a default name/org.  and we'll want to add that to the notes for the next release.