### PR TITLE
fixed deprecation warnings for Rspec tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -236,11 +236,7 @@ group :test do
   # Automatically create snapshots when Cucumber steps fail with Capybara and Rails (http://github.com/mattheworiordan/capybara-screenshot)
   gem "capybara-screenshot"
 
-  # The next generation developer focused tool for automated testing of webapps (https://github.com/SeleniumHQ/selenium)
-  gem "selenium-webdriver", "~> 3.14"
-
-  # Easy installation and use of chromedriver. (https://github.com/flavorjones/chromedriver-helper)
-  gem "chromedriver-helper", ">= 1.2.0"
+  gem 'webdrivers', '~> 3.0'
 
   gem "rspec-collection_matchers"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,8 +49,6 @@ GEM
     annotate_gem (0.0.14)
       bundler (>= 1.1)
     api-pagination (4.8.2)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
     autoprefixer-rails (9.6.1.1)
@@ -87,10 +85,7 @@ GEM
     capybara-screenshot (1.0.23)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (1.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
+    childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     contact_us (1.2.0)
@@ -200,7 +195,6 @@ GEM
       rubyzip (>= 1.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     ipaddress (0.8.3)
     jaro_winkler (1.5.3)
     jbuilder (2.6.4)
@@ -411,8 +405,8 @@ GEM
       sprockets-rails
       tilt
     sax-machine (1.3.2)
-    selenium-webdriver (3.142.5)
-      childprocess (>= 0.5, < 3.0)
+    selenium-webdriver (3.142.6)
+      childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     shellany (0.0.1)
     shoulda (3.6.0)
@@ -455,6 +449,10 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
+    webdrivers (3.9.4)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.7.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -490,7 +488,6 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
-  chromedriver-helper (>= 1.2.0)
   contact_us
   database_cleaner
   devise (>= 4.7.1)
@@ -538,7 +535,6 @@ DEPENDENCIES
   ruby_dig
   sass-rails
   sassc-rails
-  selenium-webdriver (~> 3.14)
   shoulda
   simplecov
   spring
@@ -546,6 +542,7 @@ DEPENDENCIES
   text
   thin
   web-console
+  webdrivers (~> 3.0)
   webmock
   webpacker (~> 3.5)
   wicked_pdf (~> 1.1.0)

--- a/spec/factories/departments.rb
+++ b/spec/factories/departments.rb
@@ -20,6 +20,6 @@ FactoryBot.define do
   factory :department do
     name { Faker::Commerce.department }
     code { SecureRandom.hex(5) }
-    org_id { Faker::Number.number(5) }
+    org_id { Faker::Number.number(digits: 5) }
   end
 end

--- a/spec/factories/question_formats.rb
+++ b/spec/factories/question_formats.rb
@@ -13,7 +13,7 @@
 
 FactoryBot.define do
   factory :question_format do
-    title { Faker::Lorem.words(3).join }
+    title { Faker::Lorem.words(number: 3).join }
     description { "http://test.host" }
     formattype { QuestionFormat::FORMAT_TYPES.sample }
 

--- a/spec/factories/stat_created_plan.rb
+++ b/spec/factories/stat_created_plan.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :stat_created_plan do
     date { Date.today }
     org { create(:org) }
-    count { Faker::Number.number(10) } 
+    count { Faker::Number.number(digits: 10) }
   end
 end

--- a/spec/factories/stat_joined_user.rb
+++ b/spec/factories/stat_joined_user.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :stat_joined_user do
     date { Date.today }
     org { create(:org) }
-    count { Faker::Number.number(10) }
+    count { Faker::Number.number(digits: 10) }
   end
 end

--- a/spec/mixins/versionable_model.rb
+++ b/spec/mixins/versionable_model.rb
@@ -4,7 +4,6 @@ UUID_REGEX ||= /\A[\w\d]{8}(\-[\w\d]{4}){3}-[\w\d]{12}\Z/i
 
 shared_examples_for "VersionableModel" do
 
-
   context "attributes" do
 
     it { is_expected.to have_readonly_attribute(:versionable_id) }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'webdrivers/chromedriver'
 require_relative "helpers/capybara_helper"
 require_relative "helpers/sessions_helper"
 require_relative "helpers/tiny_mce_helper"
@@ -9,6 +10,9 @@ SCREEN_SIZE = [2400, 1350]
 DIMENSION   = Selenium::WebDriver::Dimension.new(*SCREEN_SIZE)
 
 Capybara.default_driver = :rack_test
+
+# Cache for one hour
+Webdrivers.cache_time = 3600
 
 # This is a customisation of the default :selenium_chrome_headless config in:
 # https://github.com/teamcapybara/capybara/blob/master/lib/capybara.rb


### PR DESCRIPTION
Made the following updates:
- Removed old `chromedriver` and `seleniuv-webdriver` gems in favor of `web drivers` gem
- Updated Faker calls so that they use named arguments now
- Renamed `spec/mixins/versionable_model_spec.rb` to `spec/mixins/versionable_model.rb`. The file is loaded by the Rails/Rspec config and was also getting picked up and redefined by Rspec because of the `_spec` suffix o the name.

Still receiving a `.../rails-html-sanitizer-1.2.0/lib/rails/html/scrubbers.rb:148: warning: constant Loofah::HTML5::WhiteList is deprecated` warning. Our `rails-html-serializer` and `loofah` versions are all up to date. Not sure why this is still complaining. I'm guessing it may have something to do with us still being on Rails 4.x.

We may want to consider upgrading to 5.x in the near future since 4.x no longer has support 😓 