### PR TITLE
Adds contributors for plans

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -10,7 +10,6 @@ jobs:
       DB_ADAPTER: mysql2
       MYSQL_PWD: root
       RAILS_ENV: test
-      WICKED_PDF_PATH: vendor/bundle/bin/wkhtmltopdf
 
     steps:
     # Checkout the repo
@@ -73,6 +72,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-yarn-
           ${{ runner.os }}-
+
+    # Figure out where wkhtmltopdf is installed
+    - name: 'Determine wkhtmltopdf location'
+      run: echo ::set-env name=WICKED_PDF_PATH::$(echo `bundle exec which wkhtmltopdf`)
 
     # Install the JS dependencies
     - name: 'Yarn Install'

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -9,7 +9,13 @@ jobs:
     services:
       # Postgres installation
       db:
-        image: postgres:11
+        image: postgres
+        env:
+          # Latest version of Postgres has increased security. We can use the default
+          # user/password in this testing scenario though so use the following env
+          # variable to bypass this changes:
+          # https://github.com/docker-library/postgres/issues/681
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ['5432:5432']
         options: >-
           --health-cmd pg_isready
@@ -20,7 +26,6 @@ jobs:
     env:
       RAILS_ENV: test
       DATABASE_URL: postgres://postgres:@localhost:5432/roadmap_test
-      WICKED_PDF_PATH: vendor/bundle/bin/wkhtmltopdf
 
     steps:
     # Checkout the repo
@@ -37,6 +42,7 @@ jobs:
     # Extract the Ruby version from the Gemfile.lock
     - name: 'Determine Ruby Version'
       run: echo ::set-env name=RUBY_VERSION::$(echo `cat ./Gemfile.lock | grep -A 1 'RUBY VERSION' | grep 'ruby' | grep -oE '[0-9]\.[0-9]'`)
+
 
     # Install Ruby - using the version found in the Gemfile.lock
     - name: 'Install Ruby'
@@ -83,6 +89,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-yarn-
           ${{ runner.os }}-
+
+    # Figure out where wkhtmltopdf is installed
+    - name: 'Determine wkhtmltopdf location'
+      run: echo ::set-env name=WICKED_PDF_PATH::$(echo `bundle exec which wkhtmltopdf`)
 
     # Install the JS dependencies
     - name: 'Yarn Install'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
       activesupport (>= 3.0.0)
     pundit-matchers (1.6.0)
       rspec-rails (>= 3.0.0)
-    rack (1.6.11)
+    rack (1.6.13)
     rack-mini-profiler (1.1.4)
       rack (>= 1.2.0)
     rack-proxy (0.6.5)

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: contributors
+#
+#  id           :integer          not null, primary key
+#  firstname    :string
+#  surname      :string
+#  email        :string
+#  phone        :string
+#  org_id       :integer
+#  created_at   :datetime
+#  updated_at   :datetime
+#
+# Indexes
+#
+#  index_contributors_on_id      (id)
+#  index_contributors_on_email   (email)
+#  index_contributors_on_org_id  (org_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (org_id => orgs.id)
+
+class Contributor < ActiveRecord::Base
+
+  include ValidationMessages
+
+  # ================
+  # = Associations =
+  # ================
+
+  # TODO: uncomment the 'optional' bit after the Rails 5 migration. Rails 5+ will
+  #       NOT allow nil values in a belong_to field!
+  belongs_to :org #, optional: true
+
+  has_many :plans_contributors, dependent: :destroy
+
+  has_many :plans, through: :plans_contributors
+
+  has_many :identifiers, as: :identifiable, dependent: :destroy
+
+  # ===============
+  # = Validations =
+  # ===============
+
+  validates :email, email: { null: true }
+
+  # ===============
+  # Instance Methods
+  # ===============
+
+  def name(last_first: false)
+    names = [firstname, surname]
+    last_first ? names.reverse.join(", ") : names.join(" ")
+  end
+
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -26,6 +26,9 @@
 #  created_at                        :datetime
 #  updated_at                        :datetime
 #  template_id                       :integer
+#  ethical_issues                    :integer
+#  ethical_issues_description        :text
+#  ethical_issues_report             :string
 #  org_id                            :integer
 #  funder_id                         :integer
 #
@@ -116,6 +119,10 @@ class Plan < ActiveRecord::Base
   has_many :roles
 
   has_many :identifiers, as: :identifiable
+
+  has_many :plans_contributors, dependent: :destroy
+
+  has_many :contributors, through: :plans_contributors
 
   # =====================
   # = Nested Attributes =
@@ -420,7 +427,7 @@ class Plan < ActiveRecord::Base
                   .administrator
                   .order(:created_at)
                   .pluck(:user_id).first
-    User.find(usr_id)
+    usr_id.present? ? User.find(usr_id) : nil
   end
 
   # Creates a role for the specified user (will update the user's

--- a/app/models/plans_contributor.rb
+++ b/app/models/plans_contributor.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: plans_contributors
+#
+#  id                   :integer          not null, primary key
+#  plan_id              :integer
+#  contributor_id       :integer
+#  roles                :integer
+#  created_at           :datetime
+#  updated_at           :datetime
+#
+# Indexes
+#
+#  index_plans_contributors_on_roles (role)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (plan_id => plans.id)
+#  fk_rails_...  (contributor_id => contributors.id)
+#
+
+class PlansContributor < ActiveRecord::Base
+
+  include FlagShihTzu
+  include ValidationMessages
+
+  # ================
+  # = Associations =
+  # ================
+
+  belongs_to :plan
+
+  belongs_to :contributor
+
+  # =====================
+  # = Nested Attributes =
+  # =====================
+
+  accepts_nested_attributes_for :contributor
+
+  # ===============
+  # = Validations =
+  # ===============
+
+  validates :roles, presence: { message: PRESENCE_MESSAGE }
+
+  CREDIT_TAXONOMY_URI_BASE = "https://dictionary.casrai.org/Contributor_Roles".freeze
+
+  ##
+  # Define Bit Field values for roles
+  # Derived from the CASRAI CRediT Taxonomy: https://casrai.org/credit/
+  has_flags 1 =>  :conceptualization,
+            2 =>  :data_curation,
+            3 =>  :formal_analysis,
+            4 =>  :funding_acquisition,
+            5 =>  :investigation,
+            6 =>  :methodology,
+            7 =>  :project_administration,
+            8 =>  :resources,
+            9 =>  :software,
+            10 => :supervision,
+            11 => :validation,
+            12 => :visualization,
+            13 => :writing_original_draft,
+            14 => :writing_review_editing,
+            column: "roles"
+end

--- a/db/migrate/20200218213103_create_contributors.rb
+++ b/db/migrate/20200218213103_create_contributors.rb
@@ -1,0 +1,12 @@
+class CreateContributors < ActiveRecord::Migration
+  def change
+    create_table :contributors do |t|
+      t.string :firstname
+      t.string :surname
+      t.string :email, null: false, index: true
+      t.string :phone
+      t.references :org, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200218213241_create_plans_contributors.rb
+++ b/db/migrate/20200218213241_create_plans_contributors.rb
@@ -1,0 +1,10 @@
+class CreatePlansContributors < ActiveRecord::Migration
+  def change
+    create_table :plans_contributors do |t|
+      t.references :contributor, index: true
+      t.references :plan, index: true
+      t.integer :roles, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200218213414_add_ethical_issues_to_plans.rb
+++ b/db/migrate/20200218213414_add_ethical_issues_to_plans.rb
@@ -1,0 +1,7 @@
+class AddEthicalIssuesToPlans < ActiveRecord::Migration
+  def change
+    add_column :plans, :ethical_issues, :integer, null: true
+    add_column :plans, :ethical_issues_description, :text
+    add_column :plans, :ethical_issues_report, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200203190734) do
+ActiveRecord::Schema.define(version: 20200218213414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,19 @@ ActiveRecord::Schema.define(version: 20200203190734) do
   end
 
   add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id", using: :btree
+
+  create_table "contributors", force: :cascade do |t|
+    t.string   "firstname"
+    t.string   "surname"
+    t.string   "email",                     null: false
+    t.string   "phone"
+    t.integer  "org_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "contributors", ["email"], name: "index_contributors_on_email", using: :btree
+  add_index "contributors", ["org_id"], name: "index_contributors_on_org_id", using: :btree
 
   create_table "departments", force: :cascade do |t|
     t.string   "name"
@@ -238,12 +251,27 @@ ActiveRecord::Schema.define(version: 20200203190734) do
     t.string   "principal_investigator_phone"
     t.boolean  "feedback_requested",                default: false
     t.boolean  "complete",                          default: false
+    t.integer  "ethical_issues"
+    t.text     "ethical_issues_description"
+    t.string   "ethical_issues_report"
     t.integer  "org_id",                            limit: 4
     t.integer  "funder_id",                         limit: 4
   end
 
   add_index "plans", ["template_id"], name: "index_plans_on_template_id", using: :btree
   add_index "plans", ["funder_id"], name: "index_plans_on_funder_id", using: :btree
+
+  create_table "plans_contributors", force: :cascade do |t|
+    t.integer  "contributor_id"
+    t.integer  "plan_id"
+    t.integer  "roles"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "plans_contributors", ["contributor_id"], name: "index_plans_contributors_on_contributor_id", using: :btree
+  add_index "plans_contributors", ["plan_id"], name: "index_plans_contributors_on_plan_id", using: :btree
+  add_index "plans_contributors", ["roles"], name: "index_plans_contributors_on_roles", using: :btree
 
   create_table "plans_guidance_groups", force: :cascade do |t|
     t.integer "guidance_group_id"
@@ -468,6 +496,7 @@ ActiveRecord::Schema.define(version: 20200203190734) do
   add_foreign_key "answers", "users"
   add_foreign_key "answers_question_options", "answers"
   add_foreign_key "answers_question_options", "question_options"
+  add_foreign_key "contributors", "orgs"
   add_foreign_key "guidance_groups", "orgs"
   add_foreign_key "guidances", "guidance_groups"
   add_foreign_key "notes", "answers"
@@ -483,6 +512,8 @@ ActiveRecord::Schema.define(version: 20200203190734) do
   add_foreign_key "phases", "templates"
   add_foreign_key "plans", "orgs"
   add_foreign_key "plans", "templates"
+  add_foreign_key "plans_contributors", "contributors"
+  add_foreign_key "plans_contributors", "plans"
   add_foreign_key "plans_guidance_groups", "guidance_groups"
   add_foreign_key "plans_guidance_groups", "plans"
   add_foreign_key "question_options", "questions"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "moment": "^2.22.2",
     "number-to-text": "^0.3.5",
     "timeago.js": "4.0.0-beta.1",
-    "tinymce": "^4.8.3",
+    "tinymce": "^4.9.7",
     "webpack": "^3.12.0",
     "webpack-manifest-plugin": "^2.0.4",
     "webpack-merge": "3"

--- a/spec/factories/contributors.rb
+++ b/spec/factories/contributors.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: contributors
+#
+#  id           :integer          not null, primary key
+#  firstname    :string
+#  surname      :string
+#  email        :string
+#  phone        :string
+#  org_id       :integer
+#  created_at   :datetime
+#  updated_at   :datetime
+#
+# Indexes
+#
+#  index_contributors_on_id      (id)
+#  index_contributors_on_email   (email)
+#  index_contributors_on_org_id  (org_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (org_id => orgs.id)
+
+FactoryBot.define do
+  factory :contributor do
+    org
+    firstname { Faker::Movies::StarWars.character.split.first }
+    surname { Faker::Movies::StarWars.character.split.last }
+    email { Faker::Internet.email }
+    phone { Faker::PhoneNumber.phone_number }
+  end
+end

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -52,6 +52,10 @@ FactoryBot.define do
     principal_investigator_email { Faker::Internet.safe_email }
     feedback_requested { false }
     complete { false }
+    ethical_issues { [0, 1, nil].sample }
+    ethical_issues_description { Faker::Lorem.sentence }
+    ethical_issues_report { Faker::Internet.url }
+
     transient do
       phases { 0 }
       answers { 0 }

--- a/spec/factories/plans_contributors.rb
+++ b/spec/factories/plans_contributors.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: plans_contributors
+#
+#  id                   :integer          not null, primary key
+#  plan_id              :integer
+#  contributor_id       :integer
+#  roles                :integer
+#  created_at           :datetime
+#  updated_at           :datetime
+#
+# Indexes
+#
+#  index_plans_contributors_on_roles (role)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (plan_id => plans.id)
+#  fk_rails_...  (contributor_id => contributors.id)
+#
+
+FactoryBot.define do
+  factory :plans_contributor do
+    plan
+    contributor
+    roles { 0 }
+
+    transient do
+      roles_count { 1 }
+    end
+
+    after(:create) do |plans_contributor, evaluator|
+      (0..evaluator.roles_count - 1).each do |idx|
+        plans_contributor.update("#{plans_contributor.all_roles[idx]}": true)
+      end
+    end
+  end
+end

--- a/spec/helpers/usage_helper_spec.rb
+++ b/spec/helpers/usage_helper_spec.rb
@@ -47,8 +47,8 @@ describe UsageHelper do
 
       context "with data" do
         before(:each) do
-          @template1 = { name: Faker::Lorem.word, count: Faker::Number.number(digits: 1) }
-          @template2 = { name: Faker::Lorem.word, count: Faker::Number.number(digits: 1) }
+          @template1 = { name: Faker::Lorem.unique.word, count: Faker::Number.number(digits: 1) }
+          @template2 = { name: Faker::Lorem.unique.word, count: Faker::Number.number(digits: 1) }
           @last_month = Date.today.last_month.end_of_month
           @two_months = Date.today.months_ago(2).end_of_month
 

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Contributor, type: :model do
+
+  context "validations" do
+    subject { build(:contributor) }
+    it { is_expected.to allow_values("one@example.com", "foo-bar@ed.ac.uk").for(:email) }
+    it { is_expected.not_to allow_values("example.com", "foo bar@ed.ac.uk").for(:email) }
+  end
+
+  context "associations" do
+    it { is_expected.to belong_to(:org) }
+
+    it { is_expected.to have_many(:plans_contributors) }
+    it { is_expected.to have_many(:plans) }
+    it { is_expected.to have_many(:identifiers) }
+  end
+
+  context "instance methods" do
+
+    describe "#name(last_first: false)" do
+      before(:each) do
+        @contributor = build(:contributor)
+      end
+
+      it "defaults to 'first last' format" do
+        expected = "#{@contributor.firstname} #{@contributor.surname}"
+        expect(@contributor.name).to eql(expected)
+      end
+      it "allows 'first last' format" do
+        expected = "#{@contributor.firstname} #{@contributor.surname}"
+        expect(@contributor.name(last_first: false)).to eql(expected)
+      end
+      it "allows 'last, first' format" do
+        expected = "#{@contributor.surname}, #{@contributor.firstname}"
+        expect(@contributor.name(last_first: true)).to eql(expected)
+      end
+    end
+
+  end
+
+end

--- a/spec/models/plans_contributor_spec.rb
+++ b/spec/models/plans_contributor_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PlansContributor, type: :model do
+
+  context "associations" do
+    it { is_expected.to belong_to(:contributor) }
+    it { is_expected.to belong_to(:plan) }
+  end
+
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,7 +2057,7 @@ chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chownr@^1.0.1, chownr@^1.1.1:
+chownr@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
   integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
@@ -2877,7 +2877,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2939,11 +2939,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -3054,11 +3049,6 @@ detect-indent@^4.0.0:
   integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
   dependencies:
     repeating "^2.0.0"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -4148,13 +4138,6 @@ fs-extra@^7.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
-  dependencies:
-    minipass "^2.6.0"
-
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -4691,7 +4674,7 @@ icon-windows@*:
   resolved "https://registry.yarnpkg.com/icon-windows/-/icon-windows-0.0.1.tgz#abe463f50f10d6dfc3bea2d5ffd4a1b350b57fcd"
   integrity sha1-q+Rj9Q8Q1t/DvqLV/9Shs1C1f80=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4719,13 +4702,6 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -4819,11 +4795,6 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
-ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
 inline-source-map@~0.6.0:
   version "0.6.2"
@@ -6083,21 +6054,6 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
-
 mississippi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-2.0.0.tgz#3442a508fafc28500486feea99409676e4ee5a6f"
@@ -6274,15 +6230,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -6375,22 +6322,6 @@ node-libs-browser@^2.0.0:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.42:
   version "1.1.42"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.42.tgz#a999f6a62f8746981f6da90627a8d2fc090bbad7"
@@ -6427,14 +6358,6 @@ node-sass@^4.9.2:
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
-  integrity sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 nopt@~1.0.10:
   version "1.0.10"
@@ -6485,26 +6408,6 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
-
-npm-packlist@^1.1.6:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
-  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6512,7 +6415,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -6776,7 +6679,7 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4:
+osenv@0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -8203,16 +8106,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 read-cache@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
@@ -8818,7 +8711,7 @@ sass-loader@^6.0.7:
     neo-async "^2.5.0"
     pify "^3.0.0"
 
-sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
+sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -9476,7 +9369,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -9624,19 +9517,6 @@ tar@^2.0.0:
     fstream "^1.0.12"
     inherits "2"
 
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
-
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -9686,10 +9566,10 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tinymce@^4.8.3:
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-4.9.6.tgz#ffba4fc56e3196f66873b60571b9aa164b2da931"
-  integrity sha512-ZSBxBVvAHhi6KTSWGVsnv7X7drJJbInOrpCiSuvNLQz0Po8lZfeLh8nt7asQ9eGxD7TUD1dD46iXhOH+SsBbNg==
+tinymce@^4.9.7:
+  version "4.9.8"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-4.9.8.tgz#1f470a9defe3b52845fd51147cb226d44740750e"
+  integrity sha512-587xEh2+otXUNz4FVC8vBogMWpCxhiUIKNYQwOuqao9CHtCVXGHnK2rpEQHE6RsSTLsERpoMsAVte3K6KXoGzQ==
 
 tmp@0.0.33, tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
@@ -10484,11 +10364,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs-parser@13.1.1, yargs-parser@^13.1.1:
   version "13.1.1"


### PR DESCRIPTION
Addresses #2349.

These changes are dependent on the ROR/Fundref PR's new `identifiers` table

Changes proposed in this PR:
- Adds a `contributors` table (with f_key to `orgs`)
- Adds a `plans_contributors` join table that sets a bitflag `roles` field based on the CRediT Taxonomy (thanks for alerting us to that @xsrust)
- Adds the 3 new `ethical_issues` fields to the `plans` table
- Added factories/tests for the new models
- Rake upgrade task to convert all `data_contact` ('Data curation' role) and `principal_investigator` ('Investigation' role) information on a plan over to `contributors` and adds a 'Writing - original draft' role to all of the plan's authors.

Changes to model/UI forthcoming. Need to update the code that creates a plan or shares a plan to add these contributors. 
