### PR TITLE
Restyled Usage page:

### DIFF
--- a/app/javascript/views/usage/index.js
+++ b/app/javascript/views/usage/index.js
@@ -25,6 +25,27 @@ $(() => {
 
     return rangeDates;
   };
+
+  // Register a plugin for displaying a message for no data
+  Chart.plugins.register({
+    afterDraw: (chart) => {
+      if (chart.data.datasets.length === 0) {
+        const { ctx, width, height } = {
+          ctx: chart.chart.ctx,
+          width: chart.chart.width,
+          height: chart.chart.height,
+        };
+        chart.clear();
+        ctx.save();
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.font = '25px bold';
+        ctx.fillText('No data to display for selected time period', width / 2, height / 2);
+        ctx.restore();
+      }
+    },
+  });
+
   const createChart = ({ selector, data, appendTolabel = '' } = {}) => {
     new Chart($(selector), { // eslint-disable-line no-new
       type: 'bar',

--- a/app/views/usage/index.html.erb
+++ b/app/views/usage/index.html.erb
@@ -29,7 +29,7 @@
 </div>
 <div class="row">
   <div class="col-md-12">
-    <h3><%= _('Run your own filter') %></h3>
+    <h3 class="bold"><%= _('Run your own filter') %></h3>
     <% if current_user.api_token.present? %>
       <form class="usage_index">
         <%= hidden_field_tag('api_token', current_user.api_token) %>
@@ -108,7 +108,7 @@
 <div class="row">
   <div class="col-md-6">
     <div class="pull-left">
-      <h4><%= _('No. users joined during last year') %></h4>
+      <h4 class="bold"><%= _('No. users joined during last year') %></h4>
     </div>
     <div class="pull-right">
       <button type="button" class="stat btn btn-default" data-url="<%= users_joined_api_v0_statistics_path(format: :csv) %>">
@@ -121,7 +121,7 @@
   </div>
   <div class="col-md-6">
     <div class="pull-left">
-      <h4><%= _('No. plans during last year') %></h4>
+      <h4 class="bold"><%= _('No. plans during last year') %></h4>
     </div>
     <div class="pull-right">
       <button type="button" class="stat btn btn-default" data-url="<%= created_plans_api_v0_statistics_path(format: :csv) %>">
@@ -132,12 +132,21 @@
     <p class="alert alert-info" style="display: none;"><%= _('There is no data available for plans yet.') %></p>
     <canvas id="yearly_plans"></canvas>
   </div>
+</div>
+<div class="row">
   <div class="col-md-12">
-    <div class="pull-left">
-      <h4><%= _('No. plans by template') %></h4>
-    </div>
-    <div class="row">
-      <div class="col-md-12">
+    <hr>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+      <div class="col-md-6">
+        <div class="pull-left">
+          <h4 class="bold"><%= _('No. plans by template') %></h4>
+          <p class="red">&#42;&nbsp;<%= _('Mouse over the bars of the chart for data for each month.') %></p>
+        </div>
+      </div>
+      <div class="col-md-6">
         <div class="pull-right"">
           <ul class="list-inline">
             <li>
@@ -161,10 +170,11 @@
             </li>
           </ul>
         </div>
-        <div class="col-md-12" style="position: relative; width: 100%; height: 100%">
-          <canvas id="monthly_plans_by_template_canvas"></canvas>
-        </div>
       </div>
     </div>
   </div>
-</div>
+  <div class="row">
+      <div class="col-md-12" style="position: relative; width: 100%; height: 100%">
+         <canvas id="monthly_plans_by_template_canvas"></canvas>
+      </div>
+  </div>


### PR DESCRIPTION
 - The 'No. of plans by template" section restyled
 - Added instruction to 'No. of plans by template'
 - Added a message for 'No. of plans by template' chart if
 no data available for a chosen time period.

Fix for changes requested in issue #1679.

Screen shots of visual changes
![Selection_180](https://user-images.githubusercontent.com/8876215/55631287-990a6780-57af-11e9-9304-27979e335b0c.png)
![Selection_181](https://user-images.githubusercontent.com/8876215/55631286-9871d100-57af-11e9-899a-7e7517b23325.png)


