### PR TITLE
Fix for Accessibility issues with Tables (highlighted by UCOP electro…

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ import '../utils/externalLink';
 import '../utils/paginable';
 import '../utils/panelHeading';
 import '../utils/links';
+import '../utils/outOfFocus';
 import '../utils/tabHelper';
 import '../utils/tooltipHelper';
 import '../utils/popoverHelper';

--- a/app/javascript/utils/outOfFocus.js
+++ b/app/javascript/utils/outOfFocus.js
@@ -1,0 +1,9 @@
+$(() => {
+  $('td').children('div.dropdown').each((i, el) => {
+    const td = $(el).parent();
+    const toggleBtn = $(td.find('div.dropdown').find('.dropdown-toggle'));
+    td.focusout(() => {
+      toggleBtn.dropdown('toggle');
+    });
+  });
+});

--- a/app/views/paginable/templates/_customisable.html.erb
+++ b/app/views/paginable/templates/_customisable.html.erb
@@ -7,7 +7,7 @@
         <th scope="col"><%= _('Funder') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
         <th scope="col"><%= _('Status') %></th>
         <th scope="col" class="date-column"><%= _('Edited Date') %>&nbsp;<%= paginable_sort_link('templates.updated_at') %></th>
-        <th>&nbsp;</th>
+        <th scope="col">&nbsp;</th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/paginable/templates/_organisational.html.erb
+++ b/app/views/paginable/templates/_organisational.html.erb
@@ -12,7 +12,7 @@
         <th scope="col"><%= _('Status') %></th>
         <th scope="col" class="date-column"><%= _('Edited Date') %>&nbsp;<%= paginable_sort_link('templates.updated_at') %></th>
         <% if action_name != 'index' %>
-          <th>&nbsp;</th>
+          <th scope="col">&nbsp;</th>
         <% end %>
       </tr>
     </thead>


### PR DESCRIPTION

Changes:
  - Added scope="col" to table header tags <th> that were missing them.
  - The Jquery dropdown menus in tables are closed when the table cell
containing it is out of focus.

(The issue the fontawesome sort icons are read as 'column # link'.
Add some screen reader only text. This issue was sorted by someone else
who added ".screen-reader-text" class to the sort_link_name() method in
app/controllers/concerns/paginable.rb.)

Fix for issue #1455.

**Current issue with dropdown when tabbing from cell with dropdown**: 
the dropdown remains visible
![Selection_003](https://user-images.githubusercontent.com/8876215/65252498-f2ade680-daf0-11e9-897a-09a8bb7f54f1.png)

This commit closed the dropdown when out of focus.
![Selection_001](https://user-images.githubusercontent.com/8876215/65252693-5506e700-daf1-11e9-817e-82554b0f9f2e.png)
![Selection_002](https://user-images.githubusercontent.com/8876215/65252696-5506e700-daf1-11e9-91b5-b13fd61b4594.png)
