### PR TITLE
[Don't merge yet] Integrate Zenodo API for Plan PDF uploads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,6 +172,11 @@ gem "dotenv-rails"
 
 gem 'activerecord-session_store'
 
+gem "oj"
+
+gem "oauth2", "~> 1.4"
+
+gem "rest-client", "~> 2.0"
 
 # ------------------------------------------------
 # ENVIRONMENT SPECIFIC DEPENDENCIES

--- a/Gemfile
+++ b/Gemfile
@@ -172,8 +172,6 @@ gem "dotenv-rails"
 
 gem 'activerecord-session_store'
 
-gem "oj"
-
 gem "oauth2", "~> 1.4"
 
 gem "rest-client", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,6 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (3.7.12)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -532,7 +531,6 @@ DEPENDENCIES
   mocha
   mysql2 (~> 0.4.10)
   oauth2 (~> 1.4)
-  oj
   omniauth
   omniauth-orcid
   omniauth-shibboleth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       devise (>= 4.0.0)
     diff-lcs (1.3)
     docile (1.3.1)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.2)
     dotenv-rails (2.7.2)
       dotenv (= 2.7.2)
@@ -202,6 +204,8 @@ GEM
       actionpack
       nokogiri
       rubyzip (>= 1.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -257,6 +261,7 @@ GEM
     multipart-post (2.0.0)
     mysql2 (0.4.10)
     nenv (0.3.0)
+    netrc (0.11.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
@@ -268,6 +273,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    oj (3.7.12)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -345,6 +351,10 @@ GEM
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rollbar (2.19.3)
       multi_json
     rspec (3.8.0)
@@ -450,6 +460,9 @@ GEM
     tomparse (0.4.2)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicode-display_width (1.5.0)
     uniform_notifier (1.12.1)
     warden (1.2.7)
@@ -518,6 +531,8 @@ DEPENDENCIES
   mini_racer
   mocha
   mysql2 (~> 0.4.10)
+  oauth2 (~> 1.4)
+  oj
   omniauth
   omniauth-orcid
   omniauth-shibboleth
@@ -532,6 +547,7 @@ DEPENDENCIES
   rake
   recaptcha
   responders (~> 2.0)
+  rest-client (~> 2.0)
   rollbar
   rspec-collection_matchers
   rspec-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 class ApplicationController < ActionController::Base
 
-  # protect_from_forgery with: :exception
+  protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 class ApplicationController < ActionController::Base
 
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 

--- a/app/controllers/arpha/base_controller.rb
+++ b/app/controllers/arpha/base_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal
+class Arpha::BaseController < ApplicationController
+
+  include Arphaable
+
+  private
+
+
+end

--- a/app/controllers/arpha/connections_controller.rb
+++ b/app/controllers/arpha/connections_controller.rb
@@ -1,0 +1,18 @@
+class Arpha::ConnectionsController < Arpha::BaseController
+
+  def create
+    response = arpha_api_post(action: "get_api_key",
+                              username: params[:username],
+                              password: params[:password])
+
+    api_key = parse_arpha_xml(xml: response.body, node: "returnResult")
+    if api_key.present?
+      current_user.update!(arpha_api_key: api_key, arpha_username: params[:username])
+      redirect_to :back, notice: _("Successfully connected your Arpha account")
+    else
+      flash[:alert] = _("There was an error trying to connect your Arpha account: #{response.body}")
+      redirect_to :back
+    end
+  end
+
+end

--- a/app/controllers/arpha/plan_uploads_controller.rb
+++ b/app/controllers/arpha/plan_uploads_controller.rb
@@ -1,0 +1,20 @@
+class Arpha::PlanUploadsController < Arpha::BaseController
+
+  def create
+    @plan = current_user.plans.find(params[:plan_id])
+    if @plan.arpha_url?
+      redirect_to share_plan_url(@plan),
+                  notice: "Plan already uploaded to Arpha (link: #{@plan.arpha_url})"
+      return
+    end
+    if current_user.arpha_api_key?
+      @arpha_upload_service = ArphaUploadService.new(plan: @plan, user: current_user)
+      @arpha_upload_service.call
+      redirect_to @arpha_upload_service.link
+    else
+      flash[:alert] = _("Please connect your Arpha account before uploading to Arpha.")
+      redirect_to share_plan_url(@plan)
+    end
+  end
+
+end

--- a/app/controllers/arpha/plan_uploads_controller.rb
+++ b/app/controllers/arpha/plan_uploads_controller.rb
@@ -2,6 +2,7 @@ class Arpha::PlanUploadsController < Arpha::BaseController
 
   def create
     @plan = current_user.plans.find(params[:plan_id])
+    authorize @plan, :update?
     if @plan.arpha_url?
       redirect_to share_plan_url(@plan),
                   notice: "Plan already uploaded to Arpha (link: #{@plan.arpha_url})"

--- a/app/controllers/concerns/arphaable.rb
+++ b/app/controllers/concerns/arphaable.rb
@@ -1,0 +1,14 @@
+module Arphaable
+
+  private
+
+  def arpha_api_post(action:, **params)
+    RestClient.post(Arpha::BASE, params.merge(action: action), { content_type: :xml })
+  end
+
+  def parse_arpha_xml(xml:, node: )
+    value = Nokogiri(xml.to_s).xpath("//result/#{node}").text
+    value.presence || raise("Couldn't find node '#{node}' in body #{xml}")
+  end
+
+end

--- a/app/controllers/concerns/o_auth_able.rb
+++ b/app/controllers/concerns/o_auth_able.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal
+
+# Provides additional attributes for controllers that support OAuth functionality
+module OAuthAble
+
+  # List of trusted OAuth providers
+  OAUTH_PROVIDERS = %w[zenodo]
+
+  private
+
+  # A valid OAuth::Client object for a given provider. Will raise an exception if the
+  # provider hasn'tbe
+  #
+  # Returns OAuth::Client
+  # Raises StandardError
+  def client_for_oauth2_provider(provider)
+    raise "Unknown OAuth Provider" unless provider.downcase.in?(OAUTH_PROVIDERS)
+    @client_for_oauth2_provider ||= {}
+    @client_for_oauth2_provider[provider] ||= begin
+      OAuth2::Client.new(
+        ENV["#{provider.upcase}_CLIENT_ID"],
+        ENV["#{provider.upcase}_CLIENT_SECRET"],
+        site: provider.classify.constantize.const_get("BASE"),
+        logger: Logger.new(Rails.root.join("log", "#{provider}.log"), 'weekly')
+      )
+    end
+  end
+
+end

--- a/app/controllers/concerns/o_authable.rb
+++ b/app/controllers/concerns/o_authable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal
 
 # Provides additional attributes for controllers that support OAuth functionality
-module OAuthAble
+module OAuthable
 
   # List of trusted OAuth providers
   OAUTH_PROVIDERS = %w[zenodo]

--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -6,7 +6,7 @@ class Oauth2Controller < ApplicationController
 
 
   SCOPE_FOR_PROVIDER = {
-    'zenodo' => "deposit:write"
+    'zenodo' => "deposit:write deposit:actions"
   }
 
   # Base URL for this app. Will not use SSL if host is localhost

--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal
+
+class Oauth2Controller < ApplicationController
+
+  include OAuthAble
+
+
+  SCOPE_FOR_PROVIDER = {
+    'zenodo' => "deposit:write"
+  }
+
+  # Base URL for this app. Will not use SSL if host is localhost
+  REDIRECT_URI = begin
+    scheme = ENV['HOST'].to_s.starts_with?('localhost') ? 'http' : "https"
+    "#{scheme}://#{ENV['HOST']}/oauth2/callback/%{provider}"
+  end
+
+  def authorize
+    session[:"#{params[:provider]}_plan_id"] = params[:plan_id]
+    client = client_for_oauth2_provider(params[:provider])
+    redirect_to client.auth_code.authorize_url({
+      redirect_uri: REDIRECT_URI % params,
+      scope: SCOPE_FOR_PROVIDER[params[:provider]],
+      provider: params[:provider]
+    })
+  end
+
+  def callback
+    client = client_for_oauth2_provider(params[:provider])
+    @token = client.auth_code.get_token(params[:code],
+                                        redirect_uri: REDIRECT_URI % params)
+    current_user.update!(zenodo_access_token: @token.token)
+    @plan = current_user.plans.find_by(id: session[:"#{params[:provider]}_plan_id"])
+    session[:"#{params[:provider]}_plan_id"] = nil
+    if @plan
+      redirect_to share_plan_url(@plan),
+                  notice: "Successfully connected #{params[:provider]}"
+    else
+      redirect_to plans_url(custom: params[:custom]),
+                  notice: "Successfully connected #{params[:provider]}"
+    end
+
+  end
+
+end

--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -2,7 +2,7 @@
 
 class Oauth2Controller < ApplicationController
 
-  include OAuthAble
+  include OAuthable
 
 
   SCOPE_FOR_PROVIDER = {

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -73,18 +73,16 @@ class PlanExportsController < ApplicationController
   end
 
   def show_pdf
-    render pdf: file_name,
-           margin: @formatting[:margin],
-           footer: {
-             center: _("Created using %{application_name}. Last modified %{date}") % {
-               application_name: Rails.configuration.branding[:application][:name],
-               date: l(@plan.updated_at.to_date, format: :readable)
-              },
-             font_size: 8,
-             spacing:   (Integer(@formatting[:margin][:bottom]) / 2) - 4,
-             right:     "[page] of [topage]",
-             encoding: "utf8"
-           }
+    @pdf_renderer = Plan::PdfRenderer.new(@plan, {
+      selected_phase: @selected_phase,
+      formatting: @formatting,
+      show_coversheet: @show_coversheet,
+      show_sections_questions: @show_sections_questions,
+      show_unanswered: @show_unanswered,
+      show_custom_sections: @show_custom_sections,
+      public_plan: @public_plan,
+    })
+    send_data @pdf_renderer.to_pdf, filename: @pdf_renderer.file_name
   end
 
   def file_name

--- a/app/controllers/zenodo/base_controller.rb
+++ b/app/controllers/zenodo/base_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal
+
+class Zenodo::BaseController < ApplicationController
+end

--- a/app/controllers/zenodo/plan_uploads_controller.rb
+++ b/app/controllers/zenodo/plan_uploads_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal
 class Zenodo::PlanUploadsController < Zenodo::BaseController
 
-  include OAuthAble
+  include OAuthable
 
   def create
     @plan = current_user.plans.find(params[:plan_id])

--- a/app/controllers/zenodo/plan_uploads_controller.rb
+++ b/app/controllers/zenodo/plan_uploads_controller.rb
@@ -24,8 +24,4 @@ class Zenodo::PlanUploadsController < Zenodo::BaseController
     @client ||= client_for_oauth2_provider("zenodo")
   end
 
-  def token
-    @token ||= OAuth2::AccessToken.new(client, current_user.zenodo_access_token)
-  end
-
 end

--- a/app/controllers/zenodo/plan_uploads_controller.rb
+++ b/app/controllers/zenodo/plan_uploads_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal
+class Zenodo::PlanUploadsController < Zenodo::BaseController
+
+  include OAuthAble
+
+  def create
+    @plan = current_user.plans.find(params[:plan_id])
+    if @plan.zenodo_id?
+      redirect_to share_plan_url(@plan),
+                  notice: "Plan already uploaded to Zenodo (id: #{@plan.zenodo_id})"
+      return
+    end
+    if current_user.zenodo_access_token?
+      ZenodoUploadService.new(plan: @plan, user: current_user).call
+      redirect_to share_plan_url(@plan), notice: "Upload to Zenodo was successful"
+    else
+      redirect_to authorize_oauth2_url(provider: "zenodo")
+    end
+  end
+
+  private
+
+  def client
+    @client ||= client_for_oauth2_provider("zenodo")
+  end
+
+  def token
+    @token ||= OAuth2::AccessToken.new(client, current_user.zenodo_access_token)
+  end
+
+end

--- a/app/controllers/zenodo/plan_uploads_controller.rb
+++ b/app/controllers/zenodo/plan_uploads_controller.rb
@@ -5,6 +5,7 @@ class Zenodo::PlanUploadsController < Zenodo::BaseController
 
   def create
     @plan = current_user.plans.find(params[:plan_id])
+    authorize @plan, :update?
     if @plan.zenodo_id?
       redirect_to share_plan_url(@plan),
                   notice: "Plan already uploaded to Zenodo (id: #{@plan.zenodo_id})"

--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -39,6 +39,18 @@ module ExportsHelper
     "<strong>#{prefix}</strong> #{attribution.join(', ')}"
   end
 
+  def download_plan_page_title(plan, phase, hash)
+    # If there is more than one phase show the plan title and phase title
+    return hash[:phases].many? ? "#{plan.title} - #{phase[:title]}" : plan.title
+  end
+
+  def display_section?(customization, section, show_custom_sections)
+    display = !customization
+    display ||= customization && !section[:modifiable]
+    display ||= customization && section[:modifiable] && show_custom_sections
+    return display
+  end
+
   private
 
   def get_margin_value_for_side(side)

--- a/app/helpers/plans_helper.rb
+++ b/app/helpers/plans_helper.rb
@@ -38,15 +38,4 @@ module PlansHelper
     end
   end
 
-  def download_plan_page_title(plan, phase, hash)
-    # If there is more than one phase show the plan title and phase title
-    return hash[:phases].many? ? "#{plan.title} - #{phase[:title]}" : plan.title
-  end
-
-  def display_section?(customization, section, show_custom_sections)
-    display = !customization
-    display ||= customization && !section[:modifiable]
-    display ||= customization && section[:modifiable] && show_custom_sections
-    return display
-  end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -26,10 +26,12 @@
 #  created_at                        :datetime
 #  updated_at                        :datetime
 #  template_id                       :integer
+#  zenodo_id                         :integer
 #
 # Indexes
 #
 #  index_plans_on_template_id  (template_id)
+#  index_plans_on_zenodo_id    (zenodo_id)
 #
 # Foreign Keys
 #

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -8,6 +8,7 @@
 # Table name: plans
 #
 #  id                                :integer          not null, primary key
+#  arpha_url                         :string
 #  complete                          :boolean          default(FALSE)
 #  data_contact                      :string
 #  data_contact_email                :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: users
@@ -30,6 +29,7 @@
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0)
 #  surname                :string
+#  zenodo_access_token    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  invited_by_id          :integer

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@
 #  accept_terms           :boolean
 #  active                 :boolean          default(TRUE)
 #  api_token              :string
+#  arpha_api_key          :string
+#  arpha_username         :string
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime

--- a/app/renderers/plan.rb
+++ b/app/renderers/plan.rb
@@ -1,0 +1,3 @@
+class Plan
+
+end

--- a/app/renderers/plan/pdf_renderer.rb
+++ b/app/renderers/plan/pdf_renderer.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal
+
+# Render a Plan record as a PDF file
+class Plan::PdfRenderer
+
+  require 'wicked_pdf'
+
+  include ActionView::Helpers::RenderingHelper
+
+  ##
+  # Default font size for the PDF
+  FONT_SIZE = 8
+
+  ENCODING = "UTF-8"
+
+  DEFAULT_OPTIONS = {
+    font_size: FONT_SIZE,
+    right: "[page] of [topage]",
+    encoding: ENCODING,
+  }
+
+
+  attr_reader :plan
+
+  attr_reader :options
+
+  attr_reader :formatting
+
+  attr_reader :show_coversheet
+
+  attr_reader :show_sections_questions
+
+  attr_reader :show_unanswered
+
+  attr_reader :show_custom_sections
+
+  attr_reader :public_plan
+
+  attr_reader :selected_phase
+
+
+  # Create a new PdfRenderer
+  #
+  # plan - The Plan we're creating a new PDF for
+  #
+  # options - Hash of options (default: {}):
+  #           :selected_phase  -         The Phase we've selected to display.
+  #           :show_coversheet -         Should the PDF include the cover sheet
+  #                                      (optional).
+  #           :show_sections_questions - Should the PDF show the sections questions
+  #                                      (optional).
+  #           :show_unanswered -         Should the PDF show unanswered questions
+  #                                      (optional).
+  #           :show_custom_sections -    Should the PDF show custom sections (optional).
+  #           :public_plan -             Is this a public Plan? (optional).
+  #           :font_size -               Integer with PDF font size (default: 8).
+  def initialize(plan, **options)
+    @plan    = plan
+    @options = options
+    options[:font_size] = options.dig(:formatting, :font_size) || FONT_SIZE
+    options.reverse_merge!(DEFAULT_OPTIONS)
+
+    # Set template variables passed in from the controller
+    @selected_phase          = options.delete(:selected_phase)
+    raise "You must select a phase" if selected_phase.nil?
+    @show_coversheet         = !!options.delete(:show_coversheet)
+    @show_sections_questions = !!options.delete(:show_sections_questions)
+    @show_unanswered         = !!options.delete(:show_unanswered)
+    @show_custom_sections    = !!options.delete(:show_custom_sections)
+    @public_plan             = !!options.delete(:public_plan)
+    @formatting = options.delete(:formatting) || @plan.settings(:export).formatting
+
+    @options.reverse_merge!({
+      margin: @formatting,
+      spacing: (Integer(@formatting[:margin][:bottom]) / 2) - 4,
+      footer: {
+        center: _("Created using %{application_name}. Last modified %{date}") % {
+          application_name: Rails.configuration.branding[:application][:name],
+          date: I18n.l(@plan.updated_at.to_date, format: :readable)
+        },
+      }
+    })
+  end
+
+  # The PDF content as a PDF
+  #
+  # Returns String
+  def body
+    @pdf_content ||= WickedPdf.new.pdf_from_string(html_content, options)
+  end
+
+  alias to_pdf body
+
+  # The PDF content as HTML
+  #
+  # Returns String
+  def html_content
+    @html_content ||= begin
+      view = ActionView::Base.new(ActionController::Base.view_paths, {})
+      view.extend(ExportsHelper)
+      view.assign(formatting: formatting)
+      view.assign(hash: plan.as_pdf(show_coversheet))
+      view.assign(plan: plan)
+      view.assign(selected_phase: selected_phase)
+      view.assign(show_coversheet: show_coversheet)
+      view.assign(show_sections_questions: show_sections_questions)
+      view.assign(show_unanswered: show_unanswered)
+      view.assign(show_custom_sections: show_custom_sections)
+      view.assign(public_plan: public_plan)
+      view.render(file: 'public_pages/plan_export.pdf.erb')
+    end
+  end
+
+  # The name of the PDF file we're creating
+  #
+  # Returns String
+  def file_name
+    "#{plan.title}.pdf"
+  end
+
+  # NOTE: We're using File instead of Tempfile here, since the object is being sent to
+  # a third party API using the RestClient library. T
+  #
+  # Returns File
+  def tmp_file
+    @tmp_file ||= begin
+      f = File.open(tmp_file_path, 'w', encoding: ENCODING)
+      f.binmode
+      f.write(body)
+      f.close
+      File.open(tmp_file_path, 'r', encoding: ENCODING)
+    end
+  end
+
+  alias create_tmp_file tmp_file
+
+  # Remove the temporary file we created in {tmp_file}
+  #
+  # Returns Integer
+  def destroy_tmp_file!
+    File.delete(tmp_file_path)
+  end
+
+  private
+
+  def tmp_file_path
+    ensure_tmp_dir_exists!
+    File.join(tmp_dir, file_name)
+  end
+
+  def tmp_dir
+    Rails.root.join("tmp", "pdfs")
+  end
+
+  def ensure_tmp_dir_exists!
+    FileUtils.mkdir(tmp_dir) unless Dir.exists?(tmp_dir)
+  end
+
+end

--- a/app/services/arpha_upload_service.rb
+++ b/app/services/arpha_upload_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal
+
+class ArphaUploadService
+
+  include Arphaable
+
+  TEMPLATE_NAME = "arpha/plans/show.xml.erb"
+
+  attr_reader :user
+  attr_reader :plan
+  attr_reader :link
+
+  delegate :logger, to: :Rails
+
+  def initialize(plan:, user:)
+    @plan = plan
+    @user = user
+  end
+
+  def call
+    ##
+    # Authenticate user
+    authenticate_user
+
+    ##
+    # Validate the document before submitting
+    validate_document
+
+    ##
+    # Submit the document and fetch the link for redirects
+    @link = fetch_submission_link
+  end
+
+  private
+
+  def authenticate_user
+    response = arpha_api_post(action: "authenticate",
+                              username: user.arpha_username,
+                              api_key: user.arpha_api_key)
+
+    if parse_arpha_xml(xml: response.body, node: "returnCode") == "0"
+      logger.info("Successfully authenticated user with Arpha API")
+    else
+      logger.warn("Couldn't authente user with Arpha API")
+    end
+  end
+
+  def validate_document
+    response = arpha_api_post(action: "validate_document",
+                              xml: document_xml)
+
+    if parse_arpha_xml(xml: response.body, node: "returnCode") == "0"
+      logger.info "XML docuemnt validated"
+    else
+      logger.warn "XML Document was invalid!"
+    end
+  end
+
+  def fetch_submission_link
+    response = arpha_api_post(action: "import_document",
+                              xml: document_xml,
+                              username: @user.arpha_username,
+                              api_key: @user.arpha_api_key)
+    parse_arpha_xml(xml: response.body, node: "document_autologin_link")
+  end
+
+  def document_xml
+    @document_xml ||= view.render({
+      template: TEMPLATE_NAME,
+      layout: false,
+      format: "xml"
+    })
+  end
+
+  def view
+    @view ||= ActionView::Base.new(ActionController::Base.view_paths, { plan: plan })
+  end
+
+end

--- a/app/services/zenodo_upload_service.rb
+++ b/app/services/zenodo_upload_service.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal
+
+class ZenodoUploadService
+
+  require "rest_client"
+
+  ##
+  # Headers for JSON requests
+  JSON_HEADERS = { 'Content-Type' => 'application/json' }.freeze
+
+  ##
+  # Headers for multipart requests
+  MULTIPART_HEADERS = { 'Content-Type' => 'multipart/form-data' }.freeze
+
+  attr_reader :user
+
+  attr_reader :plan
+
+  def initialize(plan:, user:)
+    @plan = plan
+    @user = user
+  end
+
+  def call
+    # Create a new Deposition on the Zenodo API
+    response = create_deposition_on_api!
+
+    # Grab the API's JSON response
+    @deposition_id = Oj.load(response.body)['id']
+    @plan.update!(zenodo_id: @deposition_id)
+    create_file_on_api!
+    # Return true
+    true
+  end
+
+  private
+
+  def selected_phase
+    @selected_phase ||= begin
+      _sp = plan.phases.order("phases.updated_at DESC")
+                      .detect { |p| p.visibility_allowed?(plan) }
+      _sp ||= plan.phases.first
+    end
+  end
+
+  def formatting
+    plan.settings(:export).formatting
+  end
+
+  def pdf_renderer
+    @pdf_renderer ||= Plan::PdfRenderer.new(plan, {
+      selected_phase: selected_phase,
+      formatting: formatting,
+      show_coversheet: true,
+      show_sections_questions: true,
+      show_unanswered: true,
+      show_custom_sections: true,
+      public_plan: true,
+    })
+  end
+
+  def create_deposition_on_api!
+    RestClient.post("#{Zenodo::BASE}/api/deposit/depositions"\
+                               "?access_token=#{access_token}", {
+      title: plan.title,
+      metadata: {
+        upload_type: "other",
+        publication_type: "other",
+        publication_date: plan.created_at.iso8601,
+        title: plan.title,
+        description: plan.description.presence || plan.title,
+        grants: [ {id: plan.grant_number }],
+      },
+    }.to_json, JSON_HEADERS)
+  end
+
+  def create_file_on_api!
+    begin
+      # Create a file on the local disk for the PDF...
+      pdf_renderer.create_tmp_file
+      # Post this file our newly created Deposition...
+      url = "#{BASE}/api/deposit/depositions/#@deposition_id/files"\
+              "?access_token=#{user.zenodo_access_token}"
+      response = RestClient.post(url, { file: pdf_renderer.tmp_file }, {
+        params: {
+          filename: pdf_renderer.file_name,
+          'Content-Type' => 'multipart/form-data'
+        }
+      })
+      # Nomatter what, destroy the new file
+    ensure
+      pdf_renderer.destroy_tmp_file!
+    end
+  end
+
+  def access_token
+    user.zenodo_access_token
+  end
+
+end

--- a/app/views/arpha/authors/_author.xml.erb
+++ b/app/views/arpha/authors/_author.xml.erb
@@ -1,0 +1,12 @@
+<author 
+  first_name="<%= author.firstname %>" 
+  middle_name="" 
+  last_name="<%= author.surname %>" 
+  co_author="1"
+  right="1" 
+  country="united kingdom" 
+  city="" 
+  affiliation="" 
+  title="1" 
+  email="<%= author.email %>" 
+  submitting_author="<%= @plan.owner == author ? 1 : 0 %>" />

--- a/app/views/arpha/phases/_phase.xml.erb
+++ b/app/views/arpha/phases/_phase.xml.erb
@@ -1,0 +1,10 @@
+<fields>
+  <subsection_title>
+    <value><%= @phase.title %></value>
+  </subsection_title>
+  <content>
+    <value>
+      <%= @phase.description %>
+    </value>
+  </content>
+</fields>

--- a/app/views/arpha/plans/show.html.erb
+++ b/app/views/arpha/plans/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Arpha::Plans#show</h1>
+<p>Find me in app/views/arpha/plans/show.html.erb</p>

--- a/app/views/arpha/plans/show.xml.erb
+++ b/app/views/arpha/plans/show.xml.erb
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document>
+  <document_info>
+    <document_type>Data Management Plan</document_type>
+    <journal_name>Research Ideas and Outcomes</journal_name>
+  </document_info>
+
+  <authors>
+    <%= render partial: "arpha/authors/author",
+               collection: @plan.authors,
+               as: "author",
+               locals: { plan: @plan } %>
+
+  </authors>
+
+  <objects>
+    <article_metadata>
+      <title_and_authors>
+        <fields>
+          <title>
+            <value><%= @plan.title %></value>
+          </title>
+        </fields>
+      </title_and_authors>
+
+      <abstract>
+        <fields>
+          <abstract>
+            <value>
+              <%= @plan.description %>
+            </value>
+          </abstract>
+        </fields>
+      </abstract>
+
+      <funding_agencies>
+      </funding_agencies>
+
+      <funding_programme>
+      </funding_programme>
+
+      <project_info>
+      </project_info>
+
+      <hosting_institution>
+      </hosting_institution>
+
+      <ethics_and_security>
+      </ethics_and_security>
+
+
+      <author_contributions>
+      </author_contributions>
+
+      <conflicts_of_interest>
+      </conflicts_of_interest>
+
+    </article_metadata>
+
+    <main_text>
+      <fields>
+        <main_text>
+          <value><%= @plan.description %></value>
+        </main_text>
+        <main_text_section_title>
+          <value>Introduction</value>
+        </main_text_section_title>
+      </fields>
+      <subsection>
+        <%= render partial: "arpha/phases/phase",
+                   collection: @plan.phases,
+                   locals: { plan: @plan } %>
+      </subsection>
+    </main_text>
+
+    <acknowledgements>
+    </acknowledgements>
+    
+    <references>
+    </references>
+    
+    <supplementary_files>
+    </supplementary_files>
+    
+    <figures>
+    </figures>
+    
+    <tables>
+    </tables>
+    
+    <endnotes>
+    </endnotes>
+    
+  </objects>
+</document>

--- a/app/views/plans/share.html.erb
+++ b/app/views/plans/share.html.erb
@@ -10,4 +10,20 @@
   <div class="col-md-12">
     <%= render partial: 'share_form', layout: 'navigation', locals: { plan: @plan } %>
   </div>
+
+  <div class="col-xs-12">
+    <h2>Share on Zenodo</h2>
+    <% if current_user.zenodo_access_token? && @plan.zenodo_id? %>
+      Already shared on Zenodo
+    <% elsif current_user.zenodo_access_token? %>
+      <%= link_to("Share on Zenodo",
+          zenodo_plan_uploads_url(plan_id: @plan.id),
+          method: "post", class: "btn btn-primary") %>
+    <% else %>
+      <%= link_to("Connect with Zenodo",
+          authorize_oauth2_path(provider: "zenodo", plan_id: @plan.id),
+          class: "btn btn-primary") %>
+
+    <% end %>
+  </div>
 </div>

--- a/app/views/plans/share.html.erb
+++ b/app/views/plans/share.html.erb
@@ -11,7 +11,7 @@
     <%= render partial: 'share_form', layout: 'navigation', locals: { plan: @plan } %>
   </div>
 
-  <div class="col-xs-12">
+  <div class="col-xs-12 col-sm-6">
     <h2>Share on Zenodo</h2>
     <% if current_user.zenodo_access_token? && @plan.zenodo_id? %>
       Already shared on Zenodo
@@ -25,5 +25,49 @@
           class: "btn btn-primary") %>
 
     <% end %>
+  </div>
+
+  <div class="col-xs-12 col-sm-6">
+    <h2>Share on Arpha</h2>
+    <% if current_user.arpha_api_key? && @plan.arpha_url? %>
+      <%= link_to "View on Arpha", @plan.arpha_url, class: "btn btn-primary" %>
+    <% elsif current_user.arpha_api_key? %>
+      <%= link_to "Share on Arpha", arpha_plan_uploads_path(plan_id: @plan.id),
+                  method: :post, class: "btn btn-primary" %>
+    <% else %>
+      <%= link_to "Connect to Arpha", '#',
+                  class: "btn btn-primary",
+                  data: { toggle: "modal", target: ".arpha_login_modal" } %>
+    <% end %>
+  </div>
+
+</div>
+
+
+<div class="modal fade arpha_login_modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <button type="button" class="close pull-right" data-dismiss="modal" aria-label="<%= _('Cancel') %>">
+          <span class="fa fa-times" aria-hidden="true">&nbsp;</span>
+        </button>
+        <h2><%= _('Connect to Arpha') %></h2>
+        <p>
+          <%= _("To upload your DMP to Arpha, you'll need to create an account with <a href='https://pensoft.net' target='_blank'>Pensoft</a>. Once your Pensoft account is created, you can fill in your username and password below to connect.").html_safe %>
+        </p>
+        <%= form_tag(arpha_connections_path) do %>
+          <div class="form-group">
+            <%= label_tag(:username, "Pensoft username", class: "form-label") %>
+            <%= email_field_tag(:username, current_user.email, class: "form-control") %>
+          </div>
+          <div class="form-group">
+            <%= label_tag(:password, "Pensoft password", class: "form-label") %>
+            <%= password_field_tag(:password, "", class: "form-control") %>
+            <em class="text-muted"><%= _("We don't store this at all") %></em>
+          </div>
+          <%= submit_tag "Connect", class: "btn btn-primary" %>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,7 @@ module DMPRoadmap
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
+    config.filter_parameters += [:password, :access_token]
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true

--- a/config/initializers/arpha.rb
+++ b/config/initializers/arpha.rb
@@ -1,0 +1,3 @@
+module Arpha
+  BASE = "https://arpha.pensoft.net/api.php?"
+end

--- a/config/initializers/oauth_2.rb
+++ b/config/initializers/oauth_2.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal
+
+module OAuth2
+  ENV["HOST"] || warn("No HOST ENV variable found. OAuth 2.0 might not work as expected")
+end

--- a/config/initializers/zenodo.rb
+++ b/config/initializers/zenodo.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal
+
+module Zenodo
+
+  ENV["ZENODO_CLIENT_ID"] || warn("No ZENODO_CLIENT_ID ENV variable found.")
+
+  ENV["ZENODO_CLIENT_SECRET"] || warn("No ZENODO_CLIENT_SECRET ENV variable found.")
+
+  # Base URL for the Zenodo API. Will default to sandbox unless in production mode
+  BASE = begin
+    Rails.env.production? ? 'https://zenodo.org' : 'https://sandbox.zenodo.org'
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,14 @@ Rails.application.routes.draw do
 
   end
 
+  namespace :arpha do
+
+    resources :connections, only: [:create]
+
+    resources :plan_uploads, only: [:create]
+
+  end
+
   devise_for( :users, controllers: {
     registrations: "registrations",
     passwords: 'passwords',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,15 @@
 Rails.application.routes.draw do
 
+  get "oauth2/authorize/:provider" => 'oauth2#authorize', as: "authorize_oauth2"
+
+  get "oauth2/callback/:provider" => 'oauth2#callback', as: "callback_oauth2"
+
+  namespace :zenodo do
+
+    resources :plan_uploads, only: [:create]
+
+  end
+
   devise_for( :users, controllers: {
     registrations: "registrations",
     passwords: 'passwords',

--- a/db/migrate/20190507110803_add_zenodo_access_token_to_users.rb
+++ b/db/migrate/20190507110803_add_zenodo_access_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddZenodoAccessTokenToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :zenodo_access_token, :string
+  end
+end

--- a/db/migrate/20190507132706_add_zenodo_id_to_plans.rb
+++ b/db/migrate/20190507132706_add_zenodo_id_to_plans.rb
@@ -1,0 +1,6 @@
+class AddZenodoIdToPlans < ActiveRecord::Migration
+  def change
+    add_column :plans, :zenodo_id, :integer
+    add_index :plans, :zenodo_id
+  end
+end

--- a/db/migrate/20190510140746_add_arpha_api_key_and_pensoft_username_to_users.rb
+++ b/db/migrate/20190510140746_add_arpha_api_key_and_pensoft_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddArphaApiKeyAndPensoftUsernameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :arpha_api_key, :string
+    add_column :users, :arpha_username, :string
+  end
+end

--- a/db/migrate/20190510140844_add_arpha_url_to_plans.rb
+++ b/db/migrate/20190510140844_add_arpha_url_to_plans.rb
@@ -1,0 +1,5 @@
+class AddArphaUrlToPlans < ActiveRecord::Migration
+  def change
+    add_column :plans, :arpha_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181025220743) do
+ActiveRecord::Schema.define(version: 20190507132706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,16 @@ ActiveRecord::Schema.define(version: 20181025220743) do
     t.integer  "identifier_scheme_id"
   end
 
+  create_table "org_regions", force: :cascade do |t|
+    t.integer  "org_id"
+    t.integer  "region_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "org_regions", ["org_id"], name: "index_org_regions_on_org_id", using: :btree
+  add_index "org_regions", ["region_id"], name: "index_org_regions_on_region_id", using: :btree
+
   create_table "org_token_permissions", force: :cascade do |t|
     t.integer  "org_id"
     t.integer  "token_permission_type_id"
@@ -156,7 +166,6 @@ ActiveRecord::Schema.define(version: 20181025220743) do
     t.datetime "updated_at",                             null: false
     t.boolean  "is_other",               default: false, null: false
     t.string   "sort_name"
-    t.integer  "region_id"
     t.integer  "language_id"
     t.string   "logo_uid"
     t.string   "logo_name"
@@ -208,9 +217,11 @@ ActiveRecord::Schema.define(version: 20181025220743) do
     t.string   "principal_investigator_phone"
     t.boolean  "feedback_requested",                default: false
     t.boolean  "complete",                          default: false
+    t.integer  "zenodo_id"
   end
 
   add_index "plans", ["template_id"], name: "index_plans_on_template_id", using: :btree
+  add_index "plans", ["zenodo_id"], name: "index_plans_on_zenodo_id", using: :btree
 
   create_table "plans_guidance_groups", force: :cascade do |t|
     t.integer "guidance_group_id"
@@ -267,11 +278,18 @@ ActiveRecord::Schema.define(version: 20181025220743) do
 
   add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id", using: :btree
 
+  create_table "region_languages", force: :cascade do |t|
+    t.integer  "region_id"
+    t.integer  "language_id"
+    t.boolean  "default",     default: false, null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+  end
+
   create_table "regions", force: :cascade do |t|
-    t.string  "abbreviation"
-    t.string  "description"
-    t.string  "name"
-    t.integer "super_region_id"
+    t.string   "name",       limit: 30, null: false
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
   end
 
   create_table "roles", force: :cascade do |t|
@@ -415,6 +433,7 @@ ActiveRecord::Schema.define(version: 20181025220743) do
     t.integer  "language_id"
     t.string   "recovery_email"
     t.boolean  "active",                            default: true
+    t.string   "zenodo_access_token"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
@@ -442,10 +461,11 @@ ActiveRecord::Schema.define(version: 20181025220743) do
   add_foreign_key "notification_acknowledgements", "users"
   add_foreign_key "org_identifiers", "identifier_schemes"
   add_foreign_key "org_identifiers", "orgs"
+  add_foreign_key "org_regions", "orgs"
+  add_foreign_key "org_regions", "regions"
   add_foreign_key "org_token_permissions", "orgs"
   add_foreign_key "org_token_permissions", "token_permission_types"
   add_foreign_key "orgs", "languages"
-  add_foreign_key "orgs", "regions"
   add_foreign_key "phases", "templates"
   add_foreign_key "plans", "templates"
   add_foreign_key "plans_guidance_groups", "guidance_groups"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,16 +139,6 @@ ActiveRecord::Schema.define(version: 20190507132706) do
     t.integer  "identifier_scheme_id"
   end
 
-  create_table "org_regions", force: :cascade do |t|
-    t.integer  "org_id"
-    t.integer  "region_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  add_index "org_regions", ["org_id"], name: "index_org_regions_on_org_id", using: :btree
-  add_index "org_regions", ["region_id"], name: "index_org_regions_on_region_id", using: :btree
-
   create_table "org_token_permissions", force: :cascade do |t|
     t.integer  "org_id"
     t.integer  "token_permission_type_id"
@@ -166,6 +156,7 @@ ActiveRecord::Schema.define(version: 20190507132706) do
     t.datetime "updated_at",                             null: false
     t.boolean  "is_other",               default: false, null: false
     t.string   "sort_name"
+    t.integer  "region_id"
     t.integer  "language_id"
     t.string   "logo_uid"
     t.string   "logo_name"
@@ -278,18 +269,11 @@ ActiveRecord::Schema.define(version: 20190507132706) do
 
   add_index "questions_themes", ["question_id"], name: "index_questions_themes_on_question_id", using: :btree
 
-  create_table "region_languages", force: :cascade do |t|
-    t.integer  "region_id"
-    t.integer  "language_id"
-    t.boolean  "default",     default: false, null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-  end
-
   create_table "regions", force: :cascade do |t|
-    t.string   "name",       limit: 30, null: false
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+    t.string  "abbreviation"
+    t.string  "description"
+    t.string  "name"
+    t.integer "super_region_id"
   end
 
   create_table "roles", force: :cascade do |t|
@@ -461,11 +445,10 @@ ActiveRecord::Schema.define(version: 20190507132706) do
   add_foreign_key "notification_acknowledgements", "users"
   add_foreign_key "org_identifiers", "identifier_schemes"
   add_foreign_key "org_identifiers", "orgs"
-  add_foreign_key "org_regions", "orgs"
-  add_foreign_key "org_regions", "regions"
   add_foreign_key "org_token_permissions", "orgs"
   add_foreign_key "org_token_permissions", "token_permission_types"
   add_foreign_key "orgs", "languages"
+  add_foreign_key "orgs", "regions"
   add_foreign_key "phases", "templates"
   add_foreign_key "plans", "templates"
   add_foreign_key "plans_guidance_groups", "guidance_groups"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190507132706) do
+ActiveRecord::Schema.define(version: 20190510140844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 20190507132706) do
     t.boolean  "feedback_requested",                default: false
     t.boolean  "complete",                          default: false
     t.integer  "zenodo_id"
+    t.string   "arpha_url"
   end
 
   add_index "plans", ["template_id"], name: "index_plans_on_template_id", using: :btree
@@ -418,6 +419,8 @@ ActiveRecord::Schema.define(version: 20190507132706) do
     t.string   "recovery_email"
     t.boolean  "active",                            default: true
     t.string   "zenodo_access_token"
+    t.string   "arpha_api_key"
+    t.string   "arpha_username"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -3,6 +3,7 @@
 # Table name: plans
 #
 #  id                                :integer          not null, primary key
+#  arpha_url                         :string
 #  complete                          :boolean          default(FALSE)
 #  data_contact                      :string
 #  data_contact_email                :string

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -21,10 +21,12 @@
 #  created_at                        :datetime
 #  updated_at                        :datetime
 #  template_id                       :integer
+#  zenodo_id                         :integer
 #
 # Indexes
 #
 #  index_plans_on_template_id  (template_id)
+#  index_plans_on_zenodo_id    (zenodo_id)
 #
 # Foreign Keys
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,6 +28,7 @@
 #  reset_password_token   :string
 #  sign_in_count          :integer          default(0)
 #  surname                :string
+#  zenodo_access_token    :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  invited_by_id          :integer

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,8 @@
 #  accept_terms           :boolean
 #  active                 :boolean          default(TRUE)
 #  api_token              :string
+#  arpha_api_key          :string
+#  arpha_username         :string
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime


### PR DESCRIPTION
Changes proposed in this PR:
- Add support for users to connect their account to [Zenodo API](http://developers.zenodo.org/)
- Add support for users to upload a DMP to Zenodo as a PDF

Please note: to test this, you'll need to do the following:

1. Add a `HOST` env variable (for OAuth 2.0 redirects). This should be set to whatever master domain the app is running on (will be 'localhost:3000' in development).
2. Create an application on the [Zenodo sandbox](https://sandbox.zenodo.org/) and [Zenodo live](https://zenodo.org/) environments 
3. Obtain.a `CLIENT_ID` and `CLIENT_SECRET` for the applications, and store these as env variables.

Go to the "Share" tab for a given Plan and click the Zenodo button at the foot of the page