### PR TITLE
fixes an issue where annotations were being added to removed questions

### DIFF
--- a/app/services/template/upgrade_customization_service.rb
+++ b/app/services/template/upgrade_customization_service.rb
@@ -170,7 +170,9 @@ class Template
         target_question = target_template.questions.find_by(
           versionable_id: custom_annotation.question.versionable_id
         )
-        target_question.annotations << custom_annotation
+        if target_question.present?
+          target_question.annotations << custom_annotation
+        end
       end
     end
 


### PR DESCRIPTION
upgrade_customization was throwing an error when a question with annotations was removed from a funder template.

Decision was to remove the annotation as the question no longer exists.

We could think about sending out an email with any removed custom content, in-case they want to incorporate it elsewhere.
These 'removed' annotations will still, of course, be available in the history for the template.
