### PR TITLE
Fix bug in FastGettext initializer

### DIFF
--- a/config/initializers/fast_gettext.rb
+++ b/config/initializers/fast_gettext.rb
@@ -22,7 +22,7 @@ else
 end
 
 FastGettext.add_text_domain("app",
-  path: "config/locale",
+  path: Rails.root.join("config/locale"),
   type: :po,
   ignore_fuzzy: true,
   report_warning: false,


### PR DESCRIPTION
Updated FastGettext initialiser to use absolute path instead of relative path.