### PR TITLE
added some filename sanitization and now limiting filenames to 100 ch…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,9 @@ gem 'htmltoword'
 # A feed fetching and parsing library (http://feedjira.com)
 gem 'feedjira'
 
+# Filename sanitization for Ruby. This is useful when you generate filenames for downloads from user input
+gem 'zaru'
+
 # ------------------------------------------------
 # INTERNATIONALIZATION
 # Simple FastGettext Rails integration. (http://github.com/grosser/gettext_i18n_rails)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ GEM
     yard-tomdoc (0.7.1)
       tomparse (>= 0.4.0)
       yard
+    zaru (0.3.0)
 
 PLATFORMS
   ruby
@@ -549,6 +550,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
   yard
   yard-tomdoc
+  zaru
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -88,7 +88,15 @@ class PlanExportsController < ApplicationController
   end
 
   def file_name
-    @plan.title.gsub(/ /, "_")
+    # Sanitize bad characters and replace spaces with underscores
+    ret = @plan.title
+    Zaru.sanitize! ret
+    ret = ret.strip.gsub(/\s+/, "_")
+    # limit the filename length to 100 chars. Windows systems have a MAX_PATH allowance
+    # of 255 characters, so this should provide enough of the title to allow the user
+    # to understand which DMP it is and still allow for the file to be saved to a deeply
+    # nested directory
+    ret[0, 100]
   end
 
   def publicly_authorized?


### PR DESCRIPTION
Fixes #2249 and #2251.

- Added the Zaru gem which handles file name sanitization. 
- Updated regex so that multiple spaces convert to a single underscore (e.g. 'foo   bar' becomes 'foo_bar' instead of 'foo___bar')
- Limit the length of the filename to 100 characters. Some Windows versions have a `MAX_PATH` setting that only allows 255 characters (for the filename + path). 100 should provide the user with enough of the title to provide context while allowing for the location they save it to to be pretty deeply nested. https://stackoverflow.com/questions/265769/maximum-filename-length-in-ntfs-windows-xp-and-windows-vista
