### PR TITLE
fixed typo in plan export

### DIFF
--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -57,7 +57,7 @@
                       <% options.each do |opt| %>
                         <li><%= opt.text %></li>
                       <% end %>
-                    </l>
+                    </ul>
                   <% end %>
                   <%# case for RDA answer display %>
                   <% if question[:format].rda_metadata? && !blank %>


### PR DESCRIPTION
Fixes a layout issue discovered by @benjaminfaure.

Changes proposed in this PR:
- updated erb so from `</l>` to `</ul>`
