### PR TITLE
Table View Issue for Readonly Content of Plan and Template pages.

### DIFF
--- a/app/views/answers/_new_edit.html.erb
+++ b/app/views/answers/_new_edit.html.erb
@@ -6,7 +6,9 @@
 <% q_format = question.question_format %>
 <% if q_format.rda_metadata? %>
   <p>
-    <strong><%= sanitize question.text %></strong>
+    <div class="display-readonly-textarea-content">
+      <strong><%= sanitize question.text %></strong>
+    </div>
   </p>
   <% answer_hash = answer.answer_hash %>
   <div class="rda_metadata"><button class="remove-standard" style="display:none;"></button>

--- a/app/views/guidance_groups/_index_by_theme.html.erb
+++ b/app/views/guidance_groups/_index_by_theme.html.erb
@@ -45,7 +45,9 @@
                 <% end %>
                 <p>
                   <% unless guidances_output.include?(guidance.id) %>
-                    <%= sanitize(guidance.text) %>
+                    <div class="display-readonly-textarea-content">
+                      <%= sanitize(guidance.text) %>
+                    </div>
                     <% guidances_output << guidance.id %>
                     <% multiple = true %>
                   <% end %>

--- a/app/views/guidances/_guidance_display.html.erb
+++ b/app/views/guidances/_guidance_display.html.erb
@@ -13,7 +13,9 @@
         </div>
         <div id="collapse-guidance-<%= question.id%>" class="guidance-accordion-body collapse">
           <div class="accordion-inner">
-            <%= sanitize question.guidance_annotation(current_user.org).text %>
+            <div class="display-readonly-textarea-content">
+               <%= sanitize question.guidance_annotation(current_user.org).text %>
+            </div>
           </div>
         </div>
       </div>
@@ -29,7 +31,11 @@
             <span class="plus-laranja"> </span></a>
         </div>
         <div id="collapse-guidance-<%= guidance.id%>-<%= question.id %>" class="guidance-accordion-body collapse">
-          <div class="accordion-inner"><%= sanitize guidance.text %></div>
+          <div class="accordion-inner">
+            <div class="display-readonly-textarea-content">
+              <%= sanitize guidance.text %>
+            </div>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/notes/_show.html.erb
+++ b/app/views/notes/_show.html.erb
@@ -2,7 +2,11 @@
 <% if !note.nil? %>
     <% user = User.find(note.user_id) %>
     <ul class="list-unstyled">
-        <li><%= sanitize note.text %></li>
+        <li>
+          <div class="display-readonly-textarea-content">
+            <%= sanitize note.text %>
+          </div>
+        </li>
         <li>
             <span class="label label-info">
                 <%= "#{user.name} at #{l(note.updated_at, format: :short)}" %>

--- a/app/views/org_admin/annotations/_show.html.erb
+++ b/app/views/org_admin/annotations/_show.html.erb
@@ -2,10 +2,18 @@
   <dl<%= for_plan ? ' class="dl-horizontal"' : '' %>>
     <% if example_answer.present? %>
       <dt><%= _('%{org} Example Answer') % { org: example_answer.org.short_name } %></dt>
-      <dd><%= sanitize example_answer.text %><dd>
+      <dd>
+        <div class="display-readonly-textarea-content">
+          <%= sanitize example_answer.text %>
+        </div>
+      <dd>
     <% end %>
     <% if guidance.present? %>
-      <dd><%= sanitize guidance.text %></dd>
+      <dd>
+        <div class="display-readonly-textarea-content">
+          <%= sanitize guidance.text %>
+        </div>
+      </dd>
     <% end %>
   </dl>
 <% end %>

--- a/app/views/org_admin/questions/_show.html.erb
+++ b/app/views/org_admin/questions/_show.html.erb
@@ -13,7 +13,11 @@
           <dt><%= _('Question number')%></dt>
           <dd><%= question.number %></dd>
           <dt><%= _('Question text')%></dt>
-          <dd><%= sanitize question.text %></dd>
+          <dd>
+            <div class="display-readonly-textarea-content">
+                <%= sanitize question.text %>
+            </div>
+          </dd>
           <!-- question.option_based? -->
           <% if question.option_based? %>
             <dt><%= _('Question options') %></dt>
@@ -23,13 +27,21 @@
           <% if q_format.textfield? || q_format.textarea? %>
             <% if !question.default_value.nil? %>
               <dt><%= _('Default value')%></dt>
-              <dd><%= sanitize question.default_value %></dd>
+              <dd>
+                <% if q_format.textarea?  %>
+                  <div class="display-readonly-textarea-content">
+                    <%= sanitize question.default_value %>
+                  </div>
+                <% else %>
+                  <%= sanitize question.default_value %>
+               <% end %>
+           </dd>
             <% end %>
           <% end %>
           <!-- Format title -->
           <dt><%= _('Answer format')%></dt>
           <dd>
-            <%= q_format.title %>
+            <%= q_format.title + "."%>
             <% if q_format.option_based? %>
               <%= _('Additional comment area will be displayed.')%>
             <% else %>
@@ -38,17 +50,30 @@
           </dd>
           <!-- Suggested answer or Example-->
           <% if !question.section.phase.template.org.funder? %>
-              <% example_answer = question.example_answers(template.base_org.id).first %>
+            <% example_answer = question.example_answers(template.base_org.id).first %>
               <% if example_answer.present?  && example_answer.text.present?  %>
                   <dt><%= _('example answer')%></dt>
-                  <dd><%= sanitize example_answer.text %></dd>
+                  <dd>
+                    <% if q_format.textarea?  %>
+                      <div class="display-readonly-textarea-content">
+                        <%= sanitize example_answer.text %>
+                      </div>
+                    <% else %>
+                       <%= sanitize example_answer.text %>
+                    <% end %>
+                  </dd>
+                  
               <% end %>
           <% end %>
           <!-- Guidance linked to this question -->
           <% guidance = question.guidance_annotation(template.base_org.id) %>
           <% if guidance.present?  %>
             <dt><%= _('Guidance')%></dt>
-            <dd><%= sanitize guidance.text %></dd>
+            <dd>
+              <div class="display-readonly-textarea-content">
+                <%= sanitize guidance.text %>
+              </div>
+            </dd>
           <% end %>
           <!-- Themes -->
           <% themes_q = question.themes %>
@@ -117,7 +142,9 @@
                                role="tabpanel"
                                aria-labelledby="headingGuidance-<%= guidance.id%>-<%= question.id %>">
                             <div class="panel-body allow-break-words">
-                              <%= sanitize guidance.text %>
+                              <div class="display-readonly-textarea-content">
+                                <%= sanitize guidance.text %>
+                              </div>
                             </div>
                         </div>
                       </div>
@@ -148,7 +175,11 @@
               <dl class="dl-horizontal">
                 <% question.annotations_per_org(current_user.org_id).each do |annotation| %>
                   <dt><%= annotation.type.humanize %></dt>
-                  <dd><%= annotation.text.present? ? sanitize(annotation.text) : _('None provided') %></dd>
+                  <dd>
+                    <div class="display-readonly-textarea-content">
+                      <%= annotation.text.present? ? sanitize(annotation.text) : _('None provided') %>
+                    </div>
+                  </dd>
                 <% end %>
               </dl>
             <% else %>
@@ -187,7 +218,9 @@
               <% question.annotations_per_org(current_user.org_id).each do |annotation| %>
                 <dt><%= annotation.type.humanize %></dt>
                 <dd>
-                  <%= annotation.text.present? ? sanitize(annotation.text) : _('None provided') %>
+                  <div class="display-readonly-textarea-content">
+                    <%= annotation.text.present? ? sanitize(annotation.text) : _('None provided') %>
+                  <div class="display-readonly-textarea-content">
                 </dd>
               <% end %>
             </dl>

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -50,7 +50,11 @@
         </div>
         <div id="collapse-<%= section.id %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-<%= section.id %>">
           <div class="panel-body"><!-- accordion body -->
-            <div class="section-description"><%= sanitize section.description %></div>
+            <div class="section-description">
+              <div class="display-readonly-textarea-content">
+                <%= sanitize section.description %>
+              </div>
+            </div>
               <!-- the section body -->
               <% section.questions.each_with_index do |question, i| %>
                 <% # Load the answer or create a new one

--- a/app/views/phases/_overview.html.erb
+++ b/app/views/phases/_overview.html.erb
@@ -17,7 +17,11 @@
           <%= s.title %>
           <ul>
             <% s.questions.each do |q| %>
-              <li><%= sanitize(q.text) %></li>
+              <li>
+                <div class="display-readonly-textarea-content">
+                  <%= sanitize(q.text) %>
+                </div>
+              </li>
             <% end %>
           </ul>
         </li>


### PR DESCRIPTION
Added a div to emulate the styling for TinyMCE text area around readonly text content for answers, annotations, guidance, etc.

Fix for #2071.
