### PR TITLE
Allow Super admins to Archive and Merge users

### DIFF
--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -31,6 +31,46 @@ module SuperAdmin
       render :edit
     end
 
+    def merge
+      @user = User.find(params[:id])
+      authorize @user
+      remove = User.find(params[:merge_id])
+      topic = _("profile for %{remove} into %{keep}" % {
+        remove: remove.name(false)}, keep: @user.name(false))
+      if @user.merge(remove)
+        flash.now[:notice] = success_message(@user, _("merged"))
+      else
+        flash.now[:alert] = failure_message(@user, _("merge"))
+      end
+      render :edit
+    end
+
+    def search
+      @user = User.find(params[:id])
+      @users = User.where('email LIKE ?', "%#{params[:email]}%")
+      authorize @users
+      # WHAT TO RETURN!?!?!
+      if @users.present? # found a user, or Users, submit for merge
+        render json: {
+          form: render_to_string(partial: 'super_admin/users/confirm_merge.html.erb'),
+        }
+      else  # NO USER, re-render w/error?
+        flash.now[:alert] = "Unable to find user"
+        render :edit # re-do as responding w/ json
+      end
+    end
+
+    def archive
+      @user  = User.find(params[:id])
+      authorize @user
+      if @user.archive
+        flash.now[:notice] = success_message(@user, _("archived"))
+      else
+        flash.now[:alert] = failure_message(@user, _("archive"))
+      end
+      render :edit
+    end
+
     private
     def user_params
       params.require(:user).permit(:email, :firstname, :surname, :org_id,

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -36,7 +36,7 @@ module SuperAdmin
       authorize @user
       remove = User.find(params[:merge_id])
       topic = _("profile for %{remove} into %{keep}" % {
-        remove: remove.name(false)}, keep: @user.name(false))
+        remove: remove.name(false), keep: @user.name(false)})
       if @user.merge(remove)
         flash.now[:notice] = success_message(@user, _("merged"))
       else

--- a/app/javascript/views/super_admin/users/edit.js
+++ b/app/javascript/views/super_admin/users/edit.js
@@ -13,6 +13,6 @@ $(() => {
 
   $('#merge_form').on('ajax:success', (e, data) => {
     // replace the search form with the merge form
-    $('#merge_form').html(data.form);
+    $('#merge_form_container').html(data.form);
   });
 });

--- a/app/javascript/views/super_admin/users/edit.js
+++ b/app/javascript/views/super_admin/users/edit.js
@@ -10,4 +10,9 @@ $(() => {
       e.preventDefault();
     }
   });
+
+  $('#merge_form').on('ajax:success', (e, data) => {
+    // replace the search form with the merge form
+    $('#merge_form').html(data.form);
+  });
 });

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -411,10 +411,10 @@ class User < ActiveRecord::Base
     # merge logic
     # => answers -> map id
     to_be_merged.answers.update_all(user_id: self.id)
-    # => comments -> map id
-    to_be_merged.comments.update_all(user_id: self.id)
+    # => notes -> map id
+    to_be_merged.notes.update_all(user_id: self.id)
     # => plans -> map on id roles
-    to_me_merged.roles.update_all(user_id: self.id)
+    to_be_merged.roles.update_all(user_id: self.id)
     # => prefs -> Keep's from self
     # => auths -> map onto keep id only if keep does not have the identifier
     to_be_merged.user_identifiers.

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -49,6 +49,18 @@ class UserPolicy < ApplicationPolicy
     true
   end
 
+  def merge?
+    signed_in_user.can_super_admin?
+  end
+
+  def archive?
+    signed_in_user.can_super_admin?
+  end
+
+  def search?
+    signed_in_user.can_super_admin?
+  end
+
   class Scope < Scope
     def resolve
       scope.where(org_id: user.org_id)

--- a/app/views/super_admin/users/_confirm_merge.html.erb
+++ b/app/views/super_admin/users/_confirm_merge.html.erb
@@ -1,11 +1,16 @@
-<%= form_tag(merge_super_admin_user_path(@user), method: 'get', class: 'form-inline merge_form') do %>
+<p>
+  <%= sanitize _("<br>The selected user's content will be merged into this account. <br> The selected account will then be removed") %>
+</p>
+
+<%= form_tag(merge_super_admin_user_path(@user), method: 'put', class: 'form-inline merge_form') do %>
   <div class="form-group">
     <div class="input-group">
       <span class="input-group-addon" id="search-addon">
         <span class="fa fa-search" aria-hidden="true"></span>
       </span>
-    <%= select_tag(:email, options_from_collection_for_select(@users, "id", "email"), class: "form-control") %>
+    <%= select_tag(:merge_id, options_from_collection_for_select(@users, "id", "email"), class: "form-control") %>
     </div>
   </div>
-  <%= submit_tag( _("Merge"), class: 'btn btn-default', style: 'margin-top: 8px;') %>
+  <%= submit_tag( _("Merge"), class: 'btn btn-default', style: 'margin-top: 8px;', data: { confirm: "Confirm Account Merge:  The selected user-account will be merged and removed.  The associated plans, answers, and comments will belong to #{@user.name}" }) %>
+  <%= link_to(_("Cancel"), edit_super_admin_user_path(@user), class: 'btn btn-default') %>
 <% end %>

--- a/app/views/super_admin/users/_confirm_merge.html.erb
+++ b/app/views/super_admin/users/_confirm_merge.html.erb
@@ -1,0 +1,11 @@
+<%= form_tag(merge_super_admin_user_path(@user), method: 'get', class: 'form-inline merge_form') do %>
+  <div class="form-group">
+    <div class="input-group">
+      <span class="input-group-addon" id="search-addon">
+        <span class="fa fa-search" aria-hidden="true"></span>
+      </span>
+    <%= select_tag(:email, options_from_collection_for_select(@users, "id", "email"), class: "form-control") %>
+    </div>
+  </div>
+  <%= submit_tag( _("Merge"), class: 'btn btn-default', style: 'margin-top: 8px;') %>
+<% end %>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -68,7 +68,7 @@
               <span class="input-group-addon" id="search-addon">
                 <span class="fa fa-search" aria-hidden="true"></span>
               </span>
-            <%= text_field_tag(:email, 'Email', class: "form-control") %>
+            <%= text_field_tag(:email, nil, class: "form-control", placeholder: _("Email")) %>
             </div>
           </div>
           <%= submit_tag( _("Search"), class: 'btn btn-default', style: 'margin-top: 8px;') %>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -58,17 +58,22 @@
       <h2>
         <%= _('Merge Accounts') %>
       </h2>
-      <%= form_tag(search_super_admin_user_path(@user), method: 'get', remote: true, class: 'form-inline', id: 'merge_form') do %>
-        <div class="form-group">
-          <div class="input-group">
-            <span class="input-group-addon" id="search-addon">
-              <span class="fa fa-search" aria-hidden="true"></span>
-            </span>
-          <%= text_field_tag(:email, 'Search for a User by Email', class: "form-control") %>
+      <div id='merge_form_container'>
+        <p>
+          <%= sanitize _("First, search for a user by email, then select them from the list.") %>
+        </p>
+        <%= form_tag(search_super_admin_user_path(@user), method: 'get', remote: true, class: 'form-inline', id: 'merge_form') do %>
+          <div class="form-group">
+            <div class="input-group">
+              <span class="input-group-addon" id="search-addon">
+                <span class="fa fa-search" aria-hidden="true"></span>
+              </span>
+            <%= text_field_tag(:email, 'Email', class: "form-control") %>
+            </div>
           </div>
-        </div>
-        <%= submit_tag( _("Search"), class: 'btn btn-default', style: 'margin-top: 8px;') %>
-      <% end %>
+          <%= submit_tag( _("Search"), class: 'btn btn-default', style: 'margin-top: 8px;') %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -9,24 +9,24 @@
 </div>
 
 <div class="row">
-  <div class="col-md-12">
+  <div class="col-md-7">
     <%= form_for(@user, namespace: :superadmin, as: :user, url: super_admin_user_path(@user), html: {method: :put, id: 'super_admin_user_edit' }) do |f| %>
-      <div class="form-group col-xs-8">
+      <div class="form-group col-xs-12">
         <%= f.label(:email, _('Email'), class: 'control-label') %>
         <%= f.email_field(:email, class: "form-control", "aria-required": true) %>
       </div>
 
-      <div class="form-group col-xs-8">
+      <div class="form-group col-xs-12">
         <%= f.label(:firstname, _('First name'), class: 'control-label') %>
         <%= f.text_field(:firstname, class: "form-control", "aria-required": true) %>
       </div>
 
-      <div class="form-group col-xs-8">
+      <div class="form-group col-xs-12">
         <%= f.label(:surname, _('Last name'), class: 'control-label') %>
         <%= f.text_field(:surname, class: "form-control", "aria-required": true) %>
       </div>
 
-      <div class="form-group col-xs-8" id="org-controls">
+      <div class="form-group col-xs-12" id="org-controls">
         <%= render partial: "shared/my_org", locals: {
             f: f,
             default_org: @user.org,
@@ -36,7 +36,7 @@
       </div>
 
       <% if Language.many? %>
-        <div class="form-group col-xs-8">
+        <div class="form-group col-xs-12">
           <% lang_id = @user.language.nil? ? Language.id_for(FastGettext.default_locale) : @user.language.id %>
           <%= f.label(:language_id, _('Language'), class: 'control-label') %>
           <%= select_tag(:super_admin_user_language_id,
@@ -45,9 +45,30 @@
         </div>
       <% end %>
 
-      <div class="form-group col-xs-8">
+      <div class="form-group col-xs-12">
         <%= f.button(_('Save'), class: 'btn btn-default', type: "submit", id: "personal_details_registration_form_submit") %>
+        <%= link_to _('Archive'), super_admin_user_path(id: @user.id), 'data-method': 'delete', rel: 'nofollow',
+            'data-confirm': _("You are about to archive %{user_name}.  This will remove their personal information, but retain their plans, answers, and comments.  They will be unable to sign-in. Are you sure?") % {user_name: @user.name},
+            class: 'btn btn-default', role: 'button' %>
       </div>
     <% end %>
+  </div>
+  <div class="col-xs-5">
+    <div class="row">
+      <h2>
+        <%= _('Merge Accounts') %>
+      </h2>
+      <%= form_tag(search_super_admin_user_path(@user), method: 'get', remote: true, class: 'form-inline', id: 'merge_form') do %>
+        <div class="form-group">
+          <div class="input-group">
+            <span class="input-group-addon" id="search-addon">
+              <span class="fa fa-search" aria-hidden="true"></span>
+            </span>
+          <%= text_field_tag(:email, 'Search for a User by Email', class: "form-control") %>
+          </div>
+        </div>
+        <%= submit_tag( _("Search"), class: 'btn btn-default', style: 'margin-top: 8px;') %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,7 +259,13 @@ Rails.application.routes.draw do
   namespace :super_admin do
     resources :orgs, only: [:index, :new, :create, :destroy]
     resources :themes, only: [:index, :new, :create, :edit, :update, :destroy]
-    resources :users, only: [:edit, :update]
+    resources :users, only: [:edit, :update] do
+      member do
+        put :merge
+        put :archive
+        get :search
+      end
+    end
     resources :notifications, except: [:show]
   end
 

--- a/lib/unique_random.rb
+++ b/lib/unique_random.rb
@@ -1,0 +1,11 @@
+module UniqueRandom
+
+    def unique_random(field_name:, prefix: '', suffix:'', length: nil)
+      return loop do
+        rand = SecureRandom.urlsafe_base64(length, false)
+        constructed = "#{prefix}#{rand}#{suffix}"
+        break constructed unless self.exists?(field_name.to_sym => constructed)
+      end
+    end
+
+end


### PR DESCRIPTION
Adds 2 options to the super-admin user-edit page:
`Archiving` will remove the user's name, email, and sign-in-IPs.
`Merging` will swap apply the currently edited user's ID to all of the selected user's notes, plans, and answers, then remove the selected user.

<img width="1196" alt="Screenshot 2019-09-04 at 11 54 14" src="https://user-images.githubusercontent.com/7352616/64249080-c1d38c00-cf0a-11e9-8c2b-eb1e8113595c.png">
