### PR TITLE
create_created_plan_service_spec should ignore array ordering

### DIFF
--- a/spec/services/org/create_created_plan_service_spec.rb
+++ b/spec/services/org/create_created_plan_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Org::CreateCreatedPlanService do
   let(:org) do
-    FactoryBot.create(:org, created_at: DateTime.new(2018, 04, 01))
+    FactoryBot.create(:org, created_at: DateTime.new(2018, 4, 1))
   end
   let(:template) do
     FactoryBot.create(:template, org: org)
@@ -21,20 +21,20 @@ RSpec.describe Org::CreateCreatedPlanService do
 
   before(:each) do
     plan = FactoryBot.create(:plan,
-                              template: template,
-                              created_at: DateTime.new(2018, 04, 01))
+                             template: template,
+                             created_at: DateTime.new(2018, 4, 1))
     plan2 = FactoryBot.create(:plan,
                               template: template2,
-                              created_at: DateTime.new(2018, 04, 03))
+                              created_at: DateTime.new(2018, 4, 3))
     plan3 = FactoryBot.create(:plan,
                               template: template,
-                              created_at: DateTime.new(2018, 05, 02))
+                              created_at: DateTime.new(2018, 5, 2))
     plan4 = FactoryBot.create(:plan,
                               template: template,
-                              created_at: DateTime.new(2018, 06, 02))
+                              created_at: DateTime.new(2018, 6, 2))
     plan5 = FactoryBot.create(:plan,
                               template: template2,
-                              created_at: DateTime.new(2018, 06, 03))
+                              created_at: DateTime.new(2018, 6, 3))
     FactoryBot.create(:role,
                       :creator,
                       plan: plan,
@@ -72,11 +72,11 @@ RSpec.describe Org::CreateCreatedPlanService do
       it "generates monthly counts since org's creation" do
         described_class.call(org)
 
-        april, may, june, july = find_by_dates(dates: ["2018-04-30",
-                                                       "2018-05-31",
-                                                       "2018-06-30",
-                                                       "2018-07-31"],
-                                                       org_id: org.id)
+        april, may, june, july = find_by_dates(dates: %w[2018-04-30
+                                                         2018-05-31
+                                                         2018-06-30
+                                                         2018-07-31],
+                                               org_id: org.id)
         counts = [april, may, june, july].map(&:count)
         expect(counts).to eq([2, 1, 2, 0])
       end
@@ -84,31 +84,23 @@ RSpec.describe Org::CreateCreatedPlanService do
       it "generates monthly counts by template since org's creation" do
         described_class.call(org)
 
-        april, may, june, july = find_by_dates(dates: ["2018-04-30",
-                                                       "2018-05-31",
-                                                       "2018-06-30",
-                                                       "2018-07-31"],
-                                                       org_id: org.id)
-        expect(april.details).to match_array(
-          "by_template" => [
-            { "name" => template.title, "count" => 1 },
-            { "name" => template2.title, "count" => 1 },
-          ]
-        )
-        expect(may.details).to match_array(
-          "by_template" => [
-            { "name" => template.title, "count" => 1 },
-          ]
-        )
-        expect(june.details).to match_array(
-          "by_template" => [
-            { "name" => template.title, "count" => 1 },
-            { "name" => template2.title, "count" => 1 },
-          ]
-        )
-        expect(july.details).to match_array(
-          "by_template" => []
-        )
+        april, may, june, july = find_by_dates(dates: %w[2018-04-30
+                                                         2018-05-31
+                                                         2018-06-30
+                                                         2018-07-31],
+                                               org_id: org.id)
+        expect(april.details["by_template"]).to match_array [
+          { "name" => template.title, "count" => 1 },
+          { "name" => template2.title, "count" => 1 }
+        ]
+        expect(may.details["by_template"]).to match_array [
+          { "name" => template.title, "count" => 1 }
+        ]
+        expect(june.details["by_template"]).to match_array [
+          { "name" => template.title, "count" => 1 },
+          { "name" => template2.title, "count" => 1 }
+        ]
+        expect(july.details["by_template"]).to match_array []
       end
 
       it "monthly records are either created or updated" do
@@ -120,7 +112,7 @@ RSpec.describe Org::CreateCreatedPlanService do
 
         new_plan = FactoryBot.create(:plan,
                                      template: template2,
-                                     created_at: DateTime.new(2018, 04, 03))
+                                     created_at: DateTime.new(2018, 4, 3))
         FactoryBot.create(:role, :creator, plan: new_plan, user: user1)
 
         described_class.call(org)
@@ -137,11 +129,11 @@ RSpec.describe Org::CreateCreatedPlanService do
 
         described_class.call
 
-        april, may, june, july = find_by_dates(dates: ["2018-04-30",
-                                                       "2018-05-31",
-                                                       "2018-06-30",
-                                                       "2018-07-31"],
-                                                       org_id: org.id)
+        april, may, june, july = find_by_dates(dates: %w[2018-04-30
+                                                         2018-05-31
+                                                         2018-06-30
+                                                         2018-07-31],
+                                               org_id: org.id)
 
         counts = [april, may, june, july].map(&:count)
         expect(counts).to eq([2, 1, 2, 0])
@@ -152,32 +144,24 @@ RSpec.describe Org::CreateCreatedPlanService do
 
         described_class.call
 
-        april, may, june, july = find_by_dates(dates: ["2018-04-30",
-                                                       "2018-05-31",
-                                                       "2018-06-30",
-                                                       "2018-07-31"],
-                                                       org_id: org.id)
+        april, may, june, july = find_by_dates(dates: %w[2018-04-30
+                                                         2018-05-31
+                                                         2018-06-30
+                                                         2018-07-31],
+                                               org_id: org.id)
 
-        expect(april.details).to match_array(
-          "by_template" => [
-            { "name" => template.title, "count" => 1 },
-            { "name" => template2.title, "count" => 1 },
-          ]
-        )
-        expect(may.details).to match_array(
-          "by_template" => [
-            { "name" => template.title, "count" => 1 },
-          ]
-        )
-        expect(june.details).to match_array(
-          "by_template" => [
-            { "name" => template.title, "count" => 1 },
-            { "name" => template2.title, "count" => 1 },
-          ]
-        )
-        expect(july.details).to match_array(
-          "by_template" => []
-        )
+        expect(april.details["by_template"]).to match_array [
+          { "name" => template.title, "count" => 1 },
+          { "name" => template2.title, "count" => 1 }
+        ]
+        expect(may.details["by_template"]).to match_array [
+          { "name" => template.title, "count" => 1 }
+        ]
+        expect(june.details["by_template"]).to match_array [
+          { "name" => template.title, "count" => 1 },
+          { "name" => template2.title, "count" => 1 }
+        ]
+        expect(july.details["by_template"]).to match_array []
       end
 
       it "monthly records are either created or updated" do
@@ -190,8 +174,8 @@ RSpec.describe Org::CreateCreatedPlanService do
         expect(april.first.count).to eq(2)
 
         new_plan = FactoryBot.create(:plan,
-                                    template: template2,
-                                    created_at: DateTime.new(2018, 04, 03))
+                                     template: template2,
+                                     created_at: DateTime.new(2018, 4, 3))
         FactoryBot.create(:role, :creator, plan: new_plan, user: user1)
 
         described_class.call


### PR DESCRIPTION
We were experiencing random issues with this test failing on Travis.  
It looks like the problem is that we were matching an array of array of hashes, which it considered a singleton array.  By matching on the array of hashes directly, we can avoid this problem.

Most of the noise In the PR has been created by running rubocop.