### PR TITLE
Display issue (cropped answers & whitespace) when reviewing DMPs when…

### DIFF
--- a/app/views/answers/_new_edit.html.erb
+++ b/app/views/answers/_new_edit.html.erb
@@ -59,7 +59,7 @@
     <% elsif question.question_format.textfield?%>
         <%= render(partial: 'questions/new_edit_question_textfield', locals: { f: f, question: question, answer: answer }) %>
     <% elsif question.question_format.textarea? %>
-        <%= render(partial: 'questions/new_edit_question_textarea', locals: { f: f, question: question, answer: answer, locking: locking }) %>
+        <%= render(partial: 'questions/new_edit_question_textarea', locals: { f: f, question: question, answer: answer, locking: locking, readonly: readonly}) %>
     <% end %>
     <%= f.button(_('Save'), class: "btn btn-default", type: "submit") %>
   </fieldset>

--- a/app/views/questions/_new_edit_question_textarea.html.erb
+++ b/app/views/questions/_new_edit_question_textarea.html.erb
@@ -9,7 +9,7 @@
 %>
 <div class="form-group">
     <%= f.label(:text, sanitize(question.text), class: 'control-label') %>
-    <% if locking %>
+    <% if locking || readonly %>
       <%= sanitize("<p>#{answer.text || question.default_value}</p>") %>
     <% else %>
       <%= text_area_tag('answer[text]', answer.text || question.default_value, id: "answer-text-#{question.id}", class: "form-control tinymce_answer") %>


### PR DESCRIPTION

… answers in

readonly mode.

Fixes issue #1683.

When the review mode is readonly, then we display the answer in in a paragraphs.

(Could not replicate whitespace issue to test if this fixes it too. But will continue to look at it.)
Before change 
![selection_097](https://user-images.githubusercontent.com/8876215/50011843-0736de80-ffb5-11e8-9d71-d0a7b04e6779.png)
After change
![selection_096](https://user-images.githubusercontent.com/8876215/50011960-46fdc600-ffb5-11e8-82d8-31c4d35f54cd.png)
