### PR TITLE
Updated logic in Plan.num_answered_questions to allow for Phase context

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -93,7 +93,7 @@ class Answer < ActiveRecord::Base
   # presence of text
   #
   # Returns Boolean
-  def is_valid?
+  def answered?
     if question.present?
       if question.question_format.option_based?
         return question_options.any?

--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -52,6 +52,8 @@ class Phase < ActiveRecord::Base
 
   has_many :sections, dependent: :destroy
 
+  has_many :questions, through: :sections
+
   has_many :template_sections, -> {
     not_modifiable
   }, class_name: "Section"

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -486,11 +486,13 @@ class Plan < ActiveRecord::Base
   # The number of answered questions from the entire plan
   #
   # Returns Integer
-  def num_answered_questions
-    Answer.where(id: answers.map(&:id))
-          .includes(:question_options, question: :question_format)
-          .to_a
-          .sum { |answer| answer.is_valid? ? 1 : 0 }
+  def num_answered_questions(phase = nil)
+    return answers.select { |answer| answer.answered? }.length unless phase.present?
+
+    answered = answers.select do |answer|
+      answer.answered? && phase.questions.include?(answer.question)
+    end
+    answered.length
   end
 
   # The number of questions for a plan.
@@ -526,7 +528,7 @@ class Plan < ActiveRecord::Base
                                           question: :question_format)
                                 .where(id: answer_ids)
     num_answers = pre_fetched_answers.reduce(0) do |m, a|
-      m += 1 if a.is_valid?
+      m += 1 if a.answered?
       m
     end
     num_questions == num_answers

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -103,10 +103,11 @@ class Section < ActiveRecord::Base
   # Returns the number of answered questions for a given plan
   def num_answered_questions(plan)
     return 0 if plan.nil?
-    plan.answers.includes({ question: :question_format }, :question_options)
-                .where(question_id: question_ids)
-                .to_a
-                .count(&:is_valid?)
+
+    answered = plan.answers.select do |answer|
+      answer.answered? && questions.include?(answer.question)
+    end
+    answered.length
   end
 
   def deep_copy(**options)

--- a/app/views/answers/_status.html.erb
+++ b/app/views/answers/_status.html.erb
@@ -2,7 +2,7 @@
 <!-- Partial for handling the answer status (e.g. saving, error-saving, data-status) -->
 <span class="label label-info status" style="display:none;" data-status="saving"><%= _('Saving...') %></span>
 <span class="label label-warning status" style="display: none;" data-status="error-saving"></span>
-<% if answer.is_valid? %>
+<% if answer.answered? %>
     <span class="label label-info status" data-status="saved-at">
       <%= _('Answered')%> <time class="timeago" datetime="<%= answer.updated_at.iso8601 %>"></time>
       <%= _(' by %{user_name}') %{ :user_name => answer.user.name } if answer.user.present? %>

--- a/app/views/plans/_progress.html.erb
+++ b/app/views/plans/_progress.html.erb
@@ -1,6 +1,6 @@
 <%# locals: { plan, current_phase } %>
 <%
-  nanswers = current_phase.num_answered_questions(plan)
+  nanswers = plan.num_answered_questions(current_phase)
   nquestions = current_phase.num_questions()
   value=(nanswers.to_f/nquestions*100).round(2)
 %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -42,7 +42,7 @@
           <% end %>
         <% end %>
         <% answer = @plan.answer(question[:id], false) %>
-        <% blank = not(answer.present? && answer.is_valid?) %>
+        <% blank = not(answer.present? && answer.answered?) %>
         <% if blank && @show_unanswered %>
           <%= "    #{_("Question not answered.")}\n\n" %>
         <% elsif !blank %>

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -73,11 +73,11 @@ RSpec.describe Answer, type: :model do
 
   end
 
-  describe "#is_valid?" do
+  describe "#answered?" do
 
     let!(:answer) { create(:answer) }
 
-    subject { answer.is_valid? }
+    subject { answer.answered? }
 
     context "question present, question format is option and options empty" do
 


### PR DESCRIPTION
Fixes #2095 .

Addresses an issue with the progress bar 'answered questions` count when a plan is for a template with multiple phases. Updated the `num_answered_questions` method to accept a Phase so that it can return either the total number of questions answered for the entire plan or a specific section.