### PR TITLE
Fix for ordering of Departments in select dropdown list.

### DIFF
--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -30,7 +30,7 @@
     <input type="hidden" id="original_org" value="<%= @user.org_id %>">
   <% end %>
   
-    <% departments = current_user.org.departments %>
+    <% departments = current_user.org.departments.order(:name) %>
     <div class="form-group col-xs-8">
       <% dept_id = current_user.department.nil? ? -1 : current_user.department.id  %>
       <%= f.label(:department_id, _('Department or school'), class: 'control-label') %>


### PR DESCRIPTION
Change just orders the dropdown list by name.

Fix for issue #2088

@xsrust and @briri  sorry about this but I noticed the dropdown Department list was not ordered.
