### PR TITLE
Add an outline to table cell that is in focus.

### DIFF
--- a/app/assets/stylesheets/blocks/_accessibility.scss
+++ b/app/assets/stylesheets/blocks/_accessibility.scss
@@ -57,3 +57,12 @@ a, input, select, .form-control {
     }
   }
   
+  td {
+    &:focus-within,
+    &:focus,
+    &:hover {
+      outline-style: solid !important;
+      outline-color: $color-focus-outline !important;
+      outline-width: 2px !important;
+    }
+  }


### PR DESCRIPTION
Note we use the css :focus-within psuedo class that is not supported in either
IE or Edge
https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within

Fix #2170

Some screen shots (the outline is not totally satisfactory in the way in surrounds the table cell.)
![Ex1_tab_ouline](https://user-images.githubusercontent.com/8876215/64694158-f60df600-d490-11e9-958a-42c61403ed04.png)
![Ex2_tab_outline](https://user-images.githubusercontent.com/8876215/64694165-fa3a1380-d490-11e9-90b3-5cca9dab15a0.png)
