### PR TITLE
Fix some inconsistencies in api token tests,introduce local variable for storing a token

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -326,11 +326,11 @@ class User < ActiveRecord::Base
   # Returns Boolean
   def keep_or_generate_token!
     if api_token.nil? || api_token.empty?
-      self.api_token = loop do
+      new_token = loop do
         random_token = SecureRandom.urlsafe_base64(nil, false)
         break random_token unless User.exists?(api_token: random_token)
       end
-      update_column(:api_token, api_token)  unless new_record?
+      update_column(:api_token, new_token)  unless new_record?
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -508,7 +508,7 @@ RSpec.describe User, type: :model do
 
       let!(:user) { create(:user, api_token: "") }
 
-      it { expect { subject }.not_to change { user.api_token } }
+      it { expect { subject }.to change { user.api_token }.to(nil) }
 
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -506,7 +506,7 @@ RSpec.describe User, type: :model do
 
     context "when user is not a new record and api_token is an empty string" do
 
-      let!(:user) { create(:user, api_token: nil) }
+      let!(:user) { create(:user, api_token: "") }
 
       it { expect { subject }.not_to change { user.api_token } }
 
@@ -535,7 +535,7 @@ RSpec.describe User, type: :model do
 
     context "when user is not a new record and api_token is nil" do
 
-      let!(:user) { create(:user, api_token: "") }
+      let!(:user) { create(:user, api_token: nil) }
 
       it { expect { subject }.to change { user.api_token } }
 
@@ -545,7 +545,7 @@ RSpec.describe User, type: :model do
 
       let!(:user) { build(:user, api_token: "") }
 
-      it { expect { subject }.not_to change { user.new_record? } }
+      it { expect { subject }.not_to change { user.api_token } }
 
     end
   end


### PR DESCRIPTION
Fixes # .
Some of the tests (while going through the api implementation code) are inconsistent about what they say they do and what they actually do.
In "keep_or_generate_token!" method in the user model, a new token created is put in the user model's api_token variable and then not saved , but instead update_column method is called. The local variable, new_token is for clarity.

Changes proposed in this PR:
-Fix some inconsistencies
