### PR TITLE
fixed bug with saving template visibility

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -174,7 +174,11 @@ module OrgAdmin
       template = Template.find(params[:id])
       authorize template
       begin
-        template.assign_attributes(template_params)
+        args = template_params
+        # Swap in the appropriate visibility enum value for the checkbox value
+        args[:visibility] = args.fetch(:visibility, '0') == '1' ? 'organisationally_visible' : 'publicly_visible'
+
+        template.assign_attributes(args)
         if params["template-links"].present?
           template.links = ActiveSupport::JSON.decode(params["template-links"])
         end

--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -20,8 +20,7 @@
                          placement: 'right' }%>
     <div class="checkbox">
       <%= f.label(:visibility) do %>
-        <%= check_box_tag('template_visibility', '0',
-                            (f.object.visibility == 'organisationally_visible')) %>
+        <%= f.check_box(:visibility, checked: f.object.visibility == 'organisationally_visible') %>
 
         <%= _('for internal %{org_name} use only') % { org_name: f.object.org.name } %>
       <% end %>


### PR DESCRIPTION
Fixes #1712 .

Updated logic to properly display and save changes to a Template's visibility. 

To test/replicate the issue, make an org a 'Funder' and an 'Org' org_type. Then edit one of their templates. You should see the visibility checkbox. Try to check/uncheck the box and save.

