### PR TITLE
Changed date format of footer in the Plans pdf export to a more human…

### DIFF
--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -76,9 +76,9 @@ class PlanExportsController < ApplicationController
     render pdf: file_name,
            margin: @formatting[:margin],
            footer: {
-             center: _("Created using the %{application_name}. Last modified %{date}") % {
+             center: _("Created using %{application_name}. Last modified %{date}") % {
                application_name: Rails.configuration.branding[:application][:name],
-               date: l(@plan.updated_at.to_date, formats: :short)
+               date: l(@plan.updated_at.to_date, format: :readable)
               },
              font_size: 8,
              spacing:   (Integer(@formatting[:margin][:bottom]) / 2) - 4,

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -44,6 +44,7 @@ de:
       long: "%e. %B %Y"
       short: "%e. %b"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -40,6 +40,7 @@ el:
       long: ! '%e %B %Y'
       short: ! '%d %b'
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/en-US.yml
+++ b/config/locales/en-US.yml
@@ -43,6 +43,7 @@ en-US:
       long: "%B %d, %Y"
       short: "%b %d"
       csv: "%m/%d/%Y"
+      readable: "%d %B %Y"
     month_names:
     -
     - January

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 ---
-en-GB:
+en:
   activerecord:
     errors:
       messages:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -43,6 +43,7 @@ es:
       long: "%-d de %B de %Y"
       short: "%-d de %b"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -43,6 +43,7 @@ fi:
       long: "%A %e. %Bta %Y"
       short: "%d. %b"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/fr-CA.yml
+++ b/config/locales/fr-CA.yml
@@ -43,6 +43,7 @@ fr-CA:
       long: "%d %B %Y"
       short: "%y-%m-%d"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/fr-FR.yml
+++ b/config/locales/fr-FR.yml
@@ -43,6 +43,7 @@ fr-FR:
       short: "%e %b"
       long: "%e %B %Y"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,6 +43,7 @@ fr:
       short: "%e %b"
       long: "%e %B %Y"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,6 +43,7 @@ ja:
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -12,6 +12,7 @@ pt-BR:
       short: "%m/%d/%Y"
       long: "%B %d, %Y"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     day_names: ['Domingo', 'Segunda-feira', 'Terça-feira', 'Quarta-feira', 'Quinta-feira', 'Sexta-feira', 'Sábado']
     abbr_day_names: [Dom, Seg, Ter, Qua, Qui, Sex, Sab]

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -40,6 +40,7 @@ ro:
       long: "%d %B %Y"
       short: "%d %b"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -

--- a/config/locales/sv-FI.yml
+++ b/config/locales/sv-FI.yml
@@ -43,6 +43,7 @@ sv-FI:
       long: "%e %B %Y"
       short: "%e %b"
       csv: "%d/%m/%Y"
+      readable: "%d %B %Y"
 
     month_names:
     -


### PR DESCRIPTION
… readable date,

 e.g., "Last modified 26 April 2019".

Changes:
  - added :readable date format to language locales
  - used this date for the footer in the Plans pdf export.
    Note, changed " formats" to "format" and use :readable in footer date
     From  "date: l(@plan.updated_at.to_date, formats: :short)" -->
     to    "date: l(@plan.updated_at.to_date, format: :readable)"
  - to pass Rspec test spec/features/plans/exports_spec.rb we needed to add
    a locale file en.yml  which is a copy of en-GB.yml to avoid error
    "1) PlansExports User downloads their plan as PDF
     Failure/Error: date: l(@plan.updated_at.to_date, format: :readable)

     I18n::MissingTranslationData:
       translation missing: en.date.formats.readable"

Fix for Issue #2094.

@xsrust suggested I raise an issue about RSpec locale for say `en-GB` testing for `en` instead.

Screen shot of footer in pdf now
![Selection_221](https://user-images.githubusercontent.com/8876215/57012894-8d6c5e00-6c00-11e9-9c1a-e3de9c49f253.png)

