### PR TITLE
Table View Issue for Readonly Content of Plan and Template pages.

### DIFF
--- a/app/views/org_admin/phases/_phase.html.erb
+++ b/app/views/org_admin/phases/_phase.html.erb
@@ -20,7 +20,9 @@
         </div>
       </h3>
       <p class="pull-left">
-        <%= sanitize phase.description %>
+        <div class="display-readonly-textarea-content">
+          <%= sanitize phase.description %>
+        </div>
       </p>
     </div>
   </div>
@@ -38,7 +40,13 @@
           <tbody>
             <% phase.sections.each do |section| %>
               <tr id="<%= dom_id(section) %>" data-number="<%= section.number %>">
-                <td><p><%= section.title %></p></td>
+                <td>
+                  <p>
+                    <div class="display-readonly-textarea-content">
+                      <%= section.title %>
+                    </div>
+                  </p>
+                </td>
                 <td>
                   <% if section.questions.present? %>
                     <ul>

--- a/app/views/org_admin/phases/_show.html.erb
+++ b/app/views/org_admin/phases/_show.html.erb
@@ -4,5 +4,9 @@
   <dt><%= _('Order of display') %></dt>
   <dd><%= phase.number %></dd>
   <dt><%= _('Description') %></dt>
-  <dd><%= sanitize phase.description %></dd>
+  <dd>
+    <div class="display-readonly-textarea-content">
+      <%= sanitize phase.description %>
+    </div>
+  </dd>
 </dl>

--- a/app/views/questions/_new_edit_question_option_based.html.erb
+++ b/app/views/questions/_new_edit_question_option_based.html.erb
@@ -41,7 +41,9 @@
     <% text = question.question_format.rda_metadata? ? answer.answer_hash['text'] : answer.text %>
     <%= label_tag('answer[text]', _('Additional Information'), class: 'control-label') %>
     <% if readonly %>
-      <%= sanitize("<p>#{text}</p>") %>
+      <div class="display-readonly-textarea-content">
+        <%= sanitize("<p>#{text}</p>") %>
+      </div>
     <% else %>
       <%= text_area_tag('answer[text]', text, id: "answer-text-#{question.id}", class: "form-control tinymce_answer") %>
     <% end %>

--- a/app/views/questions/_new_edit_question_textarea.html.erb
+++ b/app/views/questions/_new_edit_question_textarea.html.erb
@@ -8,7 +8,9 @@
   within a paragraph.
 %>
 <div class="form-group allow-break-words">
-    <%= f.label(:text, sanitize(question.text), class: 'control-label') %>
+    <div class="display-readonly-textarea-content">
+      <%= f.label(:text, sanitize(question.text), class: 'control-label') %>
+    </div>
     <% if locking || readonly %>
       <div class="display-readonly-textarea-content">
         <%= sanitize("<p>#{answer.text || question.default_value}</p>") %>


### PR DESCRIPTION
    Added a div to emulate the styling for TinyMCE text area around readonly text content for phases and question labels.

    Fix for #2071

Hopefully, found all table view bugs:
![Selection_207](https://user-images.githubusercontent.com/8876215/56424632-11415480-62a9-11e9-8eea-50fcbd196e6c.png)
 
![Selection_206](https://user-images.githubusercontent.com/8876215/56424659-2d44f600-62a9-11e9-9765-260a9ea57c62.png)


