### PR TITLE
Updated deep_copy on Plan model to set feedback_requested to false

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -210,6 +210,7 @@ class Plan < ActiveRecord::Base
   def self.deep_copy(plan)
     plan_copy = plan.dup
     plan_copy.title = "Copy of " + plan.title
+    plan_copy.feedback_requested = false
     plan_copy.save!
     plan.answers.each do |answer|
       answer_copy = Answer.deep_copy(answer)

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -421,12 +421,17 @@ describe Plan do
 
   describe ".deep_copy" do
 
-    let!(:plan) { create(:plan, :creator, answers: 2, guidance_groups: 2) }
+    let!(:plan) { create(:plan, :creator, answers: 2, guidance_groups: 2,
+                         feedback_requested: true) }
 
     subject { Plan.deep_copy(plan) }
 
     it "prepends the title with 'Copy'" do
       expect(subject.title).to include("Copy")
+    end
+
+    it "sets feedback_requested to false" do
+      expect(subject.feedback_requested).to eql(false)
     end
 
     it "copies the title from source" do


### PR DESCRIPTION
Fixes #2180 .

Changes proposed in this PR:
- If a feedback had been requested for a plan, and then someone copies the plan, the copy was retaining the `feedback_requested` flag. I have updated the `deep_copy` method on the Plan model so that it always sets this flag to false.
- Added a test to Plan model's `deep_copy` method to check that feedback_requested is set to false
