### PR TITLE
Fix for making the Guidance/Comments sections of plan accessible by

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
     mysql2 (0.4.10)
     nenv (0.3.0)
     nio4r (2.5.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.3)
       nenv (~> 0.1)

--- a/app/views/phases/_guidances_notes.html.erb
+++ b/app/views/phases/_guidances_notes.html.erb
@@ -34,6 +34,7 @@
                 aria-controls="<%= "#guidance_per_question_#{question.id}_#{i}" %>"
                 role="tab"
                 data-toggle="tab"
+                tabindex="0"
                 class="view-plan-guidance">
                 <%= tab[:name] %>
               </a>


### PR DESCRIPTION
tabbing. The links were not accessible by keyboard tabbing.

Change:
- added tabindex="0" to links within Guidance/Comments sections as a
hack as they were being ignored as links for tabbing. According to https://webaim.org/techniques/keyboard/tabindex

   tabindex="0"
      - allows elements besides links and form elements to receive
      keyboard focus. It does not change the tab order, but places the element
      in the logical navigation flow, as if it were a link on the page.
      - a value of 0 indicates that the element should be placed in the default navigation order.
      This allows elements that are not natively focusable (such as <div>, <span>, <p>, and <a> with no href)
      to receive keyboard focus. Links and form controls are best for almost all interactive elements,
      but tabindex="0" allows other elements to be focusable and able to trigger interaction.

Fix for #1444.

![Selection_053](https://user-images.githubusercontent.com/8876215/69251158-e570af00-0ba8-11ea-9236-0ab8b6835f89.png)
