### PR TITLE
Fixes bug where users of other_org were unable to update profile

### DIFF
--- a/app/javascript/views/shared/my_org.js
+++ b/app/javascript/views/shared/my_org.js
@@ -46,12 +46,12 @@ export const initOrgSelection = (options) => {
       if (isValidText(id.val())) {
         if (id.val().toString() === otherOrg.val().toString()) {
           toggleInputs(false);
+          text.blur();
         }
       }
     }
   }
 };
-
 export const validateOrgSelection = (options) => {
   if (isObject(options) && options.selector) {
     const orgId = $(`${options.selector} [name="user[org_id]"]`);


### PR DESCRIPTION
We were having a bug this release where users of the other_org attempting to update their profile would throw: `undefined method `departments' for nil:NilClass`  on `current_user.org.departments`.

It turned out that this was due to the page re-directing the user back to the edit page due to the save being unsuccessful, and the org was nil because the form was submitting no org for users of the other_org unless they clicked on the 'your org name' text while editing their profile.

Fixed the bug by ensuring the other_org correctly gets set in the accessible_combobox when initilizing for users of 'other_org'.