### PR TITLE
The content of TinyMCE text area data viewed in readonly mode without…

### DIFF
--- a/app/assets/stylesheets/blocks/_readonly_textarea.scss
+++ b/app/assets/stylesheets/blocks/_readonly_textarea.scss
@@ -1,0 +1,13 @@
+/* For display of readonly textarea content without the TinyMCE editor */
+.display-readonly-textarea-content {
+  // Replicating some TinyMCE styling of textarea
+  overflow-y: hidden;
+  padding-left: 1px;
+  padding-right: 1px;
+  padding-bottom: 10px;
+  
+  // Ensure table borders are not lost
+  table td {
+    border: 1px solid black;
+  }
+}

--- a/app/views/answers/_new_edit.html.erb
+++ b/app/views/answers/_new_edit.html.erb
@@ -74,7 +74,7 @@
             <%="#{annotation.org.abbreviation} "%> <%=_('example answer')%>
           </span>
           <div class="panel-body">
-            <%= sanitize annotation.text %>
+            <div class="display-readonly-textarea-content"><%= sanitize annotation.text %></div>
           </div>
         </div>
       <% end %>

--- a/app/views/questions/_new_edit_question_textarea.html.erb
+++ b/app/views/questions/_new_edit_question_textarea.html.erb
@@ -10,7 +10,9 @@
 <div class="form-group allow-break-words">
     <%= f.label(:text, sanitize(question.text), class: 'control-label') %>
     <% if locking || readonly %>
-      <%= sanitize("<p>#{answer.text || question.default_value}</p>") %>
+      <div class="display-readonly-textarea-content">
+        <%= sanitize("<p>#{answer.text || question.default_value}</p>") %>
+      </div>
     <% else %>
       <%= text_area_tag('answer[text]', answer.text || question.default_value, id: "answer-text-#{question.id}", class: "form-control tinymce_answer") %>
     <% end %>

--- a/spec/services/org/create_last_month_created_plan_service_spec.rb
+++ b/spec/services/org/create_last_month_created_plan_service_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
         described_class.call
 
         last_month_details = StatCreatedPlan.find_by(date: Date.today.last_month.end_of_month, org_id: org.id).details
-        expect(last_month_details).to eq(
+        expect(last_month_details).to match_array(
           {
             'by_template' => [
               { 'name' => template.title, 'count' => 2 },


### PR DESCRIPTION
… thv TinyMCE editor had styling issues.

Added styling from TinyMCE to ensure that the readonly display had a similar overflow in y direction and table borders visible.

Fix for issue #2071.

