### PR TITLE
updated permissions and routing around public template export

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -2,8 +2,6 @@
 
 class PublicPagesController < ApplicationController
 
-  after_action :verify_authorized, except: [:template_index, :plan_index]
-
   # GET template_index
   # -----------------------------------------------------
   def template_index
@@ -22,7 +20,6 @@ class PublicPagesController < ApplicationController
     @template = Template.live(params[:id])
     # covers authorization for this action.
     # Pundit dosent support passing objects into scoped policies
-    skip_authorization
     unless PublicPagePolicy.new(@template).template_export?
       redirect_to public_templates_path, notice: "You are not authorized to export that template" and return
       #raise Pundit::NotAuthorizedError

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -22,10 +22,11 @@ class PublicPagesController < ApplicationController
     @template = Template.live(params[:id])
     # covers authorization for this action.
     # Pundit dosent support passing objects into scoped policies
-    unless PublicPagePolicy.new(@template).template_export?
-      raise Pundit::NotAuthorizedError
-    end
     skip_authorization
+    unless PublicPagePolicy.new(@template).template_export?
+      redirect_to public_templates_path, notice: "You are not authorized to export that template" and return
+      #raise Pundit::NotAuthorizedError
+    end
     # now with prefetching (if guidance is added, prefetch annottaions/guidance)
     @template = Template.includes(
       :org,

--- a/app/policies/public_page_policy.rb
+++ b/app/policies/public_page_policy.rb
@@ -14,7 +14,7 @@ class PublicPagePolicy < ApplicationPolicy
   end
 
   def template_export?
-    @object.present? && ( @object.is_default || @object.org.funder? ) && @object.published
+    @object.present? && ( @object.is_default? || @object.org.funder? ) && @object.published?
   end
 
   def plan_export?

--- a/app/policies/public_page_policy.rb
+++ b/app/policies/public_page_policy.rb
@@ -14,7 +14,7 @@ class PublicPagePolicy < ApplicationPolicy
   end
 
   def template_export?
-    @object.is_default || @object.org.funder?
+    @object.present? && ( @object.is_default || @object.org.funder? ) && @object.published
   end
 
   def plan_export?


### PR DESCRIPTION
Fixes #2118 .

Exported templates must additionally exist and be published

