### PR TITLE
Add typeahead field for Research Grant ID

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,12 @@
     "semi": [
       "error",
       "always"
-    ]
+    ],
+    "prefer-destructuring": ["error", {
+      "array": false,
+      "object": false
+    }, {
+      "enforceForRenamedProperties": false
+    }]
   }
 }

--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ end
 
 
 # bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right into your Sass powered applications. (https://github.com/twbs/bootstrap-sass)
-gem 'bootstrap-sass', '~> 3.3.7'
+gem 'bootstrap-sass', '~> 3.4.0'
 
 # This is required for Font-Awesome, but not used as the main sass compiler
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.5.1.1)
       execjs
     bcrypt (3.1.12)
     better_errors (2.5.1)
@@ -61,9 +61,9 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     brakeman (4.5.0)
     builder (3.2.3)
     bullet (5.9.0)
@@ -257,7 +257,7 @@ GEM
     multipart-post (2.0.0)
     mysql2 (0.4.10)
     nenv (0.3.0)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -392,7 +392,7 @@ GEM
     ruby_dig (0.0.2)
     rubyzip (1.2.2)
     safe_yaml (1.0.5)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -486,7 +486,7 @@ DEPENDENCIES
   autoprefixer-rails
   better_errors
   binding_of_caller
-  bootstrap-sass (~> 3.3.7)
+  bootstrap-sass (~> 3.4.0)
   brakeman
   bullet
   bundle-audit

--- a/app/controllers/research_projects_controller.rb
+++ b/app/controllers/research_projects_controller.rb
@@ -9,7 +9,6 @@ class ResearchProjectsController < ApplicationController
 
   def search
     @results = research_projects.select { |r| r.description.match(params[:description]) }
-    logger.debug("Returning #{@results.count} results")
     render json: @results
   end
 

--- a/app/controllers/research_projects_controller.rb
+++ b/app/controllers/research_projects_controller.rb
@@ -1,0 +1,30 @@
+class ResearchProjectsController < ApplicationController
+
+
+  DEFAULT_FUNDER_TYPE = "H2020"
+
+  def index
+    render json: research_projects
+  end
+
+  def search
+    @results = research_projects.select { |r| r.description.match(params[:description]) }
+    logger.debug("Returning #{@results.count} results")
+    render json: @results
+  end
+
+  private
+
+  def research_projects
+    @research_projects ||= begin
+      Rails.cache.fetch(["research_projects", funder_type], expires_in: 1.day) do
+        Thread.new { OpenAireRequest.new(funder_type).get!.results }.value
+      end
+    end
+  end
+
+  def funder_type
+    params.fetch(:type, DEFAULT_FUNDER_TYPE)
+  end
+
+end

--- a/app/javascript/views/plans/edit_details.js
+++ b/app/javascript/views/plans/edit_details.js
@@ -57,9 +57,16 @@ $(() => {
     toggleCheckboxes(selections);
   };
 
-  const grantNumberInfo = (grantId) => {
-    return `Grant number: ${grantId}`;
-  }
+  const grantNumberInfo = grantId => `Grant number: ${grantId}`;
+
+  const setInitialGrantProjectName = () => {
+    const grantId = grantIdHidden.val();
+    const researchProjects = window.researchProjects;
+    const researchProject = researchProjects.find(datum => datum.grant_id === grantId);
+    if (researchProject) {
+      grantIdField.val(researchProject.description);
+    }
+  };
 
   const setUpTypeahead = () => {
     if ($('.edit_plan').length) {
@@ -67,9 +74,7 @@ $(() => {
         window.researchProjects = data;
         const descriptionData = $.map(data, datum => datum.description);
         grantIdField.typeahead({ source: descriptionData });
-      }).then(function() {
-        setInitialGrantProjectName();
-      });
+      }).then(() => { setInitialGrantProjectName(); });
       grantIdField.on('change', () => {
         const current = grantIdField.typeahead('getActive');
         if (current) {
@@ -79,7 +84,7 @@ $(() => {
             return fixString(datum.description) === fixString(current);
           });
           if (currentResearchProject) {
-            const grantId = currentResearchProject.grant_id
+            const grantId = currentResearchProject.grant_id;
             $('#grant_number_info').html(grantNumberInfo(grantId));
             grantIdHidden.val(grantId);
           }
@@ -88,14 +93,6 @@ $(() => {
           grantIdHidden.val('');
         }
       });
-    }
-  };
-
-  const setInitialGrantProjectName = () => {
-    const grantId = grantIdHidden.val();
-    const researchProject = researchProjects.find(datum => datum.grant_id === grantId);
-    if (researchProject) {
-      grantIdField.val(researchProject.description);
     }
   };
 

--- a/app/javascript/views/plans/edit_details.js
+++ b/app/javascript/views/plans/edit_details.js
@@ -1,7 +1,11 @@
 import { Tinymce } from '../../utils/tinymce';
 import getConstant from '../../constants';
+import 'bootstrap-3-typeahead';
 
 $(() => {
+  const grantIdField = $('.grant-id-typeahead');
+  const grantIdHidden = $('input#plan_grant_number');
+
   Tinymce.init();
   $('#is_test').click((e) => {
     $('#plan_visibility').val($(e.target).is(':checked') ? 'is_test' : 'privately_visible');
@@ -53,6 +57,48 @@ $(() => {
     toggleCheckboxes(selections);
   };
 
+  const grantNumberInfo = (grantId) => {
+    return `Grant number: ${grantId}`;
+  }
+
+  const setUpTypeahead = () => {
+    if ($('.edit_plan').length) {
+      $.get('/research_projects.json', (data) => {
+        window.researchProjects = data;
+        const descriptionData = $.map(data, datum => datum.description);
+        grantIdField.typeahead({ source: descriptionData });
+      }).then(function() {
+        setInitialGrantProjectName();
+      });
+      grantIdField.on('change', () => {
+        const current = grantIdField.typeahead('getActive');
+        if (current) {
+          // match or partial match found
+          const currentResearchProject = window.researchProjects.find((datum) => {
+            const fixString = string => String(string).toLowerCase();
+            return fixString(datum.description) === fixString(current);
+          });
+          if (currentResearchProject) {
+            const grantId = currentResearchProject.grant_id
+            $('#grant_number_info').html(grantNumberInfo(grantId));
+            grantIdHidden.val(grantId);
+          }
+        } else {
+          $('#grant_number_info').html(grantNumberInfo(''));
+          grantIdHidden.val('');
+        }
+      });
+    }
+  };
+
+  const setInitialGrantProjectName = () => {
+    const grantId = grantIdHidden.val();
+    const researchProject = researchProjects.find(datum => datum.grant_id === grantId);
+    if (researchProject) {
+      grantIdField.val(researchProject.description);
+    }
+  };
+
   $('#other-guidance-orgs').find('input[type="checkbox"]').click((e) => {
     const checkbox = $(e.target);
     // Since this is the modal window, copy any selections over to the priority list
@@ -70,9 +116,12 @@ $(() => {
     }
     syncGuidance(checkbox.closest('ul[id]'));
   });
+
   $('#priority-guidance-orgs').find('input[type="checkbox"]').click((e) => {
     syncGuidance($(e.target).closest('ul[id]'));
   });
 
   toggleCheckboxes($('#priority-guidance-orgs input[type="checkbox"]:checked').map((i, el) => $(el).val()).get());
+
+  setUpTypeahead();
 });

--- a/app/models/research_project.rb
+++ b/app/models/research_project.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal
+
+class ResearchProject < Struct.new(:grant_id, :description)
+
+  def to_json(val = nil)
+    { grant_id: grant_id, description: description }.to_json
+  end
+
+  def id
+    object_id
+  end
+
+end

--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -30,11 +30,16 @@
       </div>
       <div class="form-group"><!-- grant_number -->
         <div class="col-md-12">
-          <%= f.label(:grant_number, _('Grant number'), class: 'control-label') %>
+          <%= label_tag(:plan_grant_number_name, _('Grant number'), class: 'control-label') %>
         </div>
+
         <div class="col-md-8">
-          <%= f.text_field(:grant_number, class: "form-control", "aria-required": false, 'data-toggle': 'tooltip',
-            title: _('Grant reference number if applicable [POST-AWARD DMPs ONLY]')) %>
+          <%= text_field_tag(:plan_grant_number_name, '',
+              class: "grant-id-typeahead form-control",
+              autocomplete: "off",
+              aria: { required: false }) %>
+          <%= f.hidden_field(:grant_number) %>
+          <span class="text-muted" id="grant_number_info">Grant number: <%= @plan.grant_number %></span>
         </div>
       </div>
       <div class="form-group"><!-- description -->

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,11 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  if File.exist?(Rails.root.join('tmp', 'caching-dev.txt'))
+    config.action_controller.perform_caching = true
+  else
+    config.action_controller.perform_caching = false
+  end
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,4 +256,15 @@ Rails.application.routes.draw do
     resources :users, only: [:edit, :update]
     resources :notifications, except: [:show]
   end
+
+  get "research_projects/search", action: "search",
+                                  controller: "research_projects",
+                                  constraints: { format: "json" }
+
+  get "research_projects/(:type)", action: "index",
+                                   controller: "research_projects",
+                                   constraints: { format: "json" }
+
+
+
 end

--- a/lib/open_aire_request.rb
+++ b/lib/open_aire_request.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal
+
+require "open-uri"
+require "nokogiri"
+
+class OpenAireRequest
+
+  API_URL = "https://api.openaire.eu/projects/dspace/%s/ALL/ALL"
+
+  attr_reader :funder_type
+
+  def initialize(funder_type)
+    @funder_type = funder_type
+  end
+
+  def get!
+    Rails.logger.info("Fetching fresh data from #{API_URL % funder_type}")
+    data = open(API_URL % funder_type)
+    Rails.logger.info("Fetched fresh data from #{API_URL % funder_type}")
+    @results = Nokogiri::XML(data).xpath("//pair/displayed-value").map do |node|
+      parts = node.content.split("-")
+      grant_id = parts.shift.to_s.strip
+      description = parts.join(" - ").strip
+      ResearchProject.new(grant_id, description)
+    end
+    return self
+  end
+
+  def results
+    Array(@results)
+  end
+
+end

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@rails/webpacker": "3.5",
     "bootstrap": "^4.1.3",
+    "bootstrap-3-typeahead": "^4.0.2",
     "bootstrap-sass": "^3.3.7",
     "chart.js": "^2.7.2",
     "eslint": "^5.8.0",

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -11,6 +11,21 @@ RSpec.describe "Plans", type: :feature do
     @template     = create(:template, org: @org)
     @user         = create(:user, org: @org)
     sign_in(@user)
+
+    OpenURI.expects(:open_uri).returns(<<~XML
+      <form-value-pairs>
+        <value-pairs value-pairs-name="H2020projects" dc-term="relation">
+          <pair>
+            <displayed-value>
+              115797 - INNODIA - Translational approaches to disease modifying therapy of type 1 diabetes: an innovative approach towards understanding and arresting type 1 diabetes – Sofia ref.: 115797
+            </displayed-value>
+            <stored-value>info:eu-repo/grantAgreement/EC/H2020/115797/EU</stored-value>
+          </pair>
+        </value-pairs>
+      </form-value-pairs>
+    XML
+    )
+
   end
 
   scenario "User creates a new Plan", :js do
@@ -36,7 +51,7 @@ RSpec.describe "Plans", type: :feature do
     expect(page).to have_css("input[type=text][value='#{@plan.title}']")
 
     within "#edit_plan_#{@plan.id}" do
-      fill_in "Grant number", with: "1234"
+      fill_in "Grant number", with: "Innodia"
       fill_in "Project abstract", with: "Plan abstract..."
       fill_in "ID", with: "ABCDEF"
       fill_in "ORCID iD", with: "My ORCID"
@@ -50,7 +65,7 @@ RSpec.describe "Plans", type: :feature do
     expect(current_path).to eql(overview_plan_path(@plan))
     expect(@plan.title).to eql("My test plan")
     expect(@plan.funder_name).to eql(@funding_org.name)
-    expect(@plan.grant_number).to eql("1234")
+    expect(@plan.grant_number).to eql("115797")
     expect(@plan.description).to eql("Plan abstract...")
     expect(@plan.identifier).to eql("ABCDEF")
     name = [@user.firstname, @user.surname].join(" ")

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,6 +1276,11 @@ bonjour@^3.5.0:
     multicast-dns "^6.0.1"
     multicast-dns-service-types "^1.1.0"
 
+bootstrap-3-typeahead@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/bootstrap-3-typeahead/-/bootstrap-3-typeahead-4.0.2.tgz#cb1c969044856862096fc8c71cc21b3acbb50412"
+  integrity sha1-yxyWkESFaGIJb8jHHMIbOsu1BBI=
+
 bootstrap-sass@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"


### PR DESCRIPTION
Changes proposed in this PR:
- Adds a typeahead select to the grant ID field so that users can choose their research project from https://api.openaire.eu/projects/dspace/h2020/ALL/ALL