### PR TITLE
added browser_spellcheck to tinymce

### DIFF
--- a/app/javascript/utils/tinymce.js
+++ b/app/javascript/utils/tinymce.js
@@ -20,6 +20,7 @@ export const defaultOptions = {
   menubar: false,
   toolbar: 'bold italic | bullist numlist | link | table',
   plugins: 'table autoresize link paste advlist lists',
+  browser_spellcheck: true,
   advlist_bullet_styles: 'circle,disc,square', // Only disc bullets display on htmltoword
   target_list: false,
   elementpath: false,


### PR DESCRIPTION
Addresses the confusingly named https://github.com/DMPRoadmap/roadmap/issues/2169
adds browser spellcheck to the tinymce boxes.


There were other options for spellcheck within tinymce, but I figured that we didn't need a server-side component for this:
https://www.tiny.cloud/docs/general-configuration-guide/spell-checking/