### PR TITLE
Fix for making links have a higher color contrast to other text in bl…

### DIFF
--- a/app/assets/stylesheets/blocks/_tinymce_content.scss
+++ b/app/assets/stylesheets/blocks/_tinymce_content.scss
@@ -1,0 +1,8 @@
+@import "../variables/tinymce";
+
+.mce-content-body {
+  
+  a {
+    color: $color-link-text;
+  }
+}

--- a/app/assets/stylesheets/variables/_colours.scss
+++ b/app/assets/stylesheets/variables/_colours.scss
@@ -11,7 +11,9 @@ $color-grey-darker: #333;
 $color-grey-light: #777;
 $color-grey-lighter: #999;
 $color-blue: #337ab7;
+$color-blue-alice-darkest: #107896;
 $color-muted: #CCC;
+
 
 /*
   Variables to define look and feel
@@ -33,7 +35,7 @@ $color-heading-text: $color-black;
 $color-navbar-text: $color-grey-light;
 $color-navbar-text-hover: $color-white;
 $color-navbar-text-disabled: $color-grey-darker;
-$color-link-text: $color-blue;
+$color-link-text: $color-blue-alice-darkest;
 $color-navbar-link-text: lighten($color-navbar-text, 15%);
 $color-org-navbar-links: $color-grey-light;
 $color-org-navbar-links-hover: $color-grey-darker;

--- a/app/assets/stylesheets/variables/_tinymce.scss
+++ b/app/assets/stylesheets/variables/_tinymce.scss
@@ -1,2 +1,3 @@
 // Import the desired TinyMCE skin name
 //@import "lightgray/skin.min";
+@import "./colours";

--- a/app/javascript/utils/tinymce.js
+++ b/app/javascript/utils/tinymce.js
@@ -41,6 +41,7 @@ export const defaultOptions = {
   // editorManager.baseURL is not resolved properly for IE since document.currentScript
   // is not supported, see issue https://github.com/tinymce/tinymce/issues/358
   skin_url: '/tinymce/skins/lightgray',
+  content_css: ['/assets/blocks/_tinymce_content.css'],
 };
 /*
   This function is invoked anytime a new editor is initialised (e.g. Tinymce.init())

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,9 @@
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
-Rails.application.config.assets.precompile += %w[ tinymce/lightgray/skin.min.css ]
+Rails.application.config.assets.precompile += %w[
+  tinymce/lightgray/skin.min.css,
+  blocks/_tinymce_content.scss
+ ]
 
 
 if Rails.env.staging? or Rails.env.production?


### PR DESCRIPTION
…ocks.

The changes were based on the article  https://www.viget.com/articles/color-contrast/

Changes:
 - Link color has been  changed from #337ab7 to #107896.
According to https://webaim.org/resources/linkcontrastchecker/?fcolor=000000&bcolor=FFFFFF&lcolor=107896 (the "Link to Body Text" ratio is 4.14:1 and passes WCAG A test and "Link to Background" ratio is 5.06 and passes the 5.06:1 which satisfies WCAG AA test.)
- The TinyMce editor required new stylesheets to be created.

Fix for issue #1457

 Some screenshots of changes

![Selection_062](https://user-images.githubusercontent.com/8876215/61868212-d31f8680-aed0-11e9-8258-9a57ecb01e13.png)
![Selection_063](https://user-images.githubusercontent.com/8876215/61868229-d87cd100-aed0-11e9-8621-9fb38007646e.png)
![Selection_064](https://user-images.githubusercontent.com/8876215/61868235-dca8ee80-aed0-11e9-8060-01d53ff09c92.png)

