### PR TITLE
Removed the clickable link from the Organisation logo, as it was repo…

### DIFF
--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -10,11 +10,10 @@
       </button>
       <% if user_signed_in? && !current_user.org.nil? %>
         <% if current_user.org.logo.present? %>
-          <%= link_to(image_tag(logo_url_for_org(current_user.org),
+          <%= image_tag(logo_url_for_org(current_user.org),
                                 alt: current_user.org.name,
                                 class: "org-logo",
-                                title: current_user.org.name),
-                      current_user.org.target_url) %>
+                                title: current_user.org.name) %>
         <% else %>
           <h4 id="banner-org-name"><%= current_user.org.name %></h4>
         <% end %>


### PR DESCRIPTION
…rted to cause problems for Accessibility. The fact that image link would open the Organisations home page rather than return to the Roadmap page was confusing for users from an Accessibility pont of view.

Change:
  - Organisation logo if present is no longer clickable.

Fix for #2173.

