### PR TITLE
updated plan sharing form according to #2111, also added text to the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ config/branding.yml
 
 # Ignore some of the initializers
 config/initializers/recaptcha.rb
-# config/initializers/devise.rb
+config/initializers/devise.rb
 config/initializers/wicked_pdf.rb
 config/initializers/fingerprint.rb
 

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -88,42 +88,51 @@
   <% new_role = Role.new %>
   <% new_role.plan = @plan %>
   <%= form_for new_role, url: {controller: :roles, action: :create }, html: {method: :post} do |f| %>
-    <div class="form-group col-xs-8">
+    <div class="form-group col-xs-6">
       <%= f.hidden_field :plan_id %>
       <%= f.fields_for :user do |user| %>
-        <%= user.label :email, _('Email'), class: 'control-label' %>
-        <%= user.email_field :email, for: :user, name: "user", class: "form-control", "aria-required": true %>
+        <%= user.label :email, _('Email'), class: 'control-label'%>
+        <%= user.email_field :email, for: :user, name: "user", class: "form-control",
+                            "aria-required": true,
+                            'data-toggle': 'tooltip',
+                            'data-html': true,
+                            title: 'Enter the email address of your collaborator: <ul><li> If they are already using DMPonline, they will see this plan on their dashboard, and recieve an email. </li> <li> If they are not currently using DMPonline, they will recieve an email inviting them to the tool so they can collaborate on your plan.</li></ul>' %>
       <% end %>
     </div>
-
-    <fieldset class="col-xs-12">
-      <legend><%= _('Permissions') %></legend>
+    <div class="clearfix"></div>
+    <%= field_set_tag  nil, class: 'col-xs-2',
+                    'data-toggle': 'tooltip',
+                    'data-html': true,
+                    title: 'Co-owner: Has admin-rights to the plan (can invite other users, view the plan, answer questions, or comment) <br /> Editor: Has edit-rights to the plan (can view the plan, answer questions, or comment) <br /> Read Only: Has read-rights to the plan(can view the plan or comment)',
+                    'data-placement':'right' do %>
+      <%= content_tag :legend , _('Permissions') %>
       <div class="form-group">
         <div class="radio">
           <%= f.label :access do %>
             <%= f.radio_button :access, administrator.access, "aria-required": true %>
-            <%= _('Co-owner: can edit project details, change visibility, and add collaborators') %>
+            <%= _('Co-owner') %>
           <% end %>
         </div>
         <div class="radio">
           <%= f.label :access do %>
             <%= f.radio_button :access, editor.access %>
-            <%= _('Editor: can comment and make changes') %>
+            <%= _('Editor') %>
           <% end %>
         </div>
         <div class="radio">
           <%= f.label :access do %>
             <%= f.radio_button :access, commenter.access %>
-            <%= _('Read only: can view and comment, but not make changes') %>
+            <%= _('Read only') %>
           <% end %>
         </div>
-
-        <%= f.button(_('Submit'), class: "btn btn-primary", type: "submit") %>
       </div>
-      <div class="clearfix"></div>
-    </fieldset>
+    <% end %>
+    <div class="clearfix"></div>
+    <div class="form-group col-xs-2">
+    <%= f.button(_('Submit'), class: "btn btn-primary", type: "submit") %>
+    </div>
   <% end %>
-   
+
 
   <div class="col-xs-12">
     <% if plan.owner_and_coowners.include?(current_user) && plan.owner.org.feedback_enabled? %>

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -96,7 +96,7 @@
                             "aria-required": true,
                             'data-toggle': 'tooltip',
                             'data-html': true,
-                            title: _('Enter the email address of your collaborator: <ul><li> If they are already using DMPonline, they will see this plan on their dashboard, and recieve an email. </li> <li> If they are not currently using DMPonline, they will recieve an email inviting them to the tool so they can collaborate on your plan.</li></ul>') %>
+                            title: _("Enter the email address of your collaborator: <ul><li> If they are already using #{Rails.configuration.branding[:application][:name]}, they will see this plan on their dashboard, and recieve an email. </li> <li> If they are not currently using #{Rails.configuration.branding[:application][:name]}, they will recieve an email inviting them to the tool so they can collaborate on your plan.</li></ul>") %>
       <% end %>
     </div>
     <div class="clearfix"></div>

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -96,14 +96,14 @@
                             "aria-required": true,
                             'data-toggle': 'tooltip',
                             'data-html': true,
-                            title: 'Enter the email address of your collaborator: <ul><li> If they are already using DMPonline, they will see this plan on their dashboard, and recieve an email. </li> <li> If they are not currently using DMPonline, they will recieve an email inviting them to the tool so they can collaborate on your plan.</li></ul>' %>
+                            title: _('Enter the email address of your collaborator: <ul><li> If they are already using DMPonline, they will see this plan on their dashboard, and recieve an email. </li> <li> If they are not currently using DMPonline, they will recieve an email inviting them to the tool so they can collaborate on your plan.</li></ul>') %>
       <% end %>
     </div>
     <div class="clearfix"></div>
     <%= field_set_tag  nil, class: 'col-xs-2',
                     'data-toggle': 'tooltip',
                     'data-html': true,
-                    title: 'Co-owner: Has admin-rights to the plan (can invite other users, view the plan, answer questions, or comment) <br /> Editor: Has edit-rights to the plan (can view the plan, answer questions, or comment) <br /> Read Only: Has read-rights to the plan(can view the plan or comment)',
+                    title: _('Co-owner: Has admin-rights to the plan (can invite other users, view the plan, answer questions, or comment) <br /> Editor: Has edit-rights to the plan (can view the plan, answer questions, or comment) <br /> Read Only: Has read-rights to the plan(can view the plan or comment)'),
                     'data-placement':'right' do %>
       <%= content_tag :legend , _('Permissions') %>
       <div class="form-group">


### PR DESCRIPTION
…email field to clarify what happens if the user is not in our system

### Email
<img width="874" alt="Screenshot 2019-07-16 at 12 23 56" src="https://user-images.githubusercontent.com/7352616/61291049-3fa9cf80-a7c5-11e9-83af-3e6bc4b9a6b5.png">

###  Radio group
<img width="991" alt="Screenshot 2019-07-16 at 12 24 03" src="https://user-images.githubusercontent.com/7352616/61291051-3fa9cf80-a7c5-11e9-878f-43f435953916.png">
