### PR TITLE
Fixed issue #2314

### DIFF
--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -58,7 +58,7 @@ class Paginable::PlansController < ApplicationController
     end
     paginable_renderise(
       partial: "org_admin_other_user",
-      scope: Plan.organisationally_or_publicly_visible(@user),
+      scope: Plan.active(@user),
       query_params: { sort_field: 'plans.updated_at', sort_direction: :desc }
     )
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -65,6 +65,10 @@ class UserPolicy < ApplicationPolicy
     signed_in_user.can_super_admin?
   end
 
+  def org_admin_other_user?
+    signed_in_user.can_super_admin? || signed_in_user.can_org_admin?
+  end
+
   class Scope < Scope
     def resolve
       scope.where(org_id: user.org_id)


### PR DESCRIPTION
Fixes issue #2314 
- Added `org_admin_other_user?` policy in UserPolicy
- Plans displayed on the user profile, using pagination should be all the user's plan. Changed pulled plans from `organisationally_or_publicly_visible` to `active`.