### PR TITLE
Notification Preferences for checkbox for "A new comment has been add…

### DIFF
--- a/config/branding.yml.sample
+++ b/config/branding.yml.sample
@@ -44,7 +44,7 @@ defaults: &defaults
   preferences:
     email:
       users:
-        new_comment: true
+        new_comment: false
         admin_privileges: true
         added_as_coowner: true
         feedback_requested: true


### PR DESCRIPTION
…ed to my DMP" is unticked for new users to the system:

 - The branding.yml will need to be altered to set the following item to false:
        preferences:
          email:
            users:
              new_comment: false

Fix for issue #2059 

This fix is basically a branding.yml change that will need to be done on deploy.

