### PR TITLE
Issue/2115

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -252,15 +252,15 @@ module OrgAdmin
       template = Template.find(params[:id])
       authorize template
       # rubocop:disable Metrics/LineLength
-      if template.latest?
-        # Now make the current version published
+      publishable, errors = template.publishability
+      if publishable
         if template.publish!
           flash[:notice] = _("Your #{template_type(template)} has been published and is now available to users.")
         else
           flash[:alert] = _("Unable to publish your #{template_type(template)}.")
         end
       else
-        flash[:alert] = _("You can not publish a historical version of this #{template_type(template)}.")
+        flash[:alert] = errors
       end
       # rubocop:enable Metrics/LineLength
       redirect_to request.referrer.present? ? request.referrer : org_admin_templates_path

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -403,6 +403,36 @@ class Template < ActiveRecord::Base
     update!(published: true)
   end
 
+  def publishability
+    error = ""
+    publishable = true
+    # template must be the most recent draft
+    if published
+      error += _("You can not publish a published template.  ")
+      publishable = false
+    end
+    if not latest?
+      error += _("You can not publish a historical version of this template.  ")
+      publishable = false
+    # all templates have atleast one phase
+    end
+    if not phases.count > 0
+      error += _("You can not publish a template without phases.  ")
+      publishable = false
+    # all phases must have atleast 1 section
+    end
+    if phases.map{|p| p.sections.count > 0}.reduce(true) { |fin, val| fin and val }
+      error += _("You cannot publish a template without sections in a phase.  ")
+      publishable = false
+    # all sections must have atleast one question
+    end
+    if sections.map{|s| s.questions.count > 0}.reduce(true) { |fin, val| fin and val }
+      error += _("You cannot publish a template without questions in a section.  ")
+      publishable = false
+    end
+    return publishable, error
+  end
+
   private
 
   # ============================

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -421,13 +421,13 @@ class Template < ActiveRecord::Base
       publishable = false
     # all phases must have atleast 1 section
     end
-    if phases.map{|p| p.sections.count > 0}.reduce(true) { |fin, val| fin and val }
-      error += _("You cannot publish a template without sections in a phase.  ")
+    unless phases.map{|p| p.sections.count > 0}.reduce(true) { |fin, val| fin and val }
+      error += _("You can not publish a template without sections in a phase.  ")
       publishable = false
     # all sections must have atleast one question
     end
-    if sections.map{|s| s.questions.count > 0}.reduce(true) { |fin, val| fin and val }
-      error += _("You cannot publish a template without questions in a section.  ")
+    unless sections.map{|s| s.questions.count > 0}.reduce(true) { |fin, val| fin and val }
+      error += _("You can not publish a template without questions in a section.  ")
       publishable = false
     end
     return publishable, error

--- a/spec/factories/phases.rb
+++ b/spec/factories/phases.rb
@@ -32,10 +32,11 @@ FactoryBot.define do
 
     transient do
       sections { 0 }
+      questions { 0 }
     end
 
     after(:create) do |phase, evaluator|
-      create_list(:section, evaluator.sections, phase: phase)
+      create_list(:section, evaluator.sections, phase: phase, questions: evaluator.questions)
     end
   end
 end

--- a/spec/factories/sections.rb
+++ b/spec/factories/sections.rb
@@ -29,5 +29,13 @@ FactoryBot.define do
     sequence(:number)
     phase
     modifiable { false }
+
+    transient do
+      questions { 0 }
+    end
+
+    after(:create) do |section, evaluator|
+      create_list(:question, evaluator.questions, section: section)
+    end
   end
 end

--- a/spec/factories/templates.rb
+++ b/spec/factories/templates.rb
@@ -72,10 +72,12 @@ FactoryBot.define do
 
     transient do
       phases { 0 }
+      sections { 0 }
+      questions { 0 }
     end
 
     after(:create) do |template, evaluator|
-      create_list(:phase, evaluator.phases, template: template)
+      create_list(:phase, evaluator.phases, template: template, sections: evaluator.sections, questions: evaluator.questions)
     end
 
   end

--- a/spec/features/templates/templates_upgrade_customisations_spec.rb
+++ b/spec/features/templates/templates_upgrade_customisations_spec.rb
@@ -67,6 +67,15 @@ RSpec.feature "Templates::UpgradeCustomisations", type: :feature do
       tinymce_fill_in :new_section_section_description, with: "New section title"
       expect { click_button("Save") }.to change { Section.count }.by(3)
     end
+
+    within("#section-#{Section.last.id}") do
+      click_button('Add Question')
+      within("#new_question_new_question") do
+        tinymce_fill_in :new_question_question_text, with: "Text for the question"
+        expect { click_button("Save")}
+      end
+    end
+
     new_funder_template = Template.last
 
     visit organisational_org_admin_templates_path

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -1378,7 +1378,7 @@ RSpec.describe Template, type: :model do
     # case when template is correctly generated
     context "When the Template has all components, is latest, and unpublished" do
 
-      let(:template) { create(:template, :default, published: false, org: org, phases: 3)}
+      let(:template) { create(:template, :default, published: false, org: org, phases: 1, sections: 1, questions: 1)}
 
       it "returns true" do
         expect(subject[0]).to eql(true)
@@ -1392,11 +1392,11 @@ RSpec.describe Template, type: :model do
 
     # case when the template is historical
     context "When the template is an historical version" do
-      let(:template) { create(:template, :default, published: true, org: org, phases:3, version: 1)}
-      let(:new_template) { template.generate_version! }
+      let(:template) { create(:template, :default, published: true, org: org, phases: 3, version: 1, sections: 1, questions: 1)}
 
-      it "is not the latest template" do
-        expect(template.latest?).to eql(false)
+      before do
+        template.generate_version!
+        template.update_column(:published,  false)
       end
 
       it "returns false" do
@@ -1408,10 +1408,63 @@ RSpec.describe Template, type: :model do
       end
 
     end
+
     # case when the template is published
+    context "When the Template has all components, is latest, and already published" do
+
+      let(:template) { create(:template, :default, published: true, org: org, phases: 1, sections: 1, questions: 1)}
+
+      it "is not publishable" do
+        expect(subject[0]).to eql(false)
+      end
+
+      it "has error_message" do
+        expect(subject[1]).to include("You can not publish a published template.")
+      end
+
+    end
     # case when template has no phases
+    context "When the Template has no phases" do
+
+      let(:template) { create(:template, :default, published: true, org: org, phases: 0)}
+
+      it "is not publishable" do
+        expect(subject[0]).to eql(false)
+      end
+
+      it "has error_message" do
+        expect(subject[1]).to include("You can not publish a template without phases")
+      end
+
+    end
     # case when a template has no sections
+    context "When the Template has no sections" do
+
+      let(:template) { create(:template, :default, published: true, org: org, phases: 1, sections: 0)}
+
+      it "is not publishable" do
+        expect(subject[0]).to eql(false)
+      end
+
+      it "has error_message" do
+        expect(subject[1]).to include("You can not publish a template without sections in a phase")
+      end
+
+    end
     # case when a section has no questions
+    context "When the Template has no questions" do
+
+      let(:template) { create(:template, :default, published: true, org: org, phases: 1, sections: 1, questions: 0)}
+
+      it "is not publishable" do
+        expect(subject[0]).to eql(false)
+      end
+
+      it "has error_message" do
+        expect(subject[1]).to include("You can not publish a template without questions in a section")
+      end
+
+    end
 
   end
 

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -1365,4 +1365,54 @@ RSpec.describe Template, type: :model do
 
   end
 
+
+  describe "#publishability" do
+
+    subject { template.publishability }
+
+    # Added an additional type to Org so that funder_only? fails
+    let!(:org) { create(:org, :funder, :organisation) }
+
+    #let!(:template) { create(:template, :default, org: org) }
+
+    # case when template is correctly generated
+    context "When the Template has all components, is latest, and unpublished" do
+
+      let(:template) { create(:template, :default, published: false, org: org, phases: 3)}
+
+      it "returns true" do
+        expect(subject[0]).to eql(true)
+      end
+
+      it "has no errors" do
+        expect(subject[1]).to eql("")
+      end
+
+    end
+
+    # case when the template is historical
+    context "When the template is an historical version" do
+      let(:template) { create(:template, :default, published: true, org: org, phases:3, version: 1)}
+      let(:new_template) { template.generate_version! }
+
+      it "is not the latest template" do
+        expect(template.latest?).to eql(false)
+      end
+
+      it "returns false" do
+        expect(subject[0]).to eql(false)
+      end
+
+      it "has error_message" do
+        expect(subject[1]).to include("You can not publish a historical version of this template.  ")
+      end
+
+    end
+    # case when the template is published
+    # case when template has no phases
+    # case when a template has no sections
+    # case when a section has no questions
+
+  end
+
 end


### PR DESCRIPTION
- Add publishability check  to templates model
- Added tests for publishability check
- refactored factory definition of templates/phases/sections to allow specification of number of sub-models to generate.  This is currently done by passing a number of sub-models for each of the current model to have.  i.e. `{phases:2 , sections:3}` will result in 2 phases, each with 3 sections, so a total of 6 sections created.  This could be re-done down the line to pass a structured object so that each of the models may have a different number of sub-models, but this granularity was not needed for my tests
- refactored templates_controller to use publishability check