### PR TITLE
Fix for issue associated with super-admins and department affiliation…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,6 +154,8 @@ class User < ActiveRecord::Base
 
   before_update :clear_other_organisation, if: :org_id_changed?
 
+  before_update :clear_department_id, if: :org_id_changed?
+
   after_update :delete_perms!, if: :org_id_changed?, unless: :can_change_org?
 
   after_update :remove_token!, if: :org_id_changed?, unless: :can_change_org?
@@ -401,6 +403,10 @@ class User < ActiveRecord::Base
 
   def clear_other_organisation
     self.other_organisation = nil
+  end
+
+  def clear_department_id
+    self.department_id = nil
   end
 
 end

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -12,26 +12,26 @@ class DepartmentPolicy < ApplicationPolicy
   end
 
   def new?
-    @user.can_org_admin?
+    @user.can_org_admin? || @user.can_super_admin?
   end
 
   def create?
-    @user.can_org_admin?
+    @user.can_org_admin? || @user.can_super_admin?
   end
 
   def edit?
-    # Only org_admins can edit their own org's departments
-    @user.can_org_admin? && @user.org.id === @department.org_id
+    (@user.can_org_admin? && @user.org.id === @department.org_id) ||
+       @user.can_super_admin?
   end
 
   def update?
-    # Only org_admins can update their own org's departments
-    @user.can_org_admin? && @user.org.id === @department.org_id
+    (@user.can_org_admin? && @user.org.id === @department.org_id) ||
+      @user.can_super_admin?
   end
 
   def destroy?
-    # Only org_admins can delete their own org's departments
-    @user.can_org_admin? && @user.org.id === @department.org_id
+    (@user.can_org_admin? && @user.org.id === @department.org_id) ||
+      @user.can_super_admin?
   end
 
 end

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -31,6 +31,7 @@
   <% end %>
   
     <% departments = current_user.org.departments.order(:name) %>
+    <% if departments.count > 0 %>
     <div class="form-group col-xs-8">
       <% dept_id = current_user.department.nil? ? -1 : current_user.department.id  %>
       <%= f.label(:department_id, _('Department or school'), class: 'control-label') %>
@@ -40,6 +41,7 @@
           disabled: departments.count === 0,
           class: "form-control") %>
     </div>
+    <% end %>
 
   <% if Language.many? %>
     <div class="form-group col-xs-8">


### PR DESCRIPTION
… in a given organisation.

Changes made:
  - Department policies now allow both org admins and super admins to
    create update and delete departments, whilst org_admins can only do this
    for their own org. Super admins can do it for any org department.
  - When a super admin switches organisation their department_id is cleared.

