### PR TITLE
Remove additional validation added to the hash for the funder_name. 

### DIFF
--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -97,9 +97,7 @@ module ExportablePlan
     hash[:affiliation] = self.owner.present? ? self.owner.org.name : ""
 
     # set the funder name
-    hash[:funder] = self.funder_name.present? ?
-                    self.funder_name : (self.template.org.present? ?
-                    self.template.org.name : "")
+    hash[:funder] = self.funder_name.present? ? self.funder_name :  ""
 
     # set the template name and customizer name if applicable
     hash[:template] = self.template.title

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -6,14 +6,15 @@
   <%# Using <b> tags as the htmltoword gem does not recognise css styles defined %>
   <%# Allow raw html (==) for plan_attribution as it has <b> tags %>
   <p><%== plan_attribution(@hash[:attribution]) %></p><br>
-  
+
   <p><b><%= _("Affiliation: ") %></b><%= @hash[:affiliation] %></p><br>
 
   <% if @hash[:funder].present? %>
-    <p><b><%= _("Template: ") %></b><%= @hash[:funder] %></p><br>
-  <% else %>
-    <p><b><%= _("Template: ") %></b><%= @hash[:template] + @hash[:customizer] %></p><br>
+    <p><b><%= _("Funder: ") %></b><%= @hash[:funder] %></p><br>
   <% end %>
+
+    <p><b><%= _("Template: ") %></b><%= @hash[:template] + @hash[:customizer] %></p><br>
+  
 
   <% if @plan.principal_investigator_identifier.present? %>
     <p><b><%= _("ORCID iD: ") %></b><%= @plan.principal_investigator_identifier %></p> <br>


### PR DESCRIPTION
Remove additional validation added to the hash for the funder_name. And remove the conditional check for the template name in the plan export coversheet

Fixes #2371 .

Changes proposed in this PR :
-
