### PR TITLE
Bug/reviewer plans view

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,7 +235,8 @@ class User < ActiveRecord::Base
   # Returns Boolean
   def can_org_admin?
     return self.can_grant_permissions? || self.can_modify_guidance? ||
-           self.can_modify_templates? || self.can_modify_org_details?
+           self.can_modify_templates? || self.can_modify_org_details? ||
+           self.can_review_plans?
   end
 
   # Can the User add new organisations?

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -21,8 +21,8 @@
             <% end %>
           </td>
           <td><%= plan.template.title %></td>
-          <td><%= plan.users.first.org.name %></td>
-          <td><%= plan.users.first.name(false) %></td>
+          <td><%= plan.owner.org.name %></td>
+          <td><%= plan.owner.name(false) %></td>
           <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
           <td class="plan-visibility">
             <%= plan.visibility === 'is_test' ? _('Test') : sanitize(display_visibility(plan.visibility)) %>


### PR DESCRIPTION
Fixes a display bug with the plans table showing the first user rather than owner of a plan
Fixes an issue where reviewers could not view the org_admin_plans_page