### PR TITLE
redirect shibboleth-authed users to sign_in/up page from homepage

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -24,6 +24,10 @@ class HomeController < ApplicationController
         redirect_to plans_url
       end
     end
+    # NOTE: Update this to handle ORCiD as well when we enable it as a login method
+    if session["devise.shibboleth_data"].present?
+      redirect_to new_user_registration_url
+    end
   end
 
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -24,7 +24,7 @@ class HomeController < ApplicationController
         redirect_to plans_url
       end
     elsif session["devise.shibboleth_data"].present?
-    # NOTE: Update this to handle ORCiD as well when we enable it as a login method
+      # NOTE: Update this to handle ORCiD as well when we enable it as a login method
       redirect_to new_user_registration_url
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -23,9 +23,8 @@ class HomeController < ApplicationController
       else
         redirect_to plans_url
       end
-    end
+    elsif session["devise.shibboleth_data"].present?
     # NOTE: Update this to handle ORCiD as well when we enable it as a login method
-    if session["devise.shibboleth_data"].present?
       redirect_to new_user_registration_url
     end
   end


### PR DESCRIPTION
Currently, a user can leave the dialogue to `sign-in to link or create an account` after they've validated a shibboleth token.  
When they navigate back to the homepage, the option to sign in with their institutional credentials has been removed. 

This adds a redirect from the home-page to the split-sign_in/registration page if we find a shibboleth account on the session.