### PR TITLE
Enable spellcheck for text fields:

### DIFF
--- a/app/views/contact_us/contacts/_new_left.html.erb
+++ b/app/views/contact_us/contacts/_new_left.html.erb
@@ -22,6 +22,7 @@
         <%= f.label(:subject, _('Subject')) %>
         <%= f.text_field(:subject,
             class: "form-control",
+            spellcheck: "true",
             "aria-required": true) %>
     </div>
 <% end %>

--- a/app/views/guidance_groups/_guidance_group_form.html.erb
+++ b/app/views/guidance_groups/_guidance_group_form.html.erb
@@ -1,6 +1,8 @@
 <div class="form-group">
   <%= f.label _('Name'), for: :name, class: "control-label" %>
-  <%= f.text_field :name, as: :string, class: "form-control", 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will be used to tell the end user where the guidance has come from. It will be appended to text identifying the theme e.g. "[guidance group name]: guidance on data sharing" so we suggest you just use the organisation or department name.'), 'aria-required': true %>
+  <%= f.text_field :name, as: :string, class: "form-control", 'data-toggle': 'tooltip',
+      title: _('Add an appropriate name for your guidance group. This name will be used to tell the end user where the guidance has come from. It will be appended to text identifying the theme e.g. "[guidance group name]: guidance on data sharing" so we suggest you just use the organisation or department name.'),
+      spellcheck: true, 'aria-required': true %>
 </div>
 <fieldset>
 	<div class="checkbox">

--- a/app/views/guidance_groups/admin_edit.html.erb
+++ b/app/views/guidance_groups/admin_edit.html.erb
@@ -12,7 +12,7 @@
 
         <div class="form-group col-xs-8">
           <%= f.label _('Name'), for: :name, class: "control-label" %>
-          <%= f.text_field :name, as: :string, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
+          <%= f.text_field :name, as: :string, class: "form-control", spellcheck: true, 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
         </div>
 
         <div class='form-input col-xs-8'>

--- a/app/views/guidance_groups/admin_new.html.erb
+++ b/app/views/guidance_groups/admin_new.html.erb
@@ -11,7 +11,7 @@
     <%= form_for :guidance_group, url: {action: "admin_create"}, html: {id: 'admin_create_guidance_group_form'} do |f| %>
         <div class="form-group col-xs-8">
           <%= f.label _('Name'), for: :name, class: "control-label" %>
-          <%= f.text_field :name, as: :string, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
+          <%= f.text_field :name, as: :string, class: "form-control", spellcheck: true, 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add an appropriate name for your guidance group. This name will tell the end user where the guidance has come from. We suggest you use the organisation or department name e.g. "OU" or "Maths & Stats"') %>
         </div>
         <fieldset class='col-xs-12'>
           <div class='form-input'>

--- a/app/views/org_admin/departments/edit.html.erb
+++ b/app/views/org_admin/departments/edit.html.erb
@@ -12,7 +12,7 @@
         <%= f.hidden_field :org_id, value: @org_id %>
         <div class="form-group col-xs-8">
           <%= f.label _('Name'), for: :name, class: "control-label" %>
-          <%= f.text_field :name, as: :string, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add the name of a school/department.') %>
+          <%= f.text_field :name, as: :string, class: "form-control", spellcheck: true, 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add the name of a school/department.') %>
         </div>
         <div class="form-group col-xs-8">
           <%= f.label _('Abbreviated name or code'), for: :code, class: "control-label" %>

--- a/app/views/org_admin/departments/new.html.erb
+++ b/app/views/org_admin/departments/new.html.erb
@@ -12,7 +12,7 @@
         <%= f.hidden_field :org_id, value: @org_id %>
         <div class="form-group col-xs-8">
           <%= f.label _('Name'), for: :name, class: "control-label" %>
-          <%= f.text_field :name, as: :string, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add the name of a school/department.') %>
+          <%= f.text_field :name, as: :string, class: "form-control", spellcheck: true, 'aria-required': true, 'data-toggle': 'tooltip', title: _('Add the name of a school/department.') %>
         </div>
         <div class="form-group col-xs-8">
           <%= f.label _('Abbreviated name or code'), for: :code, class: "control-label" %>

--- a/app/views/org_admin/phases/_form.html.erb
+++ b/app/views/org_admin/phases/_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.hidden_field :template_id, value: template.id%>
 <div class="form-group col-md-10">
   <%= f.label(:title, _('Title') ,class: "control-label") %>
-  <%= f.text_field(:title, class: "form-control", 'aria-required': true, 'data-toggle': 'tooltip', title: _('Enter a title for the phase e.g. intial DMP, full DMP... This is what users will see in the tabs when completing a plan. If you only have one phase, call it something generic e.g. Glasgow DMP')) %> 
+  <%= f.text_field(:title, class: "form-control", spellcheck: true, 'aria-required': true, 'data-toggle': 'tooltip', title: _('Enter a title for the phase e.g. intial DMP, full DMP... This is what users will see in the tabs when completing a plan. If you only have one phase, call it something generic e.g. Glasgow DMP')) %>
 </div>
 
 <div class="form-group">
@@ -18,6 +18,6 @@
   <%= f.text_area(:description, class: "phase") %>
 </div>
 
-<div class="form-group col-md-4 pull-right">   
+<div class="form-group col-md-4 pull-right">
   <%= f.button(_('Save'), class: 'btn btn-default', type: "submit") %>
 </div>

--- a/app/views/org_admin/question_options/_option_fields.html.erb
+++ b/app/views/org_admin/question_options/_option_fields.html.erb
@@ -25,9 +25,9 @@
       </div>
       <div class="col-md-3">
         <% if i == 1 %>
-          <%= op.text_field :text, as: :string, class: 'form-control', 'aria-required': true %>
+          <%= op.text_field :text, as: :string, class: 'form-control', spellcheck: true, 'aria-required': true %>
         <% else %>
-          <%= op.text_field :text, as: :string, class: 'form-control' %>
+          <%= op.text_field :text, as: :string, class: 'form-control', spellcheck: true %>
         <% end %>
       </div>
       <div class="col-md-3">

--- a/app/views/org_admin/questions/_form.html.erb
+++ b/app/views/org_admin/questions/_form.html.erb
@@ -58,7 +58,7 @@
       <%= f.label(:default_value, _('Default answer'), class: "control-label") %>
       <div class="" data-toggle="tooltip" title="<%= _('Anything you enter here will display in the answer box. If you want an answer in a certain format (e.g. tables), you can enter that style here.') %>">
         <span data-attribute="textfield" style="<%= current_format.textfield? ? '' : 'display:none;' %>">
-          <%= f.text_field(:default_value, class: 'form-control') %>
+          <%= f.text_field(:default_value, class: 'form-control', spellcheck: true) %>
         </span>
         <span data-attribute="textarea" style="<%= current_format.textarea? ? '' : 'display:none;' %>">
           <%= text_area_tag('question[default_value]', question.default_value, id: "#{question.id.present? ? question.id : 'new'}_question_default_value_area", class: "form-control question") %>

--- a/app/views/org_admin/sections/_form.html.erb
+++ b/app/views/org_admin/sections/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(section, url: url, namespace: section.id.present? ? section.id : 'new_section', html: { method: method }) do |f| %>
   <div class="form-group col-md-10">
     <%= f.label(:title, _('Title') ,class: "control-label") %>
-    <%= f.text_field(:title, { class: "form-control", placeholder: _('Enter a title for the section'), 'data-toggle': 'tooltip', title: _('Enter a title for the section'), 'aria-required': true} ) %>
+    <%= f.text_field(:title, { class: "form-control", placeholder: _('Enter a title for the section'), 'data-toggle': 'tooltip', title: _('Enter a title for the section'), spellcheck: true, 'aria-required': true} ) %>
   </div>
 
   <div class="form-group col-md-10" data-toggle="tooltip" title="<%= _("Enter a basic description. This could be a summary of what is covered in the section or instructions on how to answer. This text will be displayed in the coloured banner once a section is opened to edit.") %>">

--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group col-xs-8">
   <%= f.label(:title, _('Title'), class: "control-label") %>
-  <%= f.text_field(:title, class: "form-control", "aria-required": true) %>
+  <%= f.text_field(:title, class: "form-control", spellcheck: true, "aria-required": true) %>
 </div>
 
 <div class="form-group col-xs-8" data-toggle="tooltip" title="<%= _('Enter a description that helps you to differentiate between templates e.g. if you have ones for different audiences') %>">

--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -6,7 +6,8 @@
           <%= f.label(:title, _('Project title'), class: 'control-label') %>
         </div>
         <div class="col-md-8">
-          <%= f.text_field(:title, class: "form-control", "aria-required": true, 'data-toggle': 'tooltip',
+          <%= f.text_field(:title, class: "form-control", "aria-required": true,
+            'data-toggle': 'tooltip', spellcheck: true,
             title: _('If applying for funding, state the name exactly as in the grant proposal.')) %>
       <div class="checkbox">
         <%= f.hidden_field :visibility %>
@@ -25,6 +26,7 @@
           <%= f.text_field(
             :funder_name,
             class: "form-control",
+            spellcheck: true,
             "aria-required": false) %>
         </div>
       </div>
@@ -58,7 +60,8 @@
           <%= f.label(:identifier, _('ID'), class: 'control-label') %>
         </div>
         <div class="col-md-8">
-          <%= f.text_field(:identifier, class: "form-control", "aria-required": false, 'data-toggle': "tooltip",
+          <%= f.text_field(:identifier, class: "form-control", "aria-required": false,
+                           'data-toggle': "tooltip", spellcheck: true,
                            title: _('A pertinent ID as determined by the funder and/or organisation.')) %>
         </div>
       </div>

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -19,6 +19,7 @@
           <%= f.text_field(:title, class: 'form-control', 'aria-describedby': 'project-title', 'aria-required': 'true', 'aria-label': 'project-title',
                 'data-toggle': 'tooltip',
                 'data-placement': 'bottom',
+                spellcheck: true,
                 title: _('If applying for funding, state the project title exactly as in the proposal.')) %>
         </div>
         <div class="col-md-1">&nbsp;</div>

--- a/app/views/questions/_new_edit_question_textfield.html.erb
+++ b/app/views/questions/_new_edit_question_textfield.html.erb
@@ -1,5 +1,5 @@
 <%# locals: { f, question, answer } %>
 <div class="form-group">
     <%= f.label(:text, sanitize(question.text), class: 'control-label') %>
-    <%= text_field_tag('answer[text]', strip_tags(answer.text || question.default_value), class: 'form-control') %>
+    <%= text_field_tag('answer[text]', strip_tags(answer.text || question.default_value), class: 'form-control', spellcheck: true) %>
 </div>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -5,7 +5,8 @@
       <span class="input-group-addon" id="search-addon">
         <span class="fa fa-search" aria-hidden="true"></span>
       </span>
-      <%= text_field_tag(:search, search_term, class: 'form-control', 'aria-labelledby': 'search', 'aria-describedby': 'search-addon', 'aria-required': true) %>
+      <%= text_field_tag(:search, search_term, class: 'form-control', 'aria-labelledby': 'search',
+                        spellcheck: true, 'aria-describedby': 'search-addon', 'aria-required': true) %>
     </div>
   </div>
   <%= submit_tag(_('Search'), class: 'btn btn-default', style: 'margin-top: 8px;') %>

--- a/app/views/super_admin/notifications/_form.html.erb
+++ b/app/views/super_admin/notifications/_form.html.erb
@@ -7,6 +7,7 @@
       <%= f.text_field :title,
           class: 'form-control',
           value: @notification.title,
+          spellcheck: true,
           "aria-required": true %>
     </div>
 

--- a/app/views/super_admin/themes/_form.html.erb
+++ b/app/views/super_admin/themes/_form.html.erb
@@ -3,7 +3,7 @@
  <%= form_for @theme, url: url, html: { class: 'theme' } do |f| %>
    <div class="form-group">
      <%= f.label(:title, _('Title'), class: 'control-label') %>
-     <%= f.text_field(:title, class: "form-control", "aria-required": true) %>
+     <%= f.text_field(:title, class: "form-control", spellcheck: true, "aria-required": true) %>
    </div>
    <div class="form-group">
      <%= f.label(:description, _('Guidance')) %>


### PR DESCRIPTION
Changes:
 - added HTML 5 attribute spellcheck= "true" to text_field tag by adding
        spellcheck: true.
 - Did not add this attribute to text_fields for:
    firstname,
    surname,
    principal_investigator_name &
    data_contact.
Because it is irritating for folk to have a spellchecker say your name is incorrectly spelt.

Fix for issue #2169.
