### PR TITLE
Fixes issue with saving an Organization's shibboleth identifiers

### DIFF
--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -52,7 +52,7 @@
       <%= hidden_field_tag('org_links', value: org.links) %>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="form-group col-xs-8">
       <h3><%= _("Administrator contact") %></h3>
@@ -79,7 +79,7 @@
         <div class="row">
           <div class="form-group col-xs-8">
             <%= f.label :shib_id, _('Shibboleth Entity Id'), class: "control-label" %>
-            <%= text_field_tag :shib_id, shib_id, class: "form-control", placeholder: _('Example: urn:mace:incommon:my-org.org') %>
+            <%= text_field_tag :shib_id, shib_id, class: "form-control", placeholder: _('Example: https://idp.my-org.org/... or urn:mace:...') %>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Fixes #2288 

Changes proposed in this PR:
- Reworked save logic. The original was only allowing the 'create' and 'destroy' for an org_identifier.
- Also updated the placeholder text to display both the 'https://my-org.edu' and 'urn:mace:incommon:my-org' style Shibboleth entityIDs
