### PR TITLE
replaced timestamps on notes with timeago

### DIFF
--- a/app/javascript/views/notes/index.js
+++ b/app/javascript/views/notes/index.js
@@ -1,5 +1,6 @@
 import { Tinymce } from '../../utils/tinymce';
 import { isObject, isString } from '../../utils/isType';
+import TimeagoFactory from '../../utils/timeagoFactory';
 
 $(() => {
   const defaultViewSelector = questionId => `#note_new${questionId}`;
@@ -161,6 +162,7 @@ $(() => {
   const initOrReload = () => {
     Tinymce.init({ selector: '.note' });
     eventHandlers({ attachment: 'on' });
+    TimeagoFactory.render($('time.timeago'));
   };
   const clean = () => {
     eventHandlers({ attachment: 'off' });

--- a/app/views/notes/_show.html.erb
+++ b/app/views/notes/_show.html.erb
@@ -9,7 +9,7 @@
         </li>
         <li>
             <span class="label label-info">
-                <%= "#{user.name} at #{l(note.updated_at, format: :short)}" %>
+                <%= "#{user.name} " %> <time class="timeago" datetime="<%= note.updated_at.iso8601 %>"></time>
             </span>
         </li>
     </ul>


### PR DESCRIPTION
Currently, where we display hours/mins, this is straight from UCT, so does not correlate to the user's time, which will depend on which time zone they live in.

This brings the notes section in-line with the answers approach (using the timeago.js library).

