### PR TITLE
added plans fulltext api using pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,6 +164,8 @@ gem 'gettext', require: false, group: :development
 # A pagination engine plugin for Rails 4+ and other modern frameworks (https://github.com/kaminari/kaminari)
 gem 'kaminari'
 
+gem 'pager_api'
+
 # Following best practices from http://12factor.net run a maintainable, clean, and scalable app on Rails (https://github.com/heroku/rails_12factor)
 gem "rails_12factor", group: [:production]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,7 @@ GEM
       omniauth (>= 1.0.0)
     options (2.3.2)
     orm_adapter (0.5.0)
+    pager_api (0.3.1)
     parallel (1.17.0)
     parser (2.6.2.1)
       ast (~> 2.4.0)
@@ -521,6 +522,7 @@ DEPENDENCIES
   omniauth
   omniauth-orcid
   omniauth-shibboleth
+  pager_api
   pg (~> 0.19.0)
   progress_bar
   puma

--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -54,4 +54,14 @@ class Api::V0::PlansController < Api::V0::BaseController
     end
   end
 
+  def index
+    unless Api::V0::PlansPolicy.new(@user, nil).index?
+      raise Pundit::NotAuthorizedError
+    end
+    @plans = @user.org.plans.includes( [ {answers: :question_options} ,
+      template: [ { phases: { sections: { questions: :question_format } } }, :org]
+    ])
+    paginate @plans, per_page: 20
+  end
+
 end

--- a/app/policies/api/v0/plans_policy.rb
+++ b/app/policies/api/v0/plans_policy.rb
@@ -18,6 +18,10 @@ module Api
       def create?
         @template.present?
       end
+
+      def index?
+        @user.can_org_admin?
+      end
     end
   end
 end

--- a/app/views/api/v0/plans/index.json.jbuilder
+++ b/app/views/api/v0/plans/index.json.jbuilder
@@ -58,4 +58,4 @@ json.array! @plans.each do |plan|
     end
   end
 
-endrai
+end

--- a/app/views/api/v0/plans/index.json.jbuilder
+++ b/app/views/api/v0/plans/index.json.jbuilder
@@ -1,0 +1,61 @@
+# builds a json response to a successful project createtion
+
+json.prettify!
+
+json.array! @plans.each do |plan|
+  json.id             plan.id
+  json.title          plan.title
+  json.grant_number   plan.grant_number
+  json.template do
+    json.title        plan.template.title
+    json.id           plan.template.family_id
+  end
+  json.funder do
+    json.name         (plan.template.org.funder? ? plan.template.org.name : plan.funder_name)
+  end
+  json.principal_investigator do
+    json.name         plan.principal_investigator
+    json.email        plan.principal_investigator_email
+    json.phone        plan.principal_investigator_phone
+  end
+  json.data_contact do
+    json.name         plan.data_contact
+    json.email        plan.data_contact_email
+    json.phone        plan.data_contact_phone
+  end
+  json.users plan.roles.each do |role|
+    json.email       role.user.email
+
+  end
+  json.description    plan.description
+  json.plan_content plan.template.phases.each do |phase|
+    json.title        phase.title
+    json.description    phase.description
+    json.sections phase.sections.each do |section|
+      json.title        section.title
+      json.description  section.description
+      json.number       section.number
+      json.questions section.questions.each do |question|
+        json.text       question.text
+        json.number     question.number
+        json.format     question.question_format.title
+        json.option_based   question.question_format.option_based
+        answer = plan.answers.select{ |a| a.question_id = question.id }.first
+        if answer.present?
+          json.answered   true
+          json.answer do
+            json.text     answer.text
+            if answer.question_options.present?
+              json.options    answer.question_options.each do |option|
+                json.text       option.text
+              end
+            end
+          end
+        else
+          json.answered  false
+        end
+      end
+    end
+  end
+
+endrai

--- a/config/initializers/pager_api.rb
+++ b/config/initializers/pager_api.rb
@@ -1,0 +1,24 @@
+# Use this module to configure pager the available options
+#
+# Made with love by @icalialabs
+
+PagerApi.setup do |config|
+
+  # Pagination Handler
+  # User this option to meet your pagination handler, whether is :kaminari or :will_paginate
+  config.pagination_handler = :kaminari
+
+  # Includes Pagination information on Meta
+  #
+  # config.include_pagination_on_meta = true
+
+  # Includes Pagination information on a Link Header
+  #
+  config.include_pagination_headers = true
+
+  # Set the Total-Pages Header name
+  config.total_pages_header = "X-Total-Pages"
+
+  # Set the Total-Count Header name
+  config.total_count_header = "X-Total-Count"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,7 +142,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v0 do
       resources :guidances, only: [:index], controller: 'guidance_groups', path: 'guidances'
-      resources :plans, only: :create
+      resources :plans, only: [:create, :index]
       resources :templates, only: :index
       resource  :statistics, only: [], controller: "statistics", path: "statistics" do
         member do


### PR DESCRIPTION
adds the full-text export of plans to org-admins who have access to the plans api (configurable by org)

instead of the 'cache it on S3' approach, I decided that pagination of the content was a much simpler and better solution for this problem, and one which can be applied across the API as a whole.