### PR TITLE
The "Request expert feedback" text area on the Share Plan page displayed

### DIFF
--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -1,18 +1,24 @@
+# frozen_string_literal: true
+
 module FeedbacksHelper
+
   def feedback_confirmation_default_subject
-    _('%{application_name}: Your plan has been submitted for feedback')
+    _("%{application_name}: Your plan has been submitted for feedback")
   end
 
   def feedback_confirmation_default_message
-    _('<p>Hello %{user_name}.</p>'\
-            '<p>Your plan "%{plan_name}" has been submitted for feedback from an administrator at your organisation. '\
-            'If you have questions pertaining to this action, please contact us at %{organisation_email}.</p>')
+    _("<p>Hello %{user_name}.</p>"\
+      "<p>Your plan \"%{plan_name}\" has been submitted for feedback from an
+      administrator at your organisation. "\
+      "If you have questions pertaining to this action, please contact us
+      at %{organisation_email}.</p>")
   end
 
   def feedback_constant_to_text(text, user, plan, org)
-    _("#{text}") % {application_name: Rails.configuration.branding[:application][:name],
-                    user_name: user.name,
+    _("#{text}") % { application_name: Rails.configuration.branding[:application][:name],
+                    user_name: user.name(false),
                     plan_name: plan.title,
-                    organisation_email: org.contact_email}
+                    organisation_email: org.contact_email }
   end
+
 end

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -128,7 +128,7 @@
       <h2><%= _('Request expert feedback') %></h2>
       <p><%= _('Click below to give data management staff at your organisation access to read and comment on your plan.') %></p>
       <div class="well well-sm">
-        <%= sanitize current_user.org.feedback_email_msg.to_s %>
+        <%= sanitize current_user.org.feedback_email_msg.to_s % { user_name: current_user.name(false), plan_name: plan.title } %>
       </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
 


### PR DESCRIPTION

![selection_119](https://user-images.githubusercontent.com/8876215/52580600-9ed37480-2e20-11e9-8945-3a4d27985f01.png)
Ruby strings  %{user_name} and %{plan_name} that were not interpolated.

- The strings are now interpolated.
- The function helper function feedback_constant_to_text in FeedbacksHelper
 displays the user name instead of the email.
- also Rubocop errors and warnings in FeedbacksHelper were fixed.

Fix for issue #2047.
![selection_120](https://user-images.githubusercontent.com/8876215/52580571-8d8a6800-2e20-11e9-8c2d-85442baa0cfb.png)

