### PR TITLE
Fix for providing a highly visible highlighting mechanism for links o…

### DIFF
--- a/app/assets/stylesheets/blocks/_accessibility.scss
+++ b/app/assets/stylesheets/blocks/_accessibility.scss
@@ -28,3 +28,27 @@ div.skip a:focus {
   height:auto;
   overflow:visible !important;
 }
+
+/** Focus outline required for accessibility */
+a, input, select, .form-control {
+  &:focus,
+  &:hover,
+  &:active {
+    outline-style: solid !important;
+    outline-color: $color-focus-outline !important;
+    outline-width: 2px !important;
+  }
+}
+  
+  /** button outline-width increased for better visibility of outline */
+  button {
+
+    &:focus,
+    &:hover,
+    &:active {
+      outline-style: solid !important;
+      outline-color: $color-focus-outline !important;
+      outline-width: 3px !important;
+    }
+  }
+  

--- a/app/assets/stylesheets/variables/_colours.scss
+++ b/app/assets/stylesheets/variables/_colours.scss
@@ -15,6 +15,7 @@ $color-blue-alice-darkest: #107896;
 $color-muted: #CCC;
 
 
+
 /*
   Variables to define look and feel
 */
@@ -59,3 +60,6 @@ $color-shadow-dark: $color-black;
 
 // FontAwesome Colors
 $color-fa: $color-grey;
+
+// Focus colors
+$color-focus-outline: $color-blue-alice-darkest;


### PR DESCRIPTION
…r controls when they receive keyboard focus.

(WCAG 2.0, Additional Techniques (Advisory) for Sucess Criterion 2.4.3, https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html)

Changes:

- Added an outline to links, buttons and other bootstrap form controls.
- The outline colour was set to #107896 (Darkest Alice Blue) which is the default
colour for links.

- The default outline with set to 2px, except for buttons where it is set to 3px
to improve visiblity.

Fix for #2170.

![Test Bullets 2 - Write plan - Chromium_124](https://user-images.githubusercontent.com/8876215/62859020-e9f91200-bcf3-11e9-93da-8141dfb29d96.png)
![Test Bullets 2 - Write plan - Chromium_123](https://user-images.githubusercontent.com/8876215/62859021-e9f91200-bcf3-11e9-8c84-46bc790d06b6.png)
![Test Bullets 2 - Write plan - Chromium_121](https://user-images.githubusercontent.com/8876215/62859022-e9f91200-bcf3-11e9-8dad-71027abe3ece.png)
![Test Bullets 2 - Write plan - Chromium_120](https://user-images.githubusercontent.com/8876215/62859023-e9f91200-bcf3-11e9-8377-05ee7fa6d93c.png)
![Test Bullets 2 - Share - Chromium_119](https://user-images.githubusercontent.com/8876215/62859024-e9f91200-bcf3-11e9-889a-70751b10c97a.png)
![Test Bullets 2 - Share - Chromium_118](https://user-images.githubusercontent.com/8876215/62859025-ea91a880-bcf3-11e9-9610-cc3dbbcbb972.png)

