### PR TITLE
Fix for foreign key violation error when a department is deleted

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -22,7 +22,7 @@ class Department < ActiveRecord::Base
 
   belongs_to :org
 
-  has_many :users
+  has_many :users, dependent: :nullify
 
   # ===============
   # = Validations =


### PR DESCRIPTION
 Fix for foreign key violation error when a department is deleted
    after some users have added its department_id.
    
    Solution based on blog "Set Foreign keys to null"

    https://til.hashrocket.com/posts/jqilnp3d0h--set-foreign-keys-to-null
    
    Fix for issue #2088


