### PR TITLE
 Updated Usage page display to fix several issues.

### DIFF
--- a/app/controllers/api/v0/statistics_controller.rb
+++ b/app/controllers/api/v0/statistics_controller.rb
@@ -28,6 +28,9 @@ class Api::V0::StatisticsController < Api::V0::BaseController
         r[k] = scoped.where(created_at: dates_to_range(v)).count
       end
 
+      # Reverse hash r, so dates in ascending order
+      r = Hash[r.to_a.reverse]
+
       respond_to do |format|
         format.json { render(json: r.to_json) }
         format.csv {
@@ -66,6 +69,9 @@ class Api::V0::StatisticsController < Api::V0::BaseController
         r[k] = scoped.where(created_at: dates_to_range(v)).count
       end
 
+      # Reverse hash r, so dates in ascending order
+      r = Hash[r.to_a.reverse]
+
       respond_to do |format|
         format.json { render(json: r.to_json) }
         format.csv {
@@ -103,6 +109,9 @@ class Api::V0::StatisticsController < Api::V0::BaseController
       params[:range_dates].each_pair do |k, v|
         r[k] = scoped.where(created_at: dates_to_range(v)).count
       end
+
+      # Reverse hash r, so dates in ascending order
+      r = Hash[r.to_a.reverse]
 
       respond_to do |format|
         format.json { render(json: r.to_json) }

--- a/app/javascript/views/usage/index.js
+++ b/app/javascript/views/usage/index.js
@@ -192,8 +192,11 @@ $(() => {
         aspectRatio,
         scales: {
           xAxes: [{
-            position: 'top',
             ticks: { beginAtZero: true, stepSize: 10 },
+            stacked: true,
+          }],
+          yAxes: [{
+            stacked: true,
           }],
         },
       },
@@ -203,7 +206,6 @@ $(() => {
 
   const buildData = (data) => {
     const labels = data.map(current => yAxisLabel(current.date));
-
     const datasetsMap = data.reduce((acc, statCreatedPlan) => {
       statCreatedPlan.by_template.forEach((template) => {
         if (!acc[template.name]) {
@@ -213,9 +215,28 @@ $(() => {
       });
       return acc;
     }, {});
-
-    const datasets = Object.keys(datasetsMap).map(key => datasetsMap[key]);
-
+    // const datasets = Object.keys(datasetsMap).map(key => datasetsMap[key]);
+    const compare = (a, b) => {
+      const aIndex = labels.indexOf(a.y);
+      const bIndex = labels.indexOf(b.y);
+      if (aIndex > bIndex) return 1;
+      if (aIndex < bIndex) return -1;
+      return 0;
+    };
+    const datasets = Object.keys(datasetsMap).map((key) => {
+      const datasetByKey = datasetsMap[key];
+      const availableMonths = datasetByKey.data.reduce((acc, value) => {
+        // month has y as key
+        acc.push(value.y);
+        return acc;
+      }, []);
+      // Find missing months in data
+      const missingMonths = labels.filter(month => !availableMonths.includes(month));
+      // Add data for missing months with x value set to 0
+      missingMonths.forEach(month => datasetByKey.data.push({ x: 0, y: month }));
+      datasetByKey.data = datasetByKey.data.sort(compare);
+      return datasetByKey;
+    });
     return { labels, datasets };
   };
 
@@ -246,24 +267,32 @@ $(() => {
       switch (diffInMonths) {
       case 0:
       case 1:
+        aspectRatio = 5;
+        break;
       case 2:
       case 3:
-        aspectRatio = 4;
+        aspectRatio = 3.5;
         break;
       case 4:
       case 5:
-        aspectRatio = 3;
+      case 6:
+        aspectRatio = 2.5;
         break;
       case 7:
       case 8:
       case 9:
+      case 10:
         aspectRatio = 2;
         break;
+      case 11:
+      case 12:
+        aspectRatio = 1.5;
+        break;
       default:
-        aspectRatio = 1;
+        aspectRatio = 0.9;
       }
     } catch (e) {
-      aspectRatio = 1;
+      aspectRatio = 0.9;
     }
 
     return aspectRatio;

--- a/app/views/usage/index.html.erb
+++ b/app/views/usage/index.html.erb
@@ -105,6 +105,13 @@
     <hr />
   </div>
 </div>
+
+<div class="row">
+  <div class="col-md-12">
+    <p class="red">&#42;&nbsp;<%= _('Move the mouse pointer over the bars of a chart to see numbers.') %></p>
+  </div>
+</div>
+
 <div class="row">
   <div class="col-md-6">
     <div class="pull-left">
@@ -143,7 +150,6 @@
       <div class="col-md-6">
         <div class="pull-left">
           <h4 class="bold"><%= _('No. plans by template') %></h4>
-          <p class="red">&#42;&nbsp;<%= _('Mouse over the bars of the chart for data for each month.') %></p>
         </div>
       </div>
       <div class="col-md-6">
@@ -151,13 +157,13 @@
           <ul class="list-inline">
             <li>
               <div class="form-group">
-                <%= label_tag('monthly_plans_by_template', _('Time picker')) %>
+                <%= label_tag('monthly_plans_by_template', _('Time period')) %>
                 <select class="form-control" name="monthly_plans_by_template" data-url="<%= stat_created_plans_by_template_index_path %>">
                   <option value="<%= Date.today.last_month.end_of_month %>"><%= _('Last month') %></option>
-                  <option value="<%= Date.today.months_ago(3).end_of_month %>"><%= _('3 months ago') %></option>
-                  <option value="<%= Date.today.months_ago(6).end_of_month %>"><%= _('6 months ago') %></option>
-                  <option value="<%= Date.today.months_ago(9).end_of_month %>"><%= _('9 months ago') %></option>
-                  <option value="<%= Date.today.months_ago(12).end_of_month %>"><%= _('12 months ago') %></option>
+                  <option value="<%= Date.today.months_ago(3).end_of_month %>"><%= _('Last 3 months') %></option>
+                  <option value="<%= Date.today.months_ago(6).end_of_month %>"><%= _('Last 6 months') %></option>
+                  <option value="<%= Date.today.months_ago(9).end_of_month %>"><%= _('Last 9 months') %></option>
+                  <option value="<%= Date.today.months_ago(12).end_of_month %>"><%= _('Last 12 months') %></option>
                 </select>
               </div>
             </li>


### PR DESCRIPTION
        - Moved mouse pointer instruction.
        - Made textual changes to "No. of plans by template"
        - The bar charts for  "No. users joined during last year" and
        "No. plans during last year" months are in ascending order. They were
        in descending order previously. Updated the count statistics methods
        in statistics_controller.rb.
        - The "No. plans by template" bar chart is now  replaced by a stacked bar chart
        as this is visually better for large data.
        - updated the by_template method in the create_or_update.rb with code from @xsrust.
        This now aggregates template counts for a month correctly.
    
        Fix for issue #1679.


There is an issue with discrepancies in plan numbers between "No. of plans by template" and "No. users joined during last year" which I will raised an issue about this #2083.