### PR TITLE
added method to reattach labels to their corresponding tinymce iframe

### DIFF
--- a/app/javascript/utils/tinymce.js
+++ b/app/javascript/utils/tinymce.js
@@ -56,6 +56,23 @@ const resizeEditors = (editors) => {
   });
 };
 
+/*
+  This function is invoked after the Tinymce widget is initialized. It moves the
+  connection with the label from the hidden field (that the Tinymce writes to
+  behind the scenes) to the Tinymce iframe so that screen readers read the correct
+  label when the tinymce iframe receives focus.
+ */
+const attachLabelToIframe = (tinymceContext) => {
+  const iframe = $(tinymceContext).siblings('.mce-container').find('iframe');
+  if (isObject(iframe)) {
+    const lbl = iframe.closest('form').find('label');
+    if (isObject(lbl)) {
+      // Connect the label to the iframe
+      lbl.attr('for', iframe.attr('id'));
+    }
+  }
+};
+
 export const Tinymce = {
   /*
     Initialises a tinymce editor given the object passed. If a non-valid object is passed,
@@ -68,6 +85,11 @@ export const Tinymce = {
     } else {
       tinymce.init(defaultOptions).then(resizeEditors);
     }
+
+    // Connect the label to the Tinymce iframe
+    $(options.selector).each((idx, el) => {
+      attachLabelToIframe(el);
+    });
   },
   /*
     Finds any tinyMCE editor whose target element/textarea has the className passed


### PR DESCRIPTION
Fixes #1449.

Changes proposed in this PR:
- Extended the `app/javascript/utils/tinymce.js` file so that it reconnects labels to the Tinymce iframe after it has initialized.

To test (without a screen reader), inspect the html on any page with Tinymce editors and look for the label (question text in the case of a plan's answers) and make sure that the `for` attribute lists the id of the corresponding tinymce iframe element