### PR TITLE
Added the missing information in CSV export plans.

### DIFF
--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -148,9 +148,12 @@ module ExportablePlan
       if answer.present? || (answer.blank? && unanswered)
         answer_text = answer.present? ? answer.text :
                       (unanswered ? _("Not Answered") : "")
-        if answer.present? && answer.question_options.any?
-          answer_text = answer.question_options.pluck(:text).join(", ")
+
+        if answer.present? && answer.is_valid? && answer.question_options.any?
+          # Prepend answer_text with question_options and line-breaks.
+          answer_text = answer.question_options.pluck(:text).join(", ") + "\n\n" + answer_text
         end
+
       end
       flds = (hash[:phases].many? ? [phase[:title]] : [])
       if headings


### PR DESCRIPTION
The answers with question options was not including the answer.text, but overwriting the variable answer_text that held the value.

Fix for Issue #2058.

Not able to replicate "    2\. Line breaks in freetext boxes are being represented as semi-colons" so can't fix it.