### PR TITLE
Update the text of the Comment notification email.

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -43,7 +43,7 @@ class NotesController < ApplicationController
       plan = answer.plan
       owner = plan.owner
       deliver_if(recipients: owner, key: "users.new_comment") do |r|
-        UserMailer.new_comment(current_user, plan).deliver_now()
+        UserMailer.new_comment(current_user, plan, answer).deliver_now()
       end
       @notice = success_message(@note, _("created"))
       render(json: {

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -111,12 +111,14 @@ class UserMailer < ActionMailer::Base
 
   # commenter - User who wrote the comment
   # plan      - Plan for which the comment is associated to
-  def new_comment(commenter, plan)
+  # answer - Answer commented on
+  def new_comment(commenter, plan, answer)
     if commenter.is_a?(User) && plan.is_a?(Plan)
       owner = plan.owner
       if owner.present? && owner.active?
         @commenter = commenter
         @plan = plan
+        @answer = answer
         FastGettext.with_locale FastGettext.default_locale do
           mail(to: plan.owner.email, subject:
             _('%{tool_name}: A new comment was added to %{plan_title}') %{ :tool_name => Rails.configuration.branding[:application][:name], :plan_title => plan.title })

--- a/app/views/user_mailer/new_comment.html.erb
+++ b/app/views/user_mailer/new_comment.html.erb
@@ -3,15 +3,42 @@
   commenter_name = @commenter.name
   plan_title = @plan.title
   user_name = @plan.owner.name
+  question = @answer.question
+  question_number = question.number
+  question_text = question.text
+  section_title = question.section.title
+  phase_id = question.section.phase.id
+  phase_link = url_for(action: 'edit', controller: 'plans', id: @plan.id, phase_id: phase_id)
+  comment_number = @answer.notes.size
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>
     <%= _('Hello %{user_name}') %{ :user_name => user_name } %>
   </p>
   <p>
-    <%= _('%{commenter_name} has commented on the plan %{plan_title}. To view the comments, '\
-    'please visit the My Dashboard page in %{tool_name} and open your plan.') %{ :plan_title => plan_title,
-    :commenter_name => commenter_name, :tool_name => tool_name } %>
+    <%= _('%{commenter_name} has commented on the plan %{plan_title}. To view the comment, '\
+    'either follow the phase link below, or navigate to the plan via the My Dashboard page in %{tool_name}. ') \
+    %{ :commenter_name => commenter_name, :plan_title => plan_title, :tool_name => tool_name } %>
   </p>
+  <p>
+    <%=  _('Once there, follow the phase, section, question and comment number to navigate to the comment.') %>
+  </p>
+  <p>
+    <%= _('Phase link: %{phase_link}') %{ :phase_link => phase_link }  %>
+  </p>
+  <p>
+    <%# Added @plan.phases.size > 1 ? question.section.phase.title : _('Write Plan') so translation of 'Write Plan' may be picked up. %>
+    <%= _('Phase: %{phase_title}') %{ :phase_title => @plan.phases.size > 1 ? question.section.phase.title : _('Write Plan') }  %>
+  </p>
+  <p>
+    <%= _('Section: %{section_title}') %{ :section_title => section_title } %>
+  </p>
+  <p>
+    <%= _('Question: %{question_number}. %{question_text}') %{ :question_number => question_number, :question_text => question_text } %>
+  </p>
+  <p>
+    <%= _('Comment Number: %{comment_number}') %{ :comment_number => comment_number } %>
+  </p>
+
   <%= render partial: 'email_signature' %>
 <% end %>


### PR DESCRIPTION
Fix for issue #1872.
Example emails:

Plan with several phases:
![comment-email-01](https://user-images.githubusercontent.com/8876215/51385607-aea8b300-1b17-11e9-9ffd-d6ee18a5935a.png)
Plan with only one phase:
![comment-email-02](https://user-images.githubusercontent.com/8876215/51385634-bcf6cf00-1b17-11e9-85a8-ce9793571eda.png)


