### PR TITLE
Differentiate test plans in API output

### DIFF
--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -75,6 +75,9 @@ class Api::V0::PlansController < Api::V0::BaseController
     if params["updated_after"].present? || params["updated_before"].present?
       @plans = @plans.where(updated_at: dates_to_range(params,"updated_after","updated_before"))
     end
+    if params["remove_tests"].present? && params["remove_tests"].downcase == "true"
+      @plans = @plans.where.not(visibility: Plan.visibilities[:is_test])
+    end
     # filter on funder (dmptemplate_id)
     template_ids = extract_param_list(params, "template")
     @plans = @plans.where(templates: {family_id: template_ids}) if template_ids.present?

--- a/app/controllers/api/v0/statistics_controller.rb
+++ b/app/controllers/api/v0/statistics_controller.rb
@@ -194,6 +194,9 @@ class Api::V0::StatisticsController < Api::V0::BaseController
       raise Pundit::NotAuthorizedError
     end
     @org_plans = @user.org.plans
+    if params["remove_tests"].present? && params["remove_tests"].downcase == "true"
+      @org_plans = @org_plans.where.not(visibility: Plan.visibilities[:is_test])
+    end
     if params["start_date"].present? || params["end_date"].present?
       @org_plans = @org_plans.where(created_at: dates_to_range(params))
     end

--- a/app/views/api/v0/plans/index.json.jbuilder
+++ b/app/views/api/v0/plans/index.json.jbuilder
@@ -8,6 +8,7 @@ json.array! @plans.each do |plan|
   json.grant_number   plan.grant_number
   json.last_updated   plan.updated_at
   json.creation_date  plan.created_at
+  json.test_plan      plan.is_test?
   json.template do
     json.title        plan.template.title
     json.id           plan.template.family_id

--- a/app/views/api/v0/statistics/plans.json.jbuilder
+++ b/app/views/api/v0/statistics/plans.json.jbuilder
@@ -4,6 +4,7 @@ json.plans @org_plans.each do |plan|
   json.id             plan.id
   json.grant_number   plan.grant_number
   json.title          plan.title
+  json.test_plan      plan.is_test?
 
   json.template do
     json.title        plan.template.title


### PR DESCRIPTION
Addresses #2388 

1) Adds in a `test_plan` field to the output of the statistics and full text plans api views
2) Adds in the  ability to filter  out test  plans  by passing `remove_tests=true` as a parameter

