### PR TITLE
Do not show "expand/collapse" all links if there is only one themed g…

### DIFF
--- a/app/views/guidance_groups/_index_by_theme.html.erb
+++ b/app/views/guidance_groups/_index_by_theme.html.erb
@@ -1,15 +1,18 @@
 <%# locals{ guidance_groups_by_theme } %>
 <% parent_id = guidance_groups_by_theme.object_id %>
 <div id="<%= parent_id %>" class="panel-group" role="tablist" aria-multiselectable="true">
-  <div id="guidance-accordion-controls">
-    <div class="accordion-controls" data-parent="<%= parent_id %>">
-      <a href="#" data-toggle-direction="show"><%= _('expand all') %></a>
-        <span>|</span>
-      <a href="#" data-toggle-direction="hide"><%= _('collapse all') %></a>
-    </div>
-  </div>
   <% guidance_groups_by_theme.each_pair do |guidance_group, theme_hash| %>
     <% guidances_output = [] %>
+    <%# Do not show expand/collapse all links if there is only one item in theme_hash %>
+    <% if theme_hash.length > 1 %>
+    <div id="guidance-accordion-controls">
+      <div class="accordion-controls" data-parent="<%= parent_id %>">
+        <a href="#" data-toggle-direction="show"><%= _('expand all') %></a>
+          <span>|</span>
+        <a href="#" data-toggle-direction="hide"><%= _('collapse all') %></a>
+      </div>
+    </div>
+    <% end %>
     <% theme_hash.each_pair do |theme, guidances| %>
       <% question_guidance_id = "#{question.object_id}-#{guidances.object_id}" %>
       <%# if guidances with this theme have not been output %>


### PR DESCRIPTION
…uidance for the question on the Edit Plan page.

We now do a check before adding the "expand/collapse all" links.

Fix for Issue #2049.
![removed_expand_collapse_link_for_one_themed_guidance](https://user-images.githubusercontent.com/8876215/53885407-8e747b00-4015-11e9-8768-6658a9c2d000.png)

