### PR TITLE
Pre-fill ID on the plan details page.

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -123,6 +123,10 @@ class PlansController < ApplicationController
 
         @plan.add_user!(current_user.id, :creator)
 
+        # Set new identifier to plan id by default on create.
+        # (This may be changed by user.)
+        @plan.add_identifier!(@plan.id.to_s)
+
         respond_to do |format|
           flash[:notice] = msg
           format.html { redirect_to plan_path(@plan) }

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -450,6 +450,14 @@ class Plan < ActiveRecord::Base
     end
   end
 
+  ## Update plan identifier.
+  #
+  # Returns Boolean
+  def add_identifier!(identifier)
+    self.update(identifier: identifier)
+    save!
+  end
+
   ##
   # Whether or not the plan is associated with users other than the creator
   #


### PR DESCRIPTION
Changes:
  - the default plan :identifier is set to the plan :id on creation in the
    PlanControllers create method.
  - added a method add_identifier to Plan model.

Fix for issue #2089

![Selection_222](https://user-images.githubusercontent.com/8876215/57017567-9a487c00-6c17-11e9-8f2c-ac1464cc7918.png)

@xsrust and @briri given my ruby rails inexperience please comment if this is the the best way to do what was required by issue
