### PR TITLE
Updated functionality for Admin View of Users.

### DIFF
--- a/app/controllers/org_admin/users_controller.rb
+++ b/app/controllers/org_admin/users_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module OrgAdmin
+
+  class UsersController < ApplicationController
+
+    after_action :verify_authorized
+
+    def edit
+      @user = User.find(params[:id])
+      authorize @user
+      @departments = @user.org.departments.order(:name)
+      @plans = Plan.active(@user).page(1)
+      render "org_admin/users/edit",
+             locals: { user: @user,
+                       departments: @departments,
+                       plans: @plans,
+                       languages: @languages,
+                       orgs: @orgs,
+                       identifier_schemes: @identifier_schemes,
+                       default_org: @user.org }
+    end
+
+    def update
+      @user = User.find(params[:id])
+      authorize @user
+      @departments = @user.org.departments.order(:name)
+      @plans = Plan.active(@user).page(1)
+      # Replace the 'your' word from the canned responses so that it does
+      # not read 'Successfully updated your profile for John Doe'
+      topic = _("profile for %{username}") % { username: @user.name(false) }
+      if @user.update_attributes(user_params)
+        flash.now[:notice] = success_message(@user, _("updated"))
+      else
+        flash.now[:alert] = failure_message(@user, _("update"))
+      end
+      render :edit
+    end
+
+
+
+
+    private
+    def user_params
+      params.require(:user).permit(:department_id)
+    end
+
+  end
+
+end

--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -49,4 +49,18 @@ class Paginable::PlansController < ApplicationController
     )
   end
 
+  # GET /paginable/plans/org_admin/:page
+  def org_admin_other_user
+    @user = User.find(params[:id])
+    authorize @user
+    unless current_user.present? && current_user.can_org_admin? && @user.present?
+      raise Pundit::NotAuthorizedError
+    end
+    paginable_renderise(
+      partial: "org_admin_other_user",
+      scope: Plan.organisationally_or_publicly_visible(@user),
+      query_params: { sort_field: 'plans.updated_at', sort_direction: :desc }
+    )
+  end
+
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -34,11 +34,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def edit?
-    signed_in_user.can_super_admin?
+    signed_in_user.can_super_admin? || signed_in_user.can_org_admin?
   end
 
   def update?
-    signed_in_user.can_super_admin?
+    signed_in_user.can_super_admin? || signed_in_user.can_org_admin?
   end
 
   def update_email_preferences?

--- a/app/views/org_admin/users/edit.html.erb
+++ b/app/views/org_admin/users/edit.html.erb
@@ -1,0 +1,77 @@
+<div class="row">
+  <div class="col-md-12">
+    <h1>
+      <%= _('Editing profile for %{username}') % { username: @user.name(false) } %>
+      <%= link_to(_('View all users'), admin_index_users_path, class: 'btn btn-default pull-right', role: 'button') %>
+    </h1>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-7">
+    <%= form_for(@user, namespace: :orgadmin, as: :user, url: org_admin_user_path(@user), html: {method: :put, id: 'org_admin_user_edit' }) do |f| %>
+      <div class="form-group col-xs-12">
+        <%= f.label(:email, _('Email'), class: 'control-label') %>
+        <%= f.email_field(:email, class: "form-control", "disabled": true) %>
+      </div>
+
+      <div class="form-group col-xs-12">
+        <%= f.label(:firstname, _('First name'), class: 'control-label') %>
+        <%= f.text_field(:firstname, class: "form-control", "disabled": true) %>
+      </div>
+
+      <div class="form-group col-xs-12">
+        <%= f.label(:surname, _('Last name'), class: 'control-label') %>
+        <%= f.text_field(:surname, class: "form-control", "disabled": true) %>
+      </div>
+
+      <% if @departments.any? %>
+      <div class="form-group col-xs-8">
+        <% dept_id = @user.department.nil? ? -1 : @user.department.id  %>
+        <%= f.label(:department_id, _('Department or school'), class: 'control-label') %>
+        <%= select_tag(:department_id,
+            options_from_collection_for_select(@departments, "id", "name", dept_id),
+            include_blank: true,
+            class: "form-control",
+            name: 'user[department_id]') %>
+      </div>
+      <% end %>
+
+      <% if Language.many? %>
+        <div class="form-group col-xs-12">
+          <% lang_id = @user.language.nil? ? Language.id_for(FastGettext.default_locale) : @user.language.id %>
+          <%= f.label(:language_id, _('Language'), class: 'control-label') %>
+          <%= select_tag(:org_admin_user_language_id,
+              options_from_collection_for_select(Language.sorted_by_abbreviation, "id", "name", lang_id),
+              disabled: true,
+              class: "form-control", name: 'org_admin_user[language_id]') %>
+        </div>
+      <% end %>
+
+      <div class="form-group col-xs-12">
+        <!-- Hide save button if no departments for org -->
+        <% if @departments.any? %>
+          <%= f.button(_('Save'), class: 'btn btn-default', type: "submit", id: "personal_details_registration_form_submit") %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h2><%= _('Plans') % { username: @user.name(false) } %></h2>
+    <!-- if the user has projects -->
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <%= paginable_renderise(
+      partial: '/paginable/plans/org_admin_other_user',
+      controller: 'paginable/plans',
+      action: 'org_admin_other_user',
+      scope: @plans,
+      query_params: { sort_field: 'plans.updated_at', sort_direction: 'desc' }) %>
+  </div>
+  </div>
+</div>

--- a/app/views/paginable/plans/_org_admin_other_user.html.erb
+++ b/app/views/paginable/plans/_org_admin_other_user.html.erb
@@ -1,0 +1,34 @@
+<div class="table-responsive">
+  <table class="table table-hover" id="my-plans">
+    <thead>
+      <tr>
+        <th scope="col"><%= _('Project Title') %>&nbsp;<%= paginable_sort_link('plans.title') %></th>
+        <th scope="col"><%= _('Template') %>&nbsp;<%= paginable_sort_link('templates.title') %></th>
+        <th scope="col"><%= _('Organisation') %></th>
+        <th scope="col"><%= _('Owner') %></th>
+        <th scope="col" class="date-column"><%= _('Updated') %>&nbsp;<%= paginable_sort_link('plans.updated_at') %></th>
+        <th scope="col"><%= _('Visibility') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% scope.each do |plan| %>
+        <tr>
+          <td>
+            <% if plan.readable_by?(current_user.id) %>
+              <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
+            <% else %>
+              <%= plan.title.truncate(60) %>
+            <% end %>
+          </td>
+          <td><%= plan.template.title %></td>
+          <td><%= plan.owner.org.name %></td>
+          <td><%= plan.owner.name(false) %></td>
+          <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
+          <td class="plan-visibility">
+            <%= plan.visibility === 'is_test' ? _('Test') : sanitize(display_visibility(plan.visibility)) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -1,4 +1,5 @@
 <% is_super_admin = current_user.can_super_admin? %>
+<% is_org_admin = current_user.can_org_admin? %>
 <div class="row">
   <div class="col-md-12">
     <div class="table-responsive">
@@ -23,7 +24,13 @@
                 <tr>
                   <td>
                       <% if !user.name.nil? %>
-                          <%= is_super_admin ? link_to(user.name(false), edit_super_admin_user_path(user)) : user.name(false) %>
+                         <% if is_super_admin %>
+                          <%=  link_to(user.name(false), edit_super_admin_user_path(user)) %>
+                         <% elsif is_org_admin %>
+                           <%=  link_to(user.name(false), edit_org_admin_user_path(user)) %>
+                         <% else %>
+                          <%= user.name(false) %>
+                         <% end %>
                       <% else %>
                           <%= is_super_admin ? link_to(_('Edit Profile'), edit_user_registration_path(user)) : '' %>
                       <% end %>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -35,6 +35,18 @@
             required: true } %>
       </div>
 
+      <% if @departments.any? %>
+      <div class="form-group col-xs-8">
+        <% dept_id = @user.department.nil? ? -1 : @user.department.id  %>
+        <%= f.label(:department_id, _('Department or school'), class: 'control-label') %>
+        <%= select_tag(:department_id,
+            options_from_collection_for_select(@departments, "id", "name", dept_id),
+            include_blank: true,
+            class: "form-control",
+            name: 'user[department_id]') %>
+      </div>
+      <% end %>
+
       <% if Language.many? %>
         <div class="form-group col-xs-12">
           <% lang_id = @user.language.nil? ? Language.id_for(FastGettext.default_locale) : @user.language.id %>
@@ -75,5 +87,23 @@
         <% end %>
       </div>
     </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <h2><%= _('Plans') % { username: @user.name(false) } %></h2>
+    <!-- if the user has projects -->
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <%= paginable_renderise(
+      partial: '/paginable/plans/org_admin_other_user',
+      controller: 'paginable/plans',
+      action: 'org_admin_other_user',
+      scope: @plans,
+      query_params: { sort_field: 'plans.updated_at', sort_direction: 'desc' }) %>
+  </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Rails.application.routes.draw do
       get 'organisationally_or_publicly_visible/:page', action: :organisationally_or_publicly_visible, on: :collection, as: :organisationally_or_publicly_visible
       get 'publicly_visible/:page', action: :publicly_visible, on: :collection, as: :publicly_visible
       get 'org_admin/:page', action: :org_admin, on: :collection, as: :org_admin
+      get 'org_admin_other_user/:page', action: :org_admin_other_user, on: :collection, as: :org_admin_other_user
     end
     # Paginable actions for users
     resources :users, only: [] do
@@ -207,6 +208,7 @@ Rails.application.routes.draw do
 
   # ORG ADMIN specific pages
   namespace :org_admin do
+    resources :users, only: [:edit, :update], controller: "users"
     resources :plans, only: [:index] do
       member do
         get 'feedback_complete'


### PR DESCRIPTION
Changes:
 - for Super Admins: Added user department and plans.
 - for Org Admins:
        (1) The user view now has a clickable link for opening up
            a view of a user's profile and plans.
        (2) In a user's profile view the Department if it exists for the
            organisation is editable. The Organisation must have
            departments in systerm to avail of this functionality.

Fix for #2240.

**Super Admins' View:**
![Selection_029](https://user-images.githubusercontent.com/8876215/67292149-89980500-f4da-11e9-9b00-aafbb3607dfd.png)

**Org Admins' Views:**
![Selection_028](https://user-images.githubusercontent.com/8876215/67292257-b2b89580-f4da-11e9-9479-bd47681f601b.png)
![Selection_027](https://user-images.githubusercontent.com/8876215/67292259-b3512c00-f4da-11e9-9287-949da6c507e8.png)
![Selection_026](https://user-images.githubusercontent.com/8876215/67292262-b3e9c280-f4da-11e9-81f3-c765dcdb1f7b.png)
