### PR TITLE
Fix to make labels for the Permissions radio buttons on the Plan

### DIFF
--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -112,20 +112,20 @@
       <%= content_tag :legend , _('Permissions') %>
       <div class="form-group">
         <div class="radio">
-          <%= f.label :access do %>
-            <%= f.radio_button :access, administrator.access, "aria-required": true %>
+          <%= f.label :administrator_access do %>
+            <%= f.radio_button :access, administrator.access, id: "role_administrator_access", "aria-required": true %>
             <%= _('Co-owner') %>
           <% end %>
         </div>
         <div class="radio">
-          <%= f.label :access do %>
-            <%= f.radio_button :access, editor.access %>
+          <%= f.label :editor_access do %>
+            <%= f.radio_button :access, editor.access , id: "role_editor_access" %>
             <%= _('Editor') %>
           <% end %>
         </div>
         <div class="radio">
-          <%= f.label :access do %>
-            <%= f.radio_button :access, commenter.access %>
+          <%= f.label :commenter_access do %>
+            <%= f.radio_button :access, commenter.access, id: "role_commenter_access" %>
             <%= _('Read only') %>
           <% end %>
         </div>


### PR DESCRIPTION

Share tab clickable.

All the Write Plan sections seen to have clickable labels for radio
buttons and checkboxes.

Change:
- renamed the f.label helper method object to match id added to
f.radio_button helper.

Fix for issue #1656.

![Selection_044](https://user-images.githubusercontent.com/8876215/68224043-d35a1280-ffe5-11e9-8ed4-63396e72ac04.png)