### PR TITLE
changed overflow setting for the guidance area

### DIFF
--- a/app/assets/stylesheets/blocks/_new_window_popup.scss
+++ b/app/assets/stylesheets/blocks/_new_window_popup.scss
@@ -1,9 +1,9 @@
 a.has-new-window-popup-info,
 button.has-new-window-popup-info {
-  
+
   position:relative;
   z-index:24;
-  
+
   & > span.new-window-popup-info {
     position: absolute;
     left: -9000px;
@@ -14,9 +14,9 @@ button.has-new-window-popup-info {
   &:hover,
   &:focus,
   &:active {
-    
+
     z-index:25;
-    
+
     & > span.new-window-popup-info {
       display:block;
       position:absolute;
@@ -29,7 +29,7 @@ button.has-new-window-popup-info {
       color:#000;
       text-align: center;
     }
-    
+
   }
-  
+
 }

--- a/app/assets/stylesheets/blocks/_readonly_textarea.scss
+++ b/app/assets/stylesheets/blocks/_readonly_textarea.scss
@@ -1,17 +1,17 @@
 /* For display of readonly textarea content without the TinyMCE editor */
 .display-readonly-textarea-content {
   // Replicating some TinyMCE styling of textarea
-  overflow-y: hidden;
+  overflow: visible;
   padding-left: 1px;
   padding-right: 1px;
   padding-bottom: 10px;
-  
+
   // Ensure table borders are not lost
   table {
     td {
       border: 1px solid black;
     }
-    
+
     td, tr {
       padding: 10px;
     }


### PR DESCRIPTION
Fixes #2305 .

This seems to address the issue with the 'Opens in a new window' message in the guidances area of the write plan page. I did some checking elsewhere across the site and didn't see any other adverse side effects.
