### PR TITLE
Fix for ensuring that the Edit Request Feedback form disallows saving…

### DIFF
--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -2,18 +2,18 @@
 
 module OrgsHelper
 
-  DEFAULT_EMAIL = '%{organisation_email}'
+  EMAIL_PLACEHOLDER = "[Organisation Contact Email Placeholder]"
 
-  # Tooltip string for Org feedback form.
+  # Sample message for Org feedback form.
   #
   # org - The current Org we're updating feedback form for.
   #
   # Returns String
-  def tooltip_for_org_feedback_form(org)
-    email = org.contact_email.presence || DEFAULT_EMAIL
-    _("SAMPLE MESSAGE: A data librarian from %{org_name} will respond to your request within 48
+  def sample_message_for_org_feedback_form(org)
+    email = org.contact_email || EMAIL_PLACEHOLDER
+    _("<p>A data librarian from %{org_name} will respond to your request within 48
        hours. If you have questions pertaining to this action please contact us
-       at %{organisation_email}.") % {
+       at %{organisation_email}.</p>") % {
       organisation_email: email,
       org_name: org.name
     }
@@ -22,7 +22,7 @@ module OrgsHelper
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return
   # the remote_url, otherwise return the url
   def logo_url_for_org(org)
-    if ENV['DRAGONFLY_AWS'] == "true"
+    if ENV["DRAGONFLY_AWS"] == "true"
       org.logo.remote_url
     else
       org.logo.url

--- a/app/views/orgs/_feedback_form.html.erb
+++ b/app/views/orgs/_feedback_form.html.erb
@@ -18,10 +18,14 @@
       <%= _('Request Expert Feedback - Message Displayed on Share Plan Tab:') %>
     </h3>
     <div class="row">
-      <div class="form-group col-xs-8" data-toggle="tooltip" data-html="true" title="<%= tooltip_for_org_feedback_form(org) %>">
+      <div class="form-group col-xs-8" data-html="true">
         <%= f.label :feedback_email_msg, _('Message'), class: "control-label" %>
         <%= f.text_area :feedback_email_msg, class: "form-control",
                         "aria-required" => true %>
+      </div>
+      <div class="form-group col-xs-4">
+        <h4><%= _('Sample Message') %></h4>
+        <%= sanitize sample_message_for_org_feedback_form(org) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
… in the case where feedback is checked but no

mandatory message provided.

Fix for #1743.

(Note: I have not tried to make the sample message the default message, as doing so resulted in it being saved. @sjDCC asked if this would be possible but did not require it.)