### PR TITLE
Added code to make Search functionality case-insensitive.

### DIFF
--- a/app/models/guidance.rb
+++ b/app/models/guidance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Guidance provides information from organisations to Users, helping them when
 # answering questions. (e.g. "Here's how to think about your data
 # protection responsibilities...")
@@ -24,12 +26,15 @@
 
 # [+Project:+] DMPRoadmap
 # [+Description:+]
-#   This class keeps the information organisations enter to support users when answering questions.
-#   It always belongs to a guidance group class and it can be linked directly to a question or through one or more themes
+#   This class keeps the information organisations enter to support users
+#   when answering questions.
+#   It always belongs to a guidance group class and it can be linked directly
+#   to a question or through one or more themes
 # [+Created:+] 07/07/2014
 # [+Copyright:+] Digital Curation Centre and California Digital Library
 
 class Guidance < ActiveRecord::Base
+
   include GlobalHelpers
   include ValidationMessages
   include ValidationValues
@@ -52,7 +57,7 @@ class Guidance < ActiveRecord::Base
   validates :guidance_group, presence: { message: PRESENCE_MESSAGE }
 
   validates :published, inclusion: { message: INCLUSION_MESSAGE,
-                                     in: BOOLEAN_VALUES}
+                                     in: BOOLEAN_VALUES }
 
   validates :themes, presence: { message: PRESENCE_MESSAGE }, if: :published?
 
@@ -64,7 +69,8 @@ class Guidance < ActiveRecord::Base
   scope :search, -> (term) {
     search_pattern = "%#{term}%"
     joins(:guidance_group)
-      .where("guidances.text LIKE ? OR guidance_groups.name LIKE ?",
+      .where("lower(guidances.text) LIKE lower(?) OR " +
+            "lower(guidance_groups.name) LIKE lower(?)",
              search_pattern,
              search_pattern)
   }
@@ -120,10 +126,10 @@ class Guidance < ActiveRecord::Base
   # Returns Array
   def self.all_viewable(user)
     managing_groups = Org.includes(guidance_groups: :guidances)
-                         .managing_orgs.collect{|o| o.guidance_groups}
+                         .managing_orgs.collect { |o| o.guidance_groups }
     # find all groups owned by a Funder organisation
     funder_groups = Org.includes(guidance_groups: :guidances)
-                       .funder.collect{|org| org.guidance_groups}
+                       .funder.collect { |org| org.guidance_groups }
     # find all groups owned by any of the user's organisations
     organisation_groups = user.org.guidance_groups
 
@@ -152,4 +158,5 @@ class Guidance < ActiveRecord::Base
     end
     return false
   end
+
 end

--- a/app/models/guidance_group.rb
+++ b/app/models/guidance_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set of Guidances that pertain to a certain category of Users (e.g. Maths
 # department, vs Biology department)
 #
@@ -23,6 +25,7 @@
 #
 
 class GuidanceGroup < ActiveRecord::Base
+
   include GlobalHelpers
   include ValidationValues
   include ValidationMessages
@@ -62,7 +65,7 @@ class GuidanceGroup < ActiveRecord::Base
 
   scope :search, lambda { |term|
     search_pattern = "%#{term}%"
-    where("name LIKE ?", search_pattern)
+    where("lower(name) LIKE lower(?)", search_pattern)
   }
 
   scope :published, -> { where(published: true) }
@@ -125,4 +128,5 @@ class GuidanceGroup < ActiveRecord::Base
     all_viewable_groups = all_viewable_groups.flatten.uniq
     all_viewable_groups
   end
+
 end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: orgs
@@ -29,6 +31,7 @@
 #
 
 class Org < ActiveRecord::Base
+
   include ValidationMessages
   include ValidationValues
   include FeedbacksHelper
@@ -39,8 +42,10 @@ class Org < ActiveRecord::Base
 
   LOGO_FORMATS = %w[jpeg png gif jpg bmp].freeze
 
-  # Stores links as an JSON object: { org: [{"link":"www.example.com","text":"foo"}, ...] }
-  # The links are validated against custom validator allocated at validators/template_links_validator.rb
+  # Stores links as an JSON object:
+  #  { org: [{"link":"www.example.com","text":"foo"}, ...] }
+  # The links are validated against custom validator allocated at
+  # validators/template_links_validator.rb
   serialize :links, JSON
 
 
@@ -60,7 +65,9 @@ class Org < ActiveRecord::Base
 
   has_many :annotations
 
-  has_and_belongs_to_many :token_permission_types, join_table: "org_token_permissions", unique: true
+  has_and_belongs_to_many :token_permission_types,
+                          join_table: "org_token_permissions",
+                          unique: true
 
   has_many :org_identifiers
 
@@ -81,10 +88,12 @@ class Org < ActiveRecord::Base
 
   validates :language, presence: { message: PRESENCE_MESSAGE }
 
-  validates :contact_name, presence: { message: PRESENCE_MESSAGE, if: :feedback_enabled }
+  validates :contact_name, presence: { message: PRESENCE_MESSAGE,
+                                       if: :feedback_enabled }
 
   validates :contact_email, email: { allow_nil: true },
-                            presence: { message: PRESENCE_MESSAGE, if: :feedback_enabled }
+                            presence: { message: PRESENCE_MESSAGE,
+                                        if: :feedback_enabled }
 
   validates :org_type, presence: { message: PRESENCE_MESSAGE }
 
@@ -98,9 +107,12 @@ class Org < ActiveRecord::Base
                                              if: :feedback_enabled }
 
   validates_property :format, of: :logo, in: LOGO_FORMATS,
-                     message: _("must be one of the following formats: jpeg, jpg, png, gif, bmp")
+                     message: _("must be one of the following formats: " +
+                                "jpeg, jpg, png, gif, bmp")
 
-  validates_size_of :logo, maximum: 500.kilobytes, message: _("can't be larger than 500KB")
+  validates_size_of :logo,
+                    maximum: 500.kilobytes,
+                    message: _("can't be larger than 500KB")
 
   # allow validations for logo upload
   dragonfly_accessor :logo do
@@ -116,7 +128,7 @@ class Org < ActiveRecord::Base
             4 => :research_institute,
             5 => :project,
             6 => :school,
-            column: 'org_type'
+            column: "org_type"
 
   # Predefined queries for retrieving the managain organisation and funders
   scope :managing_orgs, -> do
@@ -125,17 +137,19 @@ class Org < ActiveRecord::Base
 
   scope :search, -> (term) {
     search_pattern = "%#{term}%"
-    where("orgs.name LIKE ? OR orgs.contact_email LIKE ?", search_pattern, search_pattern)
+    where("lower(orgs.name) LIKE lower(?) OR " +
+          "lower(orgs.contact_email) LIKE lower(?)",
+          search_pattern, search_pattern)
   }
 
   # Scope used in several controllers
   scope :with_template_and_user_counts, -> {
-     joins("LEFT OUTER JOIN templates ON orgs.id = templates.org_id")
-       .joins("LEFT OUTER JOIN users ON orgs.id = users.org_id")
-       .group("orgs.id")
-       .select("orgs.*,
-                count(distinct templates.family_id) as template_count,
-                count(users.id) as user_count")
+    joins("LEFT OUTER JOIN templates ON orgs.id = templates.org_id")
+      .joins("LEFT OUTER JOIN users ON orgs.id = users.org_id")
+      .group("orgs.id")
+      .select("orgs.*,
+              count(distinct templates.family_id) as template_count,
+              count(users.id) as user_count")
   }
 
   before_validation :set_default_feedback_email_subject
@@ -174,7 +188,7 @@ class Org < ActiveRecord::Base
     ret << "Research Institute" if self.research_institute?
     ret << "Project" if self.project?
     ret << "School" if self.school?
-    return (ret.length > 0 ? ret.join(', ') : "None")
+    return (ret.length > 0 ? ret.join(", ") : "None")
   end
 
   def funder_only?
@@ -211,7 +225,7 @@ class Org < ActiveRecord::Base
 
   def org_admins
     User.joins(:perms).where("users.org_id = ? AND perms.name IN (?)", self.id,
-      ['grant_permissions', 'modify_templates', 'modify_guidance', 'change_org_details'])
+      ["grant_permissions", "modify_templates", "modify_guidance", "change_org_details"])
   end
 
   def plans
@@ -223,7 +237,8 @@ class Org < ActiveRecord::Base
   end
 
   def grant_api!(token_permission_type)
-    self.token_permission_types << token_permission_type unless self.token_permission_types.include? token_permission_type
+    self.token_permission_types << token_permission_type unless
+      self.token_permission_types.include? token_permission_type
   end
 
   private
@@ -234,7 +249,7 @@ class Org < ActiveRecord::Base
   def resize_image
     unless logo.nil?
       if logo.height != 100
-        self.logo = logo.thumb('x100')  # resize height and maintain aspect ratio
+        self.logo = logo.thumb("x100")  # resize height and maintain aspect ratio
       end
     end
   end
@@ -251,7 +266,7 @@ class Org < ActiveRecord::Base
         # Attempt to locate the file by name. If it exists update the uid
         logo = Dir.glob("#{data_store_path}/**/*#{self.logo_name}")
         if !logo.empty?
-          self.logo_uid = logo.first.gsub(data_store_path, '')
+          self.logo_uid = logo.first.gsub(data_store_path, "")
         else
           # Otherwise the logo is missing so clear it to prevent save failures
           self.logo = nil
@@ -268,11 +283,12 @@ class Org < ActiveRecord::Base
 
   # creates a dfefault Guidance Group on create on the Org
   def create_guidance_group
-    GuidanceGroup.create!({
-      name: abbreviation? ? self.abbreviation : self.name ,
+    GuidanceGroup.create!(
+      name: abbreviation? ? self.abbreviation : self.name,
       org: self,
       optional_subset: false,
       published: false,
-    })
+    )
   end
+
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -189,8 +189,10 @@ class Template < ActiveRecord::Base
   # Retrieves unarchived templates whose title or org.name includes the term
   # passed
   scope :search, lambda { |term|
-    unarchived.joins(:org).where("templates.title LIKE :term OR orgs.name LIKE :term",
-                                 term: "%#{term}%")
+    unarchived.joins(:org)
+              .where("lower(templates.title) LIKE lower(:term) OR " +
+                     "lower(orgs.name) LIKE lower(:term)",
+                     term: "%#{term}%")
   }
 
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: themes
@@ -11,6 +13,7 @@
 #
 
 class Theme < ActiveRecord::Base
+
   include ValidationMessages
 
   # ================
@@ -32,7 +35,8 @@ class Theme < ActiveRecord::Base
 
   scope :search, -> (term) {
     search_pattern = "%#{term}%"
-    where("title LIKE ? OR description LIKE ?", search_pattern, search_pattern)
+    where("lower(title) LIKE lower(?) OR description LIKE lower(?)",
+          search_pattern, search_pattern)
   }
 
   # ===========================
@@ -43,6 +47,7 @@ class Theme < ActiveRecord::Base
   #
   # Returns String
   def to_s
-  	title
+    title
   end
+
 end

--- a/spec/services/org/create_created_plan_service_spec.rb
+++ b/spec/services/org/create_created_plan_service_spec.rb
@@ -1,8 +1,10 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe Org::CreateCreatedPlanService do
   let(:org) do
-    FactoryBot.create(:org, created_at: DateTime.new(2018,04,01))
+    FactoryBot.create(:org, created_at: DateTime.new(2018, 04, 01))
   end
   let(:template) do
     FactoryBot.create(:template, org: org)
@@ -16,136 +18,165 @@ RSpec.describe Org::CreateCreatedPlanService do
   let(:user2) do
     FactoryBot.create(:user, org: org)
   end
-  #let(:creator) { Role.access_values_for(:creator).first }
-  #let(:administrator) { Role.access_values_for(:administrator).first }
+
   before(:each) do
-    plan = FactoryBot.create(:plan, template: template, created_at: DateTime.new(2018,04,01))
-    plan2 = FactoryBot.create(:plan, template: template2, created_at: DateTime.new(2018,04,03))
-    plan3 = FactoryBot.create(:plan, template: template, created_at: DateTime.new(2018,05,02))
-    plan4 = FactoryBot.create(:plan, template: template, created_at: DateTime.new(2018,06,02))
-    plan5 = FactoryBot.create(:plan, template: template2, created_at: DateTime.new(2018,06,03))
-    FactoryBot.create(:role, :creator, plan: plan, user: user1)
-    FactoryBot.create(:role, :administrator, plan: plan, user: user2)
-    FactoryBot.create(:role, :creator, plan: plan2, user: user1)
-    FactoryBot.create(:role, :creator, plan: plan3, user: user1)
-    FactoryBot.create(:role, :administrator, plan: plan4, user: user2)
-    FactoryBot.create(:role, :administrator, plan: plan5, user: user2)
+    plan = FactoryBot.create(:plan,
+                              template: template,
+                              created_at: DateTime.new(2018, 04, 01))
+    plan2 = FactoryBot.create(:plan,
+                              template: template2,
+                              created_at: DateTime.new(2018, 04, 03))
+    plan3 = FactoryBot.create(:plan,
+                              template: template,
+                              created_at: DateTime.new(2018, 05, 02))
+    plan4 = FactoryBot.create(:plan,
+                              template: template,
+                              created_at: DateTime.new(2018, 06, 02))
+    plan5 = FactoryBot.create(:plan,
+                              template: template2,
+                              created_at: DateTime.new(2018, 06, 03))
+    FactoryBot.create(:role,
+                      :creator,
+                      plan: plan,
+                      user: user1)
+    FactoryBot.create(:role,
+                      :administrator,
+                      plan: plan,
+                      user: user2)
+    FactoryBot.create(:role,
+                      :creator,
+                      plan: plan2,
+                      user: user1)
+    FactoryBot.create(:role,
+                      :creator,
+                      plan: plan3,
+                      user: user1)
+    FactoryBot.create(:role,
+                      :administrator,
+                      plan: plan4,
+                      user: user2)
+    FactoryBot.create(:role,
+                      :administrator,
+                      plan: plan5,
+                      user: user2)
   end
 
-  def find_by_dates(dates: , org_id:)
+  def find_by_dates(dates:, org_id:)
     dates.map do |date|
       StatCreatedPlan.find_by(date: date, org_id: org_id)
     end
   end
 
-  describe '.call' do
-    context 'when org is passed' do
+  describe ".call" do
+    context "when org is passed" do
       it "generates monthly counts since org's creation" do
         described_class.call(org)
 
-        april, may, june, july = find_by_dates(dates: ['2018-04-30', '2018-05-31', '2018-06-30', '2018-07-31'], org_id: org.id)
+        april, may, june, july = find_by_dates(dates: ["2018-04-30",
+                                                       "2018-05-31",
+                                                       "2018-06-30",
+                                                       "2018-07-31"],
+                                                       org_id: org.id)
         counts = [april, may, june, july].map(&:count)
-        expect(counts).to eq([2,1,2,0])
+        expect(counts).to eq([2, 1, 2, 0])
       end
 
       it "generates monthly counts by template since org's creation" do
         described_class.call(org)
 
-        april, may, june, july = find_by_dates(dates: ['2018-04-30', '2018-05-31', '2018-06-30', '2018-07-31'], org_id: org.id)
-        expect(april.details).to eq(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 1 },
-              { 'name' => template2.title, 'count' => 1 },
-            ]
-          }
+        april, may, june, july = find_by_dates(dates: ["2018-04-30",
+                                                       "2018-05-31",
+                                                       "2018-06-30",
+                                                       "2018-07-31"],
+                                                       org_id: org.id)
+        expect(april.details).to match_array(
+          "by_template" => [
+            { "name" => template.title, "count" => 1 },
+            { "name" => template2.title, "count" => 1 },
+          ]
         )
-        expect(may.details).to eq(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 1 },
-            ]
-          }
+        expect(may.details).to match_array(
+          "by_template" => [
+            { "name" => template.title, "count" => 1 },
+          ]
         )
-        expect(june.details).to eq(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 1 },
-              { 'name' => template2.title, 'count' => 1 },
-            ]
-          }
+        expect(june.details).to match_array(
+          "by_template" => [
+            { "name" => template.title, "count" => 1 },
+            { "name" => template2.title, "count" => 1 },
+          ]
         )
-        expect(july.details).to eq(
-          {
-            'by_template' => []
-          }
+        expect(july.details).to match_array(
+          "by_template" => []
         )
       end
 
       it "monthly records are either created or updated" do
         described_class.call(org)
 
-        april = StatCreatedPlan.where(date: '2018-04-30', org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
         expect(april).to have(1).items
         expect(april.first.count).to eq(2)
 
-        new_plan = FactoryBot.create(:plan, template: template2, created_at: DateTime.new(2018,04,03))
+        new_plan = FactoryBot.create(:plan,
+                                     template: template2,
+                                     created_at: DateTime.new(2018, 04, 03))
         FactoryBot.create(:role, :creator, plan: new_plan, user: user1)
 
         described_class.call(org)
 
-        april = StatCreatedPlan.where(date: '2018-04-30', org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
         expect(april).to have(1).items
         expect(april.first.count).to eq(3)
       end
     end
 
-    context 'when no org is passed' do
-      it 'generates monthly counts for each org since their creation' do
+    context "when no org is passed" do
+      it "generates monthly counts for each org since their creation" do
         Org.stubs(:all).returns([org])
 
         described_class.call
 
-        april, may, june, july = find_by_dates(dates: ['2018-04-30', '2018-05-31', '2018-06-30', '2018-07-31'], org_id: org.id)
+        april, may, june, july = find_by_dates(dates: ["2018-04-30",
+                                                       "2018-05-31",
+                                                       "2018-06-30",
+                                                       "2018-07-31"],
+                                                       org_id: org.id)
 
         counts = [april, may, june, july].map(&:count)
-        expect(counts).to eq([2,1,2,0])
+        expect(counts).to eq([2, 1, 2, 0])
       end
 
-      it 'generates montly counts by template for each org since their creation' do
+      it "generates montly counts by template for each org since their creation" do
         Org.stubs(:all).returns([org])
 
         described_class.call
 
-        april, may, june, july = find_by_dates(dates: ['2018-04-30', '2018-05-31', '2018-06-30', '2018-07-31'], org_id: org.id)
+        april, may, june, july = find_by_dates(dates: ["2018-04-30",
+                                                       "2018-05-31",
+                                                       "2018-06-30",
+                                                       "2018-07-31"],
+                                                       org_id: org.id)
 
-        expect(april.details).to eq(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 1 },
-              { 'name' => template2.title, 'count' => 1 },
-            ]
-          }
+        expect(april.details).to match_array(
+          "by_template" => [
+            { "name" => template.title, "count" => 1 },
+            { "name" => template2.title, "count" => 1 },
+          ]
         )
-        expect(may.details).to eq(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 1 },
-            ]
-          }
+        expect(may.details).to match_array(
+          "by_template" => [
+            { "name" => template.title, "count" => 1 },
+          ]
         )
-        expect(june.details).to eq(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 1 },
-              { 'name' => template2.title, 'count' => 1 },
-            ]
-          }
+        expect(june.details).to match_array(
+          "by_template" => [
+            { "name" => template.title, "count" => 1 },
+            { "name" => template2.title, "count" => 1 },
+          ]
         )
-        expect(july.details).to eq(
-          {
-            'by_template' => []
-          }
+        expect(july.details).to match_array(
+          "by_template" => []
         )
       end
 
@@ -154,16 +185,18 @@ RSpec.describe Org::CreateCreatedPlanService do
 
         described_class.call
 
-        april = StatCreatedPlan.where(date: '2018-04-30', org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
         expect(april).to have(1).items
         expect(april.first.count).to eq(2)
 
-        new_plan = FactoryBot.create(:plan, template: template2, created_at: DateTime.new(2018,04,03))
+        new_plan = FactoryBot.create(:plan,
+                                    template: template2,
+                                    created_at: DateTime.new(2018, 04, 03))
         FactoryBot.create(:role, :creator, plan: new_plan, user: user1)
 
         described_class.call
 
-        april = StatCreatedPlan.where(date: '2018-04-30', org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
         expect(april).to have(1).items
         expect(april.first.count).to eq(3)
       end

--- a/spec/services/org/create_last_month_created_plan_service_spec.rb
+++ b/spec/services/org/create_last_month_created_plan_service_spec.rb
@@ -1,8 +1,10 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe Org::CreateLastMonthCreatedPlanService do
   let(:org) do
-    FactoryBot.create(:org, created_at: DateTime.new(2018,04,01))
+    FactoryBot.create(:org, created_at: DateTime.new(2018, 04, 01))
   end
   let(:template) do
     FactoryBot.create(:template, org: org)
@@ -19,63 +21,83 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
   let(:creator) { Role.access_values_for(:creator).first }
   let(:administrator) { Role.access_values_for(:administrator).first }
   before(:each) do
-    plan = FactoryBot.create(:plan, template: template, created_at: Date.today.last_month)
-    plan2 = FactoryBot.create(:plan, template: template, created_at: Date.today.last_month)
-    plan3 = FactoryBot.create(:plan, template: template2, created_at: Date.today.last_month)
+    plan = FactoryBot.create(:plan,
+                             template: template,
+                             created_at: Date.today.last_month)
+    plan2 = FactoryBot.create(:plan,
+                              template: template,
+                              created_at: Date.today.last_month)
+    plan3 = FactoryBot.create(:plan,
+                              template: template2,
+                              created_at: Date.today.last_month)
     FactoryBot.create(:role, :creator, plan: plan, user: user1)
     FactoryBot.create(:role, :administrator, plan: plan, user: user1)
     FactoryBot.create(:role, :creator, plan: plan2, user: user1)
     FactoryBot.create(:role, :creator, plan: plan3, user: user2)
   end
 
-  describe '.call' do
-    context 'when org is passed' do
+  describe ".call" do
+    context "when org is passed" do
       it "generates counts from today's last month" do
         described_class.call(org)
 
-        last_month_count = StatCreatedPlan.find_by(date: Date.today.last_month.end_of_month, org_id: org.id).count
+        last_month_count = StatCreatedPlan.find_by(
+          date: Date.today.last_month.end_of_month,
+          org_id: org.id).count
         expect(last_month_count).to eq(3)
       end
 
       it "generates counts by template from today's last month" do
         described_class.call(org)
 
-        last_month_details = StatCreatedPlan.find_by(date: Date.today.last_month.end_of_month, org_id: org.id).details
-        expect(last_month_details).to eq(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 2 },
-              { 'name' => template2.title, 'count' => 1 },
-            ]
-          }
+        last_month_details = StatCreatedPlan.find_by(
+          date: Date.today.last_month.end_of_month,
+          org_id: org.id).details
+
+        expect(last_month_details).to match_array(
+          "by_template" => [
+            { "name" => template.title, "count" => 2 },
+            { "name" => template2.title, "count" => 1 },
+          ]
         )
       end
 
       it "monthly records are either created or updated" do
         described_class.call(org)
 
-        last_month = StatCreatedPlan.where(date: Date.today.last_month.end_of_month, org_id: org.id)
+        last_month = StatCreatedPlan.where(
+          date: Date.today.last_month.end_of_month,
+          org_id: org.id)
+
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(3)
 
-        new_plan = FactoryBot.create(:plan, template: template2, created_at: Date.today.last_month.end_of_month)
+        new_plan = FactoryBot.create(:plan,
+                                     template: template2,
+                                     created_at: Date.today.last_month.end_of_month)
         FactoryBot.create(:role, :creator, plan: new_plan, user: user1)
 
         described_class.call(org)
 
-        last_month = StatCreatedPlan.where(date: Date.today.last_month.end_of_month, org_id: org.id)
+        last_month = StatCreatedPlan.where(
+          date: Date.today.last_month.end_of_month,
+          org_id: org.id)
+
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(4)
       end
     end
 
-    context 'when no org is passed' do
+    context "when no org is passed" do
       it "generates counts from today's last month" do
         Org.expects(:all).returns([org])
 
         described_class.call
 
-        last_month_count = StatCreatedPlan.find_by(date: Date.today.last_month.end_of_month, org_id: org.id).count
+        last_month_count = StatCreatedPlan.find_by(
+          date: Date.today.last_month.end_of_month,
+          org_id: org.id).count
+
         expect(last_month_count).to eq(3)
       end
 
@@ -84,14 +106,15 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         described_class.call
 
-        last_month_details = StatCreatedPlan.find_by(date: Date.today.last_month.end_of_month, org_id: org.id).details
+        last_month_details = StatCreatedPlan.find_by(
+          date: Date.today.last_month.end_of_month,
+          org_id: org.id).details
+
         expect(last_month_details).to match_array(
-          {
-            'by_template' => [
-              { 'name' => template.title, 'count' => 2 },
-              { 'name' => template2.title, 'count' => 1 },
-            ]
-          }
+          "by_template" => [
+            { "name" => template.title, "count" => 2 },
+            { "name" => template2.title, "count" => 1 },
+          ]
         )
       end
 
@@ -100,16 +123,22 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         described_class.call
 
-        last_month = StatCreatedPlan.where(date: Date.today.last_month.end_of_month, org: org)
+        last_month = StatCreatedPlan.where(
+          date: Date.today.last_month.end_of_month,
+          org: org)
+
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(3)
 
-        new_plan = FactoryBot.create(:plan, template: template2, created_at: Date.today.last_month.end_of_month)
+        new_plan = FactoryBot.create(:plan,
+                                     template: template2,
+                                     created_at: Date.today.last_month.end_of_month)
         FactoryBot.create(:role, :creator, plan: new_plan, user: user1)
 
         described_class.call
 
-        last_month = StatCreatedPlan.where(date: Date.today.last_month.end_of_month, org: org)
+        last_month = StatCreatedPlan.where(date: Date.today.last_month.end_of_month,
+                                           org: org)
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(4)
       end


### PR DESCRIPTION
 Changes:
   - relevant models with :search scope updated with lower casing  of the column
     values and the search parameters.
   - fixed all rubocop warnings on the changed models except
     "Style/RedundantReturn: Redundant return detected."

   Note: one could not use 'ILIKE' in WHERE clauses changed as it is not supported by MariaDB and MySql.
   Hence we use lower() in changed WHERE clauses.

 Fix for issue #2080
