### PR TITLE
Remove `#static_pages/roadmap` route

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -14,9 +14,6 @@ class StaticPagesController < ApplicationController
   def contact_us
   end
 
-  def roadmap
-  end
-
   def privacy
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,6 @@ Rails.application.routes.draw do
   root :to => 'home#index'
   get "about_us" => 'static_pages#about_us'
   get "help" => 'static_pages#help'
-  get "roadmap" => 'static_pages#roadmap'
   get "terms" => 'static_pages#termsuse'
   get "privacy" => 'static_pages#privacy'
   get "public_plans" => 'public_pages#plan_index'


### PR DESCRIPTION
Currently we have a route and a static-page definition for a `/roadmap` endpoint, which we don't have a template for.  I had a quick look, and while we historically used it, none of our services (Nor DMPTool/ OpiDor) are currently using that endpoint, so I think it's safe to remove.

Just happened to notice it  was unused.