### PR TITLE
IssueID #1893 - Fix for export of plans in docx format.

### DIFF
--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -33,12 +33,9 @@
             <% section[:questions].each do |question| %>
               <div class="question">
                 <% if !@public_plan && @show_sections_questions%>
-                  <%# Hack: for DOCX export - otherwise, bold highlightin of question inconsistent. %>
+                  <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
                   <% if local_assigns[:export_format] && export_format == 'docx' %>
-                    <% question_text = question[:text].to_s %>
-                    <% question_text = question_text.gsub('<p>', '<p><strong>'); %>
-                    <% question_text = question_text.gsub('</p>', '</strong></p>'); %>
-                    <strong><%=  sanitize question_text, scrubber: TableFreeScrubber.new %></strong>
+                    <strong><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></strong>
                   <% else %>
                     <div class="bold"><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>
                   <% end %>


### PR DESCRIPTION
The change 5538309ddd4b1c2bcd833debc4261beece420f20 broke the docx export.
We no longer alter the question[:text].to_s before it it is sanitized in _Plan.erb. Adding surrounding the sanitized question[:text].to_s with <strong> tags
ensures the questions are highlighted bold.

Fix for #1893.
