### PR TITLE
fixed issue with archiving users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -394,16 +394,18 @@ class User < ActiveRecord::Base
   #
   # Returns boolean
   def archive
-    firstname = 'Deleted'
-    surname = 'User'
-    email = User.unique_random(field_name: 'email', prefix: 'user_',
-      suffix: '@removed_users.dcc', length: 5)
-    recovery_email = nil
-    api_token = nil
-    encrypted_password = nil
-    last_sign_in_ip = nil
-    current_sign_in_ip =  nil
-    active = false
+    self.firstname = 'Deleted'
+    self.surname = 'User'
+    self.email = User.unique_random(field_name: 'email',
+      prefix: 'user_',
+      suffix: Rails.configuration.branding[:application].fetch(:archived_accounts_email_suffix, '@example.org'),
+      length: 5)
+    self.recovery_email = nil
+    self.api_token = nil
+    self.encrypted_password = nil
+    self.last_sign_in_ip = nil
+    self.current_sign_in_ip =  nil
+    self.active = false
     return self.save
   end
 

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -59,8 +59,9 @@
 
       <div class="form-group col-xs-12">
         <%= f.button(_('Save'), class: 'btn btn-default', type: "submit", id: "personal_details_registration_form_submit") %>
-        <%= link_to _('Archive'), super_admin_user_path(id: @user.id), 'data-method': 'delete', rel: 'nofollow',
-            'data-confirm': _("You are about to archive %{user_name}.  This will remove their personal information, but retain their plans, answers, and comments.  They will be unable to sign-in. Are you sure?") % {user_name: @user.name},
+
+        <%= link_to _('Archive'), archive_super_admin_user_path(id: @user.id),
+            data: { method: :put, confirm: _("You are about to archive %{user_name}.  This will remove their personal information, but retain their plans, answers, and comments.  They will be unable to sign-in. Are you sure?") % {user_name: @user.name } },
             class: 'btn btn-default', role: 'button' %>
       </div>
     <% end %>

--- a/config/branding.yml.sample
+++ b/config/branding.yml.sample
@@ -2,7 +2,7 @@ defaults: &defaults
   legal_entity: 'the University of Edinburgh, University of Glasgow and the University of California'
 
   # Warning: The abbreviation here should match the org.abbreviation value registered in your database!
-  organisation:
+  organisation: &organization_defaults
     name: 'Curation Center'
     abbreviation: 'CC'  # This value is used to identify the default guidance that get auto-selected when a new plan is created
     url: 'https://github.com/DMPRoadmap/roadmap/wiki'
@@ -32,7 +32,7 @@ defaults: &defaults
     #          Comment this line out if you want to use DMPRoadmap's built-in contact form.
     contact_us_url: 'https://somewhere.com/contact-us'
 
-  application:
+  application: &application_defaults
     name: 'DMPRoadmap'
     url: 'https://github.com/DMPRoadmap/roadmap'
     version: '0.1.0'
@@ -41,6 +41,7 @@ defaults: &defaults
     user_group_subscription_url: 'http://listserv.ucop.edu/cgi-bin/wa.exe?SUBED1=ROADMAP-L&A=1'
     api_documentation_url: 'https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation'
     api_max_page_size: 100
+    archived_accounts_email_suffix: '@removed_accounts-example.org'
 
   preferences:
     email:


### PR DESCRIPTION
Fixes #1489 .

Changes proposed in this PR:
- Fixed 'Archive' link/button to go to the correct controller/action
- Moved the default email suffix to the branding.yml file @xsrust you will need to add this value to your copy
- Updated the 'archive' method on the User model to update the fields (was not actually saving the changes without the `self.` bit
