### PR TITLE
Further changes for Text field should be mandatory for option based q…

### DIFF
--- a/app/assets/stylesheets/variables/_bold.scss
+++ b/app/assets/stylesheets/variables/_bold.scss
@@ -1,0 +1,3 @@
+.bold {
+  font-weight: bold;
+}

--- a/app/models/concerns/validation_messages.rb
+++ b/app/models/concerns/validation_messages.rb
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
+
 module ValidationMessages
-  # frozen_string_literal: true
 
   PRESENCE_MESSAGE = _("can't be blank")
 
   UNIQUENESS_MESSAGE = _("must be unique")
 
   INCLUSION_MESSAGE = _("isn't a valid value")
-  
-  OPTION_PRESENCE_MESSAGE = _("You must have at least one option.")
+
+  OPTION_PRESENCE_MESSAGE = _("You must have at least one option with accompanying text.")
 
   QUESTION_TEXT_PRESENCE_MESSAGE = _("for 'Question text' can't be blank.")
 

--- a/app/views/org_admin/question_options/_option_fields.html.erb
+++ b/app/views/org_admin/question_options/_option_fields.html.erb
@@ -1,11 +1,11 @@
 <div class="row">
-  <div class="col-md-3">
+  <div class="col-md-3 bold">
     <%= _('Order')%>
   </div>
   <div class="col-md-3">
-    <%= _('Text')%>
+    <%= f.label(:text, _('Text'), class: "control-label") %>
   </div>
-  <div class="col-md-3">
+  <div class="col-md-3 bold">
     <%= _('Default')%>
   </div>
   <div class="col-md-3">
@@ -24,7 +24,11 @@
         <%= op.number_field :number, min: 1, class: 'form-control' %>
       </div>
       <div class="col-md-3">
-        <%= op.text_field :text, as: :string, class: 'form-control' %>
+        <% if i == 1 %>
+          <%= op.text_field :text, as: :string, class: 'form-control', 'aria-required': true %>
+        <% else %>
+          <%= op.text_field :text, as: :string, class: 'form-control' %>
+        <% end %>
       </div>
       <div class="col-md-3">
         <%= op.check_box :is_default %>

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,5 +1,6 @@
-# frozen_string_literal: true.
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe Question, type: :model do
 
@@ -59,7 +60,7 @@ RSpec.describe Question, type: :model do
   describe "#to_s" do
 
     before do
-      subject.text = 'foo bar'
+      subject.text = "foo bar"
     end
 
     it "returns the Question's text" do
@@ -88,7 +89,9 @@ RSpec.describe Question, type: :model do
       it {
         expect {
           create(:question, question_format: question_format, options: 0)
-        }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: You must have at least one option.")
+        }.to raise_error(ActiveRecord::RecordInvalid,
+         "Validation failed: You must have at least one option with accompanying text."
+        )
       }
 
       it { is_expected.to eql(true) }
@@ -107,13 +110,13 @@ RSpec.describe Question, type: :model do
 
   describe "#deep_copy" do
 
-    let!(:question) { create(:question, {
+    let!(:question) { create(:question,
       default_value: "foo bar",
       modifiable: true,
       number: 12,
       option_comment_display: false,
       text: "How many foos can bar?",
-    }) }
+    ) }
 
     let!(:options) { Hash.new }
 


### PR DESCRIPTION
…uestions.

Fix for issue #1725

The question_options field on the Customisable Phase template has the
following changes:
- the 'Text' label has the asterick for required.
- the error message for missing question option now reads
 "You must have at least one option with accompanying text."
- Corrected some Rubocop errors on the files added.
