### PR TITLE
Fixed link for UC3 at footer since the page was previously not found.

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -19,7 +19,7 @@
     <ul class="nav navbar-nav navbar-right">
       <li>
         <%= link_to( image_tag("uc3_logo_white.png", class: "img-responsive", alt: 'University of California Curation Center (opens in a new window)'),
-                               "http://www.cdlib.org/uc3/", title: "University of California Curation Center", target: '_blank') %>
+                               "http://www.cdlib.org/services/uc3/", title: "University of California Curation Center", target: '_blank') %>
       </li>
       <li>
         <%= link_to( image_tag("dcc_logo_white.png", class: "img-responsive", alt: 'Digital Curation Centre (opens in a new window)'),


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
-
The link to the UC3 page on the California Digital Library website at the footer of pretty much every  was giving me a page not found error; I believe the link is out of date. Although this annotation doesn't seem to be available to the public I updated it anyway.