### PR TITLE
fixed an inconsistency in  the template counts for the usage dashboard

### DIFF
--- a/app/helpers/usage_helper.rb
+++ b/app/helpers/usage_helper.rb
@@ -43,7 +43,7 @@ module UsageHelper
         # Replace any of the month/year plan counts for this template IF it has
         # any plans defined
         template_hash[:data] = template_hash[:data].map do |data|
-          data[:y] == date ? { x: template["count"], y: data[:y] } : data
+          data[:y] == date ? { x: template["count"] + data[:x], y: data[:y] } : data
         end
         datasets[template["name"]] = template_hash
       end


### PR DESCRIPTION
After some digging, it turned out the inconsistency was twofold.  

First, when generating the  statistics objects, we organise the templates by their `family_id` but we save the stats objects by `template.title`.  This means when both customized and non-customized versions of a template  are used within an organisation, we save  two separate counts, with the same name, ex:
```
{"count"=>8,
  "date"=>"2019-05-31",
  "by_template"=>
   [{"name"=>"BBSRC Template", "count"=>1},
    {"name"=>"EPSRC Data Management Plan", "count"=>1},
    {"name"=>"University of Manchester Generic Template", "count"=>3},
    {"name"=>"Wellcome Trust Template", "count"=>1},
    {"name"=>"Wellcome Trust Template", "count"=>1},
    {"name"=>"TEST New funder template", "count"=>1}]},
```

Then, when we're re-martialing the data for  the plans_by_template chart, we iterate, identifying the different templates by name, and thus over-write the data with the last count.  

It might be worthwile to adjust the way we save the statistics to differentiate between raw and customized funder templates, but for the  meantime, I adjusted  the template-chart helper to just  add the counts when it encounters duplicate entries.