### PR TITLE
added logic to hide guidance selection if there is no selectable guid…

### DIFF
--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -151,48 +151,58 @@
     </div>
     <div class="col-md-4">
       <h2><%= _('Select Guidance') %></h2>
-      <p><%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations.') %
-          {application_name: Rails.configuration.branding[:application][:name]} %>
-          </p>
-      <fieldset>
-        <p><%= _('Select up to 6 organisations to see their guidance.') %></p>
-        <ul id="priority-guidance-orgs">
-          <%= render partial: "guidance_choices",
-                        locals: {choices: @important_ggs, form: f,
-                                 current_selections: @selected_guidance_groups} %>
-        </ul>
-      </fieldset>
-      <p><%= _('Find guidance from additional organisations below') %></p>
-      <%= link_to _('See the full list'), '#', 'data-toggle' =>  'modal', 'data-target' => '#modal-full-guidances', class: 'modal-guidances-window' %>
 
-      <br>
-      <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
+      <% if @all_guidance_groups.length > 0 %>
+        <p><%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations.') %
+            {application_name: Rails.configuration.branding[:application][:name]} %>
+            </p>
+        <fieldset>
+          <p><%= _('Select up to 6 organisations to see their guidance.') %></p>
+          <ul id="priority-guidance-orgs">
+            <%= render partial: "guidance_choices",
+                          locals: {choices: @important_ggs, form: f,
+                                   current_selections: @selected_guidance_groups} %>
+          </ul>
+        </fieldset>
+
+        <% if @all_guidance_groups.length > @important_ggs.length %>
+          <p><%= _('Find guidance from additional organisations below') %></p>
+          <%= link_to _('See the full list'), '#', 'data-toggle' =>  'modal', 'data-target' => '#modal-full-guidances', class: 'modal-guidances-window' %>
+        <% end %>
+        <br>
+        <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
+
+      <% else %>
+        <p><%= _("There is no additional guidance for this template.") %></p>
+      <% end %>
     </div>
 
-    <div id="modal-full-guidances" class="modal fade" tabindex="-1" role="dialog">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="sign-in">
-            <div class="modal-body">
-              <button type="button" class="close pull-right" data-dismiss="modal" aria-label="<%= _('Cancel') %>">
-                <span class="fa fa-times" aria-hidden="true">&nbsp;</span>
-              </button>
-              <h2><%= _('Select Guidance') %></h2>
-              <p>
-                <%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations. Please choose up to 6 organisations of the following organisations who offer guidance relevant to your plan.') %
-                {application_name: Rails.configuration.branding[:application][:name]} %>
-              </p>
-              <p><strong><%= _("Don't forget to save your changes after making your selections.") %></strong></p>
-              <ul id="other-guidance-orgs">
-                <%= render partial: "guidance_choices",
-                           locals: {choices: @all_ggs_grouped_by_org, form: f,
-                                     current_selections: @selected_guidance_groups} %>
-              </ul>
+    <% if @all_guidance_groups.length > @important_ggs.length %>
+      <div id="modal-full-guidances" class="modal fade" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="sign-in">
+              <div class="modal-body">
+                <button type="button" class="close pull-right" data-dismiss="modal" aria-label="<%= _('Cancel') %>">
+                  <span class="fa fa-times" aria-hidden="true">&nbsp;</span>
+                </button>
+                <h2><%= _('Select Guidance') %></h2>
+                <p>
+                  <%= _('To help you write your plan, %{application_name} can show you guidance from a variety of organisations. Please choose up to 6 organisations of the following organisations who offer guidance relevant to your plan.') %
+                  {application_name: Rails.configuration.branding[:application][:name]} %>
+                </p>
+                <p><strong><%= _("Don't forget to save your changes after making your selections.") %></strong></p>
+                <ul id="other-guidance-orgs">
+                  <%= render partial: "guidance_choices",
+                             locals: {choices: @all_ggs_grouped_by_org, form: f,
+                                       current_selections: @selected_guidance_groups} %>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    <% end %>
 
   <% end %>
 </div>


### PR DESCRIPTION
Added a checks to hide/display the guidance selection options on the plan details page depending on whether or not there are any applicable themed guidance associated with the plan's template and if there are only display the 'full list' link if it makes sense