### PR TITLE
Table View Issue for Readonly Content of Plan and Template pages.

### DIFF
--- a/app/assets/stylesheets/blocks/_readonly_textarea.scss
+++ b/app/assets/stylesheets/blocks/_readonly_textarea.scss
@@ -7,7 +7,13 @@
   padding-bottom: 10px;
   
   // Ensure table borders are not lost
-  table td {
-    border: 1px solid black;
+  table {
+    td {
+      border: 1px solid black;
+    }
+    
+    td, tr {
+      padding: 10px;
+    }
   }
 }

--- a/app/views/phases/_overview.html.erb
+++ b/app/views/phases/_overview.html.erb
@@ -6,7 +6,9 @@
       <a href="<%= edit_plan_path(plan_id, phase_id: phase.id) %>" class="btn btn-default pull-right"><%= _('Write plan') %></a>
     </h4>
     <p class="text-justify">
-      <%= sanitize(phase.description) %>
+        <div class="display-readonly-textarea-content">
+          <%= sanitize(phase.description) %>
+        </div>
     </p>
   </div>
 

--- a/app/views/plans/_overview_details.html.erb
+++ b/app/views/plans/_overview_details.html.erb
@@ -9,7 +9,9 @@
       <%= _('This plan is based on the "%{template_title}" template provided by %{org_name}.') %{ :template_title => plan.template.title, :org_name => plan.template.org.name } %>
     </p>
     <p>
-      <%= sanitize(plan.template.description) %>
+      <div class="display-readonly-textarea-content">
+        <%= sanitize(plan.template.description) %>
+      </div>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Changes:
- to re-style the readonly text tables with padding
- added the TinyMCE like styling to the Phase overview description

Fix for #2071.
![Selection_211](https://user-images.githubusercontent.com/8876215/56428209-80717580-62b6-11e9-9916-41013394ec6f.png)
![Selection_210](https://user-images.githubusercontent.com/8876215/56428210-80717580-62b6-11e9-951d-40927275f231.png)
