### PR TITLE
Fix for format issues for bullet points in Plan docx exports.

### DIFF
--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -53,21 +53,21 @@
 
                   <%# case where Question has options %>
                   <% if options.any? %>
-                    <ul>
+                    <ol>
                       <% options.each do |opt| %>
                         <li><%= opt.text %></li>
                       <% end %>
-                    </ul>
+                    </ol>
                   <% end %>
                   <%# case for RDA answer display %>
                   <% if question[:format].rda_metadata? && !blank %>
                     <% ah = answer.answer_hash %>
                     <% if ah['standards'].present? %>
-                      <ul>
+                      <ol>
                         <% ah['standards'].each do |id, title| %>
                           <li><%= title %></li>
                         <% end %>
-                      </ul>
+                      </ol>
                     <% end %>
                     <p><%= sanitize ah['text'] %></p>
                     <br>


### PR DESCRIPTION
**(NOT FOR MERGING YET: Identified issue for non-options in older Word versions.)**

The fix was suggested by @benjaminfaure: https://github.com/DMPRoadmap/roadmap/issues/2147#issuecomment-535935932

Changes:
Replaced <li> tag with <ol> in _plan.erb as suggested by @benjaminfaure
that <li> tag being transformed as € sign in the Word export.

Fix for issue #2147

