### PR TITLE
Fix for providing a text alternative for tooltips for assistive techn…

### DIFF
--- a/app/views/guidances/new_edit.html.erb
+++ b/app/views/guidances/new_edit.html.erb
@@ -7,6 +7,7 @@ else
   method = "POST"
 end
 %>
+<% guidance_text_tooltip =  _('Enter your guidance here. You can include links where needed.') %>
 
 <% title _('Guidance') %>
 <%# locals: { guidance, themes, guidance_groups, options } %>
@@ -19,7 +20,8 @@ end
 <div class="row">
   <div class="col-xs-12">
     <%= form_for(@guidance, url: url, html: { method: method , id: 'new_edit_guidance'}) do |f| %>
-      <div class="form-group" data-toggle="tooltip" title="<%= _('Enter your guidance here. You can include links where needed.') %>">
+      <div class="form-group" data-toggle="tooltip" title="<%= guidance_text_tooltip %>">
+        <em class="sr-only"><%= guidance_text_tooltip %></em>
         <%= f.label :text, class: 'control-label' %>
         <%= text_area_tag("guidance-text", @guidance.text, class: "form-control", 'aria-required': true, rows: 10) %>
       </div>

--- a/app/views/org_admin/annotations/_form.html.erb
+++ b/app/views/org_admin/annotations/_form.html.erb
@@ -2,6 +2,7 @@
   <div class="form-group col-md-10">
     <%= f.label(:type, f.object.type.humanize, class: "control-label") %>
     <div data-toggle="tooltip" title="<%= tooltip_for_annotation_text(f.object) %>">
+      <em class="sr-only"><%= tooltip_for_annotation_text(f.object) %></em>
       <%= f.text_area(:text, class: 'question',
           id: "question_annotations_attributes_#{unique_dom_id(f.object)}_text") %>
     </div>

--- a/app/views/org_admin/phases/_form.html.erb
+++ b/app/views/org_admin/phases/_form.html.erb
@@ -1,7 +1,10 @@
+<% title_tooltip = _('Enter a title for the phase e.g. initial DMP, full DMP... This is what users will see in the tabs when completing a plan. If you only have one phase, call it something generic e.g. Glasgow DMP') %>
+
 <%= f.hidden_field :template_id, value: template.id%>
 <div class="form-group col-md-10">
   <%= f.label(:title, _('Title') ,class: "control-label") %>
-  <%= f.text_field(:title, class: "form-control", spellcheck: true, 'aria-required': true, 'data-toggle': 'tooltip', title: _('Enter a title for the phase e.g. intial DMP, full DMP... This is what users will see in the tabs when completing a plan. If you only have one phase, call it something generic e.g. Glasgow DMP')) %>
+  <em class="sr-only"><%= title_tooltip %></em>
+  <%= f.text_field(:title, class: "form-control", spellcheck: true, 'aria-required': true, 'data-toggle': 'tooltip', title: title_tooltip ) %>
 </div>
 
 <div class="form-group">

--- a/app/views/org_admin/questions/_form.html.erb
+++ b/app/views/org_admin/questions/_form.html.erb
@@ -1,3 +1,5 @@
+<% question_default_value_tooltip = _('Anything you enter here will display in the answer box. If you want an answer in a certain format (e.g. tables), you can enter that style here.') %>
+
 <h4>
   <%= question.id.present? ? _('Question %{number}:') % { number: question.number } : _('New question:') %>
 </h4>
@@ -56,7 +58,8 @@
   <!--Question default_value -->
     <div class="form-group col-md-10" data-attribute="default_value" style="<%= current_format.textfield? || current_format.textarea? ? '' : 'display: none;' %>">
       <%= f.label(:default_value, _('Default answer'), class: "control-label") %>
-      <div class="" data-toggle="tooltip" title="<%= _('Anything you enter here will display in the answer box. If you want an answer in a certain format (e.g. tables), you can enter that style here.') %>">
+      <div class="" data-toggle="tooltip" title="<%= question_default_value_tooltip %>">
+        <em class="sr-only"><%= question_default_value_tooltip %></em>
         <span data-attribute="textfield" style="<%= current_format.textfield? ? '' : 'display:none;' %>">
           <%= f.text_field(:default_value, class: 'form-control', spellcheck: true) %>
         </span>

--- a/app/views/org_admin/sections/_form.html.erb
+++ b/app/views/org_admin/sections/_form.html.erb
@@ -1,10 +1,13 @@
+<% description_tooltip = _("Enter a basic description. This could be a summary of what is covered in the section or instructions on how to answer. This text will be displayed in the coloured banner once a section is opened to edit.") %>
+
 <%= form_for(section, url: url, namespace: section.id.present? ? section.id : 'new_section', html: { method: method }) do |f| %>
   <div class="form-group col-md-10">
     <%= f.label(:title, _('Title') ,class: "control-label") %>
     <%= f.text_field(:title, { class: "form-control", placeholder: _('Enter a title for the section'), 'data-toggle': 'tooltip', title: _('Enter a title for the section'), spellcheck: true, 'aria-required': true} ) %>
   </div>
 
-  <div class="form-group col-md-10" data-toggle="tooltip" title="<%= _("Enter a basic description. This could be a summary of what is covered in the section or instructions on how to answer. This text will be displayed in the coloured banner once a section is opened to edit.") %>">
+  <div class="form-group col-md-10" data-toggle="tooltip" title="<%= description_tooltip %>">
+    <em class="sr-only"><%= description_tooltip %></em>
     <%= f.label(:description, _('Description'), class: "control-label") %>
     <%= f.text_area(:description, class: "section") %>
   </div>

--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -1,9 +1,12 @@
+<% description_tooltip = _('Enter a description that helps you to differentiate between templates e.g. if you have ones for different audiences') %>
+
 <div class="form-group col-xs-8">
   <%= f.label(:title, _('Title'), class: "control-label") %>
   <%= f.text_field(:title, class: "form-control", spellcheck: true, "aria-required": true) %>
 </div>
 
-<div class="form-group col-xs-8" data-toggle="tooltip" title="<%= _('Enter a description that helps you to differentiate between templates e.g. if you have ones for different audiences') %>">
+<div class="form-group col-xs-8" data-toggle="tooltip" title="<%=  description_tooltip %>">
+  <em class="sr-only"><%= description_tooltip %></em>
   <%= f.label(:description, _('Description'), class: "control-label") %>
   <%= f.text_area(:description, class: "template") %>
 </div>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -1,3 +1,8 @@
+<%
+  shared_links_tooltip = _('Links will be displayed next to your organisation\'s logo')
+  org_config_info_tooltip =  _('This information can only be changed by a system administrator. Contact the Help Desk if you have questions or to request changes.')
+%>
+
 <%= form_for(org, url: url, html: { multipart: true, method: method, id: "edit_org_profile_form" } ) do |f| %>
   <div class="row">
     <div class="form-group col-xs-8">
@@ -36,13 +41,14 @@
 
   <div class="row">
     <div class="col-xs-8">
+      <em class="sr-only"><%= shared_links_tooltip %></em>
       <%= render(partial: '/shared/links',
                  locals: {
                    context: 'org',
                    title: _('Organisation URLs'),
                    links: (org.links.present? ? org.links['org'] : []),
                    max_number_links: MAX_NUMBER_LINKS_FUNDER,
-                   tooltip: _('Links will be displayed next to your organisation\'s logo') }) %>
+                   tooltip: shared_links_tooltip }) %>
       <%= hidden_field_tag('org_links', value: org.links) %>
     </div>
   </div>
@@ -63,8 +69,8 @@
     </div>
   </div>
 
-  <div class="bordered col-xs-8" data-toggle="tooltip" title="<%= _('This information can only be changed by a system administrator. Contact the Help Desk if you have questions or to request changes.') %>">
-    <h3><%= _('Organisational Configuration Information') %></h3>
+  <div class="bordered col-xs-8" data-toggle="tooltip" title="<%= org_config_info_tooltip %>">
+    <h3><%= _('Organisational Configuration Information') %><em class="sr-only"><%= org_config_info_tooltip %></em></h3>
     <% if current_user.can_super_admin? %>
       <% if Rails.application.config.shibboleth_use_filtered_discovery_service %>
         <% shibboleth = org.org_identifiers.select{ |ids| ids.identifier_scheme == IdentifierScheme.find_by(name: 'shibboleth')} %>

--- a/app/views/paginable/templates/_publicly_visible.html.erb
+++ b/app/views/paginable/templates/_publicly_visible.html.erb
@@ -1,3 +1,4 @@
+<% sample_plans_tooltip =  _('Sample plans are provided by a funder, an organisation or a trusted party.') %>
 <div class="table-responsive">
   <table class="table table-hover">
     <thead>
@@ -7,7 +8,10 @@
         <th scope="col"><%= _('Organisation Name') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
         <th scope="col" class="date-column"><%= _('Last Updated') %>&nbsp;<%= paginable_sort_link('templates.updated_at') %></th>
         <th scope="col" class="sorter-false"><%= _('Funder Links') %></th>
-        <th scope="col" class="sorter-false" data-toggle="tooltip" title="<%= _('Sample plans are provided by a funder, an organisation or a trusted party.') %>"><%= _('Sample Plans') %><br><small><%= _('(if available)') %></small></th>
+        <th scope="col" class="sorter-false" data-toggle="tooltip" title="<%= sample_plans_tooltip %>">
+          <%= _('Sample Plans') %><br><small><%= _('(if available)') %></small>
+          <em class="sr-only"><%= sample_plans_tooltip %></em>
+        </th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/plans/_edit_details.html.erb
+++ b/app/views/plans/_edit_details.html.erb
@@ -1,3 +1,7 @@
+<% project_title_tooltip =  _('If applying for funding, state the name exactly as in the grant proposal.') %>
+<% project_abstract_tooltip = _("Briefly summarise your research project to help others understand the purposes for which the data are being collected or created.") %>
+<% id_tooltip = _('A pertinent ID as determined by the funder and/or organisation.') %>
+
 <div class="row">
     <div class="col-md-8">
     <%= form_for plan, html: {method: :put, class: 'form-horizontal edit_plan' } do |f| %>
@@ -6,9 +10,10 @@
           <%= f.label(:title, _('Project title'), class: 'control-label') %>
         </div>
         <div class="col-md-8">
+          <em class="sr-only"><%= project_title_tooltip %></em>
           <%= f.text_field(:title, class: "form-control", "aria-required": true,
             'data-toggle': 'tooltip', spellcheck: true,
-            title: _('If applying for funding, state the name exactly as in the grant proposal.')) %>
+            title: project_title_tooltip) %>
       <div class="checkbox">
         <%= f.hidden_field :visibility %>
         <%= f.label(:is_test, class: 'control-label') do %>
@@ -48,7 +53,8 @@
         <div class="col-md-12">
           <%= f.label(:description, _('Project abstract'), class: 'control-label') %>
         </div>
-        <div class="col-md-8" data-toggle="tooltip" title="<%= _("Briefly summarise your research project to help others understand the purposes for which the data are being collected or created.") %>">
+        <div class="col-md-8" data-toggle="tooltip" title="<%= project_abstract_tooltip %>">
+          <em class="sr-only"><%= project_abstract_tooltip %></em>
           <%= f.text_area(
             :description, rows: 6,
             class: 'form-control tinymce',
@@ -60,9 +66,10 @@
           <%= f.label(:identifier, _('ID'), class: 'control-label') %>
         </div>
         <div class="col-md-8">
+          <em class="sr-only"><%= id_tooltip %></em>
           <%= f.text_field(:identifier, class: "form-control", "aria-required": false,
                            'data-toggle': "tooltip", spellcheck: true,
-                           title: _('A pertinent ID as determined by the funder and/or organisation.')) %>
+                           title: id_tooltip) %>
         </div>
       </div>
       <fieldset class="project-details">

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -2,6 +2,8 @@
 <% editor = Role.new(editor: true, commenter: true) %>
 <% commenter = Role.new(commenter: true) %>
 <% administerable = @plan.administerable_by?(current_user) %>
+<% email_tooltip = _("Enter the email address of your collaborator: If they are already using #{Rails.configuration.branding[:application][:name]}, they will see this plan on their dashboard, and recieve an email. If they are not currently using #{Rails.configuration.branding[:application][:name]}, they will recieve an email inviting them to the tool so they can collaborate on your plan.") %>
+<% permissions_tooltip = _('Co-owner: Has admin-rights to the plan (can invite other users, view the plan, answer questions, or comment). Editor: Has edit-rights to the plan (can view the plan, answer questions, or comment). Read Only: Has read-rights to the plan (can view the plan or comment)') %>
 
 <h2><%= _('Set plan visibility') %></h2>
 <p class="form-control-static"><%= _('Public or organisational visibility is intended for finished plans. You must answer at least %{percentage}%% of the questions to enable these options. Note: test plans are set to private visibility by default.') % { :percentage => Rails.application.config.default_plan_percentage_answered } %></p>
@@ -92,18 +94,20 @@
       <%= f.hidden_field :plan_id %>
       <%= f.fields_for :user do |user| %>
         <%= user.label :email, _('Email'), class: 'control-label'%>
+         <em class="sr-only"><%= email_tooltip %></em>
         <%= user.email_field :email, for: :user, name: "user", class: "form-control",
                             "aria-required": true,
                             'data-toggle': 'tooltip',
                             'data-html': true,
-                            title: _("Enter the email address of your collaborator: <ul><li> If they are already using #{Rails.configuration.branding[:application][:name]}, they will see this plan on their dashboard, and recieve an email. </li> <li> If they are not currently using #{Rails.configuration.branding[:application][:name]}, they will recieve an email inviting them to the tool so they can collaborate on your plan.</li></ul>") %>
+                            title: email_tooltip %>
       <% end %>
     </div>
     <div class="clearfix"></div>
+    <em class="sr-only"><%= permissions_tooltip %></em>
     <%= field_set_tag  nil, class: 'col-xs-2',
                     'data-toggle': 'tooltip',
                     'data-html': true,
-                    title: _('Co-owner: Has admin-rights to the plan (can invite other users, view the plan, answer questions, or comment) <br /> Editor: Has edit-rights to the plan (can view the plan, answer questions, or comment) <br /> Read Only: Has read-rights to the plan(can view the plan or comment)'),
+                    title: permissions_tooltip,
                     'data-placement':'right' do %>
       <%= content_tag :legend , _('Permissions') %>
       <div class="form-group">

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -1,4 +1,11 @@
 <% title _('Create a new plan') %>
+<% required_project_title_tooltip = _('This field is required.') %>
+<% project_title_tooltip = _('If applying for funding, state the project title exactly as in the proposal.') %>
+<% required_research_org_tooltip = _('You must select a research organisation from the list or click the checkbox.') %>
+<% research_org_tooltip = _('Please select a valid research organisation from the list.') %>
+<% required_primary_funding_tooltip = _('You must select a funder from the list or click the checkbox.') %>
+<% primary_funding_tooltip = _('Please select a valid funding organisation from the list.') %>
+
 <div class="row">
   <div class="col-md-12">
     <h1><%= _('Create a new plan') %></h1>
@@ -13,14 +20,15 @@
   <div class="col-md-12">
     <%= form_for Plan.new, url: plans_path do |f| %>
       <!-- Plan name section -->
-      <h2 id="project-title"><span class="red" title="<%= _('This field is required.') %>">* </span><%= _('What research project are you planning?') %></h2>
+      <h2 id="project-title"><span class="red" title="<%= required_project_title_tooltip %>">*<em class="sr-only"><%= required_project_title_tooltip %></em> </span><%= _('What research project are you planning?') %></h2>
       <div class="row">
         <div class="form-group col-xs-6">
+          <em class="sr-only"><%= project_title_tooltip %></em>
           <%= f.text_field(:title, class: 'form-control', 'aria-describedby': 'project-title', 'aria-required': 'true', 'aria-label': 'project-title',
                 'data-toggle': 'tooltip',
                 'data-placement': 'bottom',
                 spellcheck: true,
-                title: _('If applying for funding, state the project title exactly as in the proposal.')) %>
+                title: project_title_tooltip ) %>
         </div>
         <div class="col-md-1">&nbsp;</div>
         <div class="form-group col-xs-5">
@@ -35,11 +43,12 @@
 
       <!-- Organisation selection -->
       <h2 id="research-org">
-        <span class="red" title="<%= _('You must select a research organisation from the list or click the checkbox.') %>">* </span>
+        <span class="red" title="<%= required_research_org_tooltip %>">*<em class="sr-only"><%= required_research_org_tooltip %></em> </span>
         <%= _('Select the primary research organisation') %>
       </h2>
       <div class="row">
         <div class="form-group col-md-6">
+           <em class="sr-only"><%= research_org_tooltip %></em>
           <%= render partial: "shared/accessible_combobox",
                      locals: {name: 'plan[org_name]',
                               id: 'plan_org_name',
@@ -48,7 +57,7 @@
                               attribute: 'name',
                               required: true,
                               error: _('You must select a research organisation from the list.'),
-                              tooltip: _('Please select a valid research organisation from the list.'),
+                              tooltip: research_org_tooltip,
                               placement: 'bottom'} %>
         </div>
         <div class="col-md-1 pad-top-10 create-plan-or"><strong>- <%= _('or') %> -</strong></div>
@@ -64,9 +73,10 @@
       </div>
 
       <!-- Funder selection -->
-      <h2 id="funder-org"><span class="red" title="<%= _('You must select a funder from the list or click the checkbox.') %>">* </span><%= _('Select the primary funding organisation') %></h2>
+      <h2 id="funder-org"><span class="red" title="<%= required_primary_funding_tooltip %>">* <em class="sr-only"><%= required_primary_funding_tooltip %></em> </span><%= _('Select the primary funding organisation') %></h2>
       <div class="row">
         <div class="form-group col-xs-6">
+          <em class="sr-only"><%= primary_funding_tooltip %></em>
           <%= render partial: "shared/accessible_combobox",
                      locals: {name: 'plan[funder_name]',
                               id: 'plan_funder_name',
@@ -75,7 +85,7 @@
                               attribute: 'name',
                               required: true,
                               error: _('You must select a funding organisation from the list.'),
-                              tooltip: _('Please select a valid funding organisation from the list.'),
+                              tooltip: primary_funding_tooltip,
                               placement: 'bottom'} %>
         </div>
         <div class="col-md-1 create-plan-or"><strong>- <%= _('or') %> -</strong></div>

--- a/app/views/shared/_accessible_combobox.html.erb
+++ b/app/views/shared/_accessible_combobox.html.erb
@@ -8,6 +8,7 @@
   <% models.map{|m| json["#{m[attribute]}"] = m.id} %>
   <!-- If the incoming name has a namespace prefix, remove it so that the controller can access the params -->
   <% name = name.gsub(name.match(/^.*\[/)[0].split('_')[0] + '_', '') %>
+  <em class="sr-only"><%= title %></em>
   <input type="text" name="<%= name %>" id="<%= id %>"
          class="js-combobox form-control <%= classes %>" list="<%= id %>_list"
          placeholder="<%= _('Begin typing to see a filtered list') %>"

--- a/app/views/shared/_links.html.erb
+++ b/app/views/shared/_links.html.erb
@@ -10,6 +10,7 @@
         </small>&nbsp;
         <a href="#" aria-label="<%= _('Text') %>" data-toggle="tooltip" data-placement="right" title="<%= tooltip %>">
           <i class="fa fa-question-circle fa-reverse" aria-hidden="true"></i>
+          <em class="sr-only"><%= tooltip %></em>
         </a>
       </h3>
     </div>

--- a/app/views/shared/_popover.html.erb
+++ b/app/views/shared/_popover.html.erb
@@ -1,7 +1,8 @@
 <%# available locals: message, placement %>
 <% if message.present? %>
-  <a href="#" class="btn btn-default" data-toggle="tooltip" 
+  <a href="#" class="btn btn-default" data-toggle="tooltip"
      title="<%= message %>" placement="<%= placement %>">
     <i class="fa fa-question-circle"></i>
+    <em class="sr-only"><%= message %>></em>
   </a>
 <% end %>

--- a/app/views/shared/_table_filter.html.erb
+++ b/app/views/shared/_table_filter.html.erb
@@ -1,3 +1,5 @@
+<% remove_filter_tooltip = _('Remove the filter') %>
+
 <div class="tablefilter form-group pull-right">
   <form>
     <ul class="list-inline">
@@ -8,9 +10,10 @@
             class="clear_filter"
             href="#"
             data-toggle="tooltip"
-            title="<%= _('Remove the filter') -%>" 
-            aria-label="<%= _('Remove the filter') %>">
+            title="<%= remove_filter_tooltip %>"
+            aria-label="<%= remove_filter_tooltip %>">
               <i class="fa fa-times" aria-hidden="true"></i>
+              <em class="sr-only"><%= remove_filter_tooltip %></em>
           </a>
       </li>
     </ul>


### PR DESCRIPTION
…ologies.

The fix consists of adding the current tooltip text to a <em> tag with the bootstrap class
sr-only that is made only available to assitive technologies.

Fix for issue #2174.

