### PR TITLE
issue#2375 allow change of delimiter for csv download

### DIFF
--- a/app/assets/stylesheets/blocks/_usage.sccs
+++ b/app/assets/stylesheets/blocks/_usage.sccs
@@ -1,0 +1,4 @@
+.single-char-input {
+  display: inline;
+  width: 20px;
+}

--- a/app/assets/stylesheets/utils/_margins.scss
+++ b/app/assets/stylesheets/utils/_margins.scss
@@ -4,6 +4,9 @@
 .mb-10 {
   margin-bottom: 10px;
 }
+.mt-5 {
+  margin-top: 5px;
+}
 .mt-10 {
   margin-top: 10px;
 }

--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -37,7 +37,7 @@ class UsageController < ApplicationController
     authorize :usage
 
     data = Org::TotalCountStatService.call
-    sep = params["sep"]
+    sep = sep_param
     data_csvified = Csvable.from_array_of_hashes(data, true, sep)
 
     send_data(data_csvified, filename: "totals.csv")
@@ -74,7 +74,7 @@ class UsageController < ApplicationController
     authorize :usage
 
     user_data(args: default_query_args)
-    sep = params["sep"]
+    sep = sep_param
     send_data(CSV.generate({:col_sep => sep}) do |csv|
       csv << [_("Month"), _("No. Users joined")]
       total = 0
@@ -93,7 +93,7 @@ class UsageController < ApplicationController
     authorize :usage
 
     plan_data(args: default_query_args)
-    sep = params["sep"]
+    sep = sep_param
     send_data(CSV.generate({:col_sep => sep}) do |csv|
       csv << [_("Month"), _("No. Completed Plans")]
       total = 0
@@ -113,7 +113,7 @@ class UsageController < ApplicationController
 
     args = default_query_args
     args[:start_date] = first_plan_date
-    sep = params["sep"]
+    sep = sep_param
     {:col_sep => sep}
 
     plan_data(args: args, sort: :desc)
@@ -158,6 +158,11 @@ class UsageController < ApplicationController
       start_date: Date.today.months_ago(12).end_of_month.strftime("%Y-%m-%d"),
       end_date: Date.today.last_month.end_of_month.strftime("%Y-%m-%d")
     }
+  end
+
+  # set the csv separator or default to comma
+  def sep_param
+    params["sep"] || ','
   end
 
   def min_max_dates(args:)

--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -188,7 +188,8 @@ class UsageController < ApplicationController
   end
 
   def first_plan_date
-    StatCreatedPlan.all.order(:date).limit(1).pluck(:date).first
+    StatCreatedPlan.all.order(:date).limit(1).pluck(:date).first \
+    || Date.today.last_month.end_of_month
   end
 
 end

--- a/app/javascript/views/usage/index.js
+++ b/app/javascript/views/usage/index.js
@@ -5,7 +5,8 @@ $(() => {
   // fns to handle the separator character menu
   // for CSV download
   const changeStatFnGen = (str) => {
-    const fn = (item, index) => {
+    const fn = (item) => {
+      /* eslint no-param-reassign: ["error", { "props": false }] */
       item.href = item.href.replace(/sep=.*/, str);
     };
     return fn;
@@ -15,7 +16,7 @@ $(() => {
   // on change look for "stat" elements and chnage their query param
   document.getElementById('csv-field-sep').addEventListener('click', (e) => {
     const statElems = document.getElementsByClassName('stat');
-    const newSep = "sep=".concat(encodeURIComponent(e.target.value));
+    const newSep = 'sep='.concat(encodeURIComponent(e.target.value));
     const changeStatFn = changeStatFnGen(newSep);
     Array.from(statElems).forEach(changeStatFn);
   });

--- a/app/javascript/views/usage/index.js
+++ b/app/javascript/views/usage/index.js
@@ -2,6 +2,24 @@ import { isObject } from '../../utils/isType';
 import { initializeCharts, createChart, drawHorizontalBar } from '../../utils/charts';
 
 $(() => {
+  // fns to handle the separator character menu
+  // for CSV download
+  const changeStatFnGen = (str) => {
+    const fn = (item, index) => {
+      item.href = item.href.replace(/sep=.*/, str);
+    };
+    return fn;
+  };
+
+  // attach listener to separator select menu
+  // on change look for "stat" elements and chnage their query param
+  document.getElementById('csv-field-sep').addEventListener('click', (e) => {
+    const statElems = document.getElementsByClassName('stat');
+    const newSep = "sep=".concat(encodeURIComponent(e.target.value));
+    const changeStatFn = changeStatFnGen(newSep);
+    Array.from(statElems).forEach(changeStatFn);
+  });
+
   initializeCharts();
 
   // Create the Users joined chart

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -24,11 +24,11 @@ class Stat < ActiveRecord::Base
 
   class << self
 
-    def to_csv(stats)
+    def to_csv(stats, sep=",")
       data = stats.map do |stat|
         { date: stat.date, count: stat.count }
       end
-      Csvable.from_array_of_hashes(data)
+      Csvable.from_array_of_hashes(data, sep)
     end
 
   end

--- a/app/models/stat_created_plan.rb
+++ b/app/models/stat_created_plan.rb
@@ -33,17 +33,17 @@ class StatCreatedPlan < Stat
 
   class << self
 
-    def to_csv(created_plans, details: { by_template: false })
+    def to_csv(created_plans, details: { by_template: false, sep: "," })
       if details[:by_template]
-        to_csv_by_template(created_plans)
+        to_csv_by_template(created_plans, details[:sep])
       else
-        super(created_plans)
+        super(created_plans, details[:sep])
       end
     end
 
     private
 
-    def to_csv_by_template(created_plans)
+    def to_csv_by_template(created_plans, sep = ",")
       template_names = lambda do |created_plans|
         unique = Set.new
         created_plans.each do |created_plan|
@@ -66,7 +66,7 @@ class StatCreatedPlan < Stat
         tuple[:Count] = created_plan.count
         tuple
       end
-      Csvable.from_array_of_hashes(data, false)
+      Csvable.from_array_of_hashes(data, false, sep)
     end
 
   end

--- a/app/views/usage/_total_usage.html.erb
+++ b/app/views/usage/_total_usage.html.erb
@@ -1,12 +1,20 @@
-<%# locals: user_count, plan_count %>
+<%# locals: user_count, plan_count, separators %>
 
 <div class="row">
   <div class="col-md-12" >
-    <div class="col-md-10">
+    <div class="col-md-6">
       <h1>Usage statistics</h1>
     </div>
+    <div class="col-md-4">
+      <form class="form-inline">
+        <label for="csv-field-sep">
+          <%= _('csv download field separator') %>:
+        </label>
+        <%= select_tag "csv-field-sep", options_for_select(separators, separators[0]), {class: "single-char-select"} %>
+      </form>
+    </div>
     <div class="col-xs-2">
-      <%= link_to usage_global_statistics_path, class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
+      <%= link_to usage_global_statistics_path(sep: ","), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
         <%= _('Download global usage') %> <i class="fa fa-download" aria-hidden="true"></i>
       <% end %>
     </div>

--- a/app/views/usage/_total_usage.html.erb
+++ b/app/views/usage/_total_usage.html.erb
@@ -6,7 +6,7 @@
       <h1>Usage statistics</h1>
     </div>
     <div class="col-md-4">
-      <form class="form-inline">
+      <form class="form-inline mt-10 mb-10 pull-right">
         <label for="csv-field-sep">
           <%= _('csv download field separator') %>:
         </label>

--- a/app/views/usage/index.html.erb
+++ b/app/views/usage/index.html.erb
@@ -1,7 +1,7 @@
 <% title _('Usage statistics') %>
 
 <%= render partial: 'usage/total_usage',
-           locals: { user_count: @total_org_users, plan_count: @total_org_plans } %>
+           locals: { user_count: @total_org_users, plan_count: @total_org_plans, separators: @separators } %>
 
 <%= render partial: 'usage/filter' %>
 
@@ -17,8 +17,8 @@
       <h4 class="bold"><%= _('No. users joined during last year') %></h4>
     </div>
     <div class="pull-right">
-      <%= link_to usage_yearly_users_path, class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
-        <%= _('Download') %> <i class="fa fa-download" aria-hidden="true"></i>
+      <%= link_to usage_yearly_users_path(sep: ","), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
+        <%= _('Download') %> <input class="fa fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
     <div class="clearfix"></div>
@@ -32,7 +32,7 @@
       <h4 class="bold"><%= _('No. plans during last year') %></h4>
     </div>
     <div class="pull-right">
-      <%= link_to usage_yearly_plans_path, class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
+      <%= link_to usage_yearly_plans_path(sep: ","), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
         <%= _('Download') %> <i class="fa fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
@@ -76,7 +76,7 @@
             </li>
             <li>
               <div class="form-group">
-                <%= link_to usage_all_plans_by_template_path, class: 'btn btn-default', role: 'button', target: '_blank' do %>
+                <%= link_to usage_all_plans_by_template_path(sep: ","), class: 'btn btn-default stat', role: 'button', target: '_blank' do %>
                   <%= _('Download all') %> <i class="fa fa-download" aria-hidden="true"></i>
                 <% end %>
              </div>

--- a/app/views/usage/index.html.erb
+++ b/app/views/usage/index.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="pull-right">
       <%= link_to usage_yearly_users_path(sep: ","), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
-        <%= _('Download') %> <input class="fa fa-download" aria-hidden="true"></i>
+        <%= _('Download') %> <i class="fa fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
     <div class="clearfix"></div>

--- a/lib/csvable.rb
+++ b/lib/csvable.rb
@@ -16,7 +16,7 @@ module Csvable
           .map(&:to_s)
       end
 
-      CSV.generate({:col_sep => sep}) do |csv|
+      CSV.generate({col_sep: sep}) do |csv|
         csv << headers
         data.each do |row|
           csv << row.values

--- a/lib/csvable.rb
+++ b/lib/csvable.rb
@@ -5,7 +5,7 @@ module Csvable
   require "csv"
   class << self
 
-    def from_array_of_hashes(data = [], humanize = true)
+    def from_array_of_hashes(data = [], humanize = true, sep = ",")
       return "" unless data.first&.keys
       if humanize
         headers = data.first.keys
@@ -16,7 +16,7 @@ module Csvable
           .map(&:to_s)
       end
 
-      CSV.generate do |csv|
+      CSV.generate({:col_sep => sep}) do |csv|
         csv << headers
         data.each do |row|
           csv << row.values

--- a/spec/models/stat_created_plan_spec.rb
+++ b/spec/models/stat_created_plan_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe StatCreatedPlan, type: :model do
             count: 0)
           data = [may, june, july]
 
-          csv = described_class.to_csv(data, details: { by_template: true })
+          csv = described_class.to_csv(data, details: { by_template: true, sep: ","})
 
           expected_csv = <<~HERE
           Date,Template1,Template2,Template3,Count


### PR DESCRIPTION
Fixes #2375  .

Changes proposed in this PR:
- add a select menu to the usage page which gives a choice of three separators
- this could be extended to allow for them to be specified in branding.yml but it'll do for starters
- each download then also has a "sep" field which gets changed by a JS event listener attached to the select menu
- the various CSV handling functions then get an extra sep parameter whch gets passed in from the download url
