### PR TITLE
removed old unused Feedjira code and dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,9 +156,6 @@ gem 'wicked_pdf', '~> 1.1.0'
 # This simple gem allows you to create MS Word docx documents from simple html documents. This makes it easy to create dynamic reports and forms that can be downloaded by your users as simple MS Word docx files. (http://github.com/karnov/htmltoword)
 gem 'htmltoword', '1.1.0'
 
-# A feed fetching and parsing library (http://feedjira.com)
-gem 'feedjira'
-
 # Filename sanitization for Ruby. This is useful when you generate filenames for downloads from user input
 gem 'zaru'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,9 +133,6 @@ GEM
     faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
     fast_gettext (2.0.1)
-    feedjira (3.1.0)
-      loofah (>= 2.3.1)
-      sax-machine (>= 1.0)
     ffi (1.11.3)
     flag_shih_tzu (0.3.23)
     fog-aws (3.5.2)
@@ -404,7 +401,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sax-machine (1.3.2)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -498,7 +494,6 @@ DEPENDENCIES
   dragonfly-s3_data_store
   factory_bot_rails
   faker
-  feedjira
   flag_shih_tzu (~> 0.3.23)
   font-awesome-sass (~> 4.2.0)
   fuubar

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,12 +3,6 @@
 class StaticPagesController < ApplicationController
 
   def about_us
-    dcc_news_feed_url = "http://www.dcc.ac.uk/news/dmponline-0/feed"
-    @dcc_news_feed = Feedjira::Feed.fetch_and_parse dcc_news_feed_url
-    respond_to do |format|
-      format.rss { redirect_to dcc_news_feed_url }
-      format.html
-    end
   end
 
   def contact_us

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -8,7 +8,7 @@
 <div id="footer-navbar" class="navbar-inverse navbar-fixed-bottom" role="navigation">
   <div class="container-fluid">
     <ul class="nav navbar-nav">
-      <li><%= link_to "&copy; 2004 - #{Time.now.year} #{Rails.configuration.branding[:organisation][:name]}".sanitize, "#{Rails.configuration.branding[:organisation][:url]}"%></li>
+      <li><%= link_to sanitize("&copy; 2004 - #{Time.now.year} #{Rails.configuration.branding[:organisation][:name]}"), "#{Rails.configuration.branding[:organisation][:url]}"%></li>
       <li>•</li>
       <li><a href="<%= about_us_path %>"><%= _('About') %></a></li>
       <li><a href="<%= contact_us %>"><%= _('Contact us') %></a></li>


### PR DESCRIPTION
Fixes #2411 .

The old Feedjira code on the `static_pages_controller.rb`is no longer used. Removing it from the codebase.
