### PR TITLE
issue/2014: Issues Preventing Shiboleth account creation or linking from the homescreen

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,9 +24,6 @@ class SessionsController < Devise::SessionsController
           success = _("Your account has been successfully linked to your institutional credentials. You will now be able to sign in with them.")
           # rubocop:enable LineLength
         end
-        existing_user.update_attributes(
-          shibboleth_id: session["devise.shibboleth_data"][:uid]
-        )
       end
       unless existing_user.get_locale.nil?
         session[:locale] = existing_user.get_locale

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -39,10 +39,12 @@
           <p class="text-center">
             <%= _("This will create an account and link it to your credentials.") %>
           </p>
-          <p>
-            <%= render partial: 'shared/create_account_form', locals: {extended: false} %>
-            <br>
-          </p>
+          <div id="create-account-form">
+            <p >
+              <%= render partial: 'shared/create_account_form' %>
+              <br>
+            </p>
+          </div>
         </div>
     <% else %>
       <div>
@@ -50,7 +52,9 @@
           <%= _("Create account") %>&nbsp;&nbsp;
           <i class="fa fa-user-plus" aria-hidden="true">&nbsp;&nbsp;</i>
         </h2>
-        <%= render partial: 'shared/create_account_form', locals: { extended: true } %>
+        <div id="create-account-form">
+          <%= render partial: 'shared/create_account_form' %>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
updated sessions controller to no longer set shibboleth_id field on user account, changed devise registrations/new so the js could find the create-account-form.
