### PR TITLE
Issue 2346 - Create a super admin view of the Plans report

### DIFF
--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -14,7 +14,8 @@ class OrgAdmin::PlansController < ApplicationController
       .where('users.org_id = ? AND plans.feedback_requested is TRUE AND roles.active is TRUE',
               current_user.org_id).pluck(:plan_id)
     @feedback_plans = Plan.where(id: feedback_ids).reject{|p| p.nil?}
-    @plans = current_user.org.plans.page(1)
+    @super_admin = current_user.can_super_admin?
+    @plans = @super_admin ? Plan.all.page(1) : current_user.org.plans.page(1)
   end
 
   # GET org_admin/plans/:id/feedback_complete

--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -42,9 +42,15 @@ class Paginable::PlansController < ApplicationController
     unless current_user.present? && current_user.can_org_admin?
       raise Pundit::NotAuthorizedError
     end
+    #check if current user if super_admin
+    @super_admin = current_user.can_super_admin?
+    plans = @super_admin ? Plan.all : current_user.org.plans
+    plans = plans.joins(:template, roles: [user: :org]).where(Role.creator_condition)
+
     paginable_renderise(
       partial: "org_admin",
-      scope: current_user.org.plans,
+      scope: plans,
+      view_all: !current_user.can_super_admin?,
       query_params: { sort_field: 'plans.updated_at', sort_direction: :desc }
     )
   end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -164,8 +164,11 @@ class Plan < ActiveRecord::Base
 
   scope :search, lambda { |term|
     search_pattern = "%#{term}%"
-    joins(:template)
+    joins(:template, roles: [user: :org])
+    .where(Role.creator_condition)
     .where("lower(plans.title) LIKE lower(:search_pattern)
+            OR lower(orgs.name) LIKE lower (:search_pattern)
+            OR lower(orgs.abbreviation) LIKE lower (:search_pattern)
             OR lower(templates.title) LIKE lower(:search_pattern)
             OR lower(plans.principal_investigator) LIKE lower(:search_pattern)
             OR lower(plans.principal_investigator_identifier) LIKE lower(:search_pattern)",

--- a/app/views/org_admin/plans/index.html.erb
+++ b/app/views/org_admin/plans/index.html.erb
@@ -34,18 +34,21 @@
         </div>
       </div>
     <% end %>
-    <% if @plans.length > 0 %>
-      <%= link_to sanitize(_('Download plans <em class="sr-only">(new window)</em><span class="new-window-popup-info">%{open_in_new_window_text}</span>') %
+    <% if @plans.length > 0  %>
+      <% unless @super_admin %>
+        <%= link_to sanitize(_('Download plans <em class="sr-only">(new window)</em><span class="new-window-popup-info">%{open_in_new_window_text}</span>') %
                            { open_in_new_window_text: _('Opens in new window') },
                            tags: %w{ span em }),
                   org_admin_download_plans_path(format: :csv),
                   target: '_blank',
                   class: 'btn btn-default pull-right has-new-window-popup-info' %>
+      <% end %>
       <%= paginable_renderise(
         partial: '/paginable/plans/org_admin',
         controller: 'paginable/plans',
         action: 'org_admin',
         scope: @plans,
+        view_all: !current_user.can_super_admin?,
         query_params: { sort_field: 'plans.updated_at', sort_direction: :desc }) %>
     <% end %>
   </div>

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -4,7 +4,7 @@
       <tr>
         <th scope="col"><%= _('Project Title') %>&nbsp;<%= paginable_sort_link('plans.title') %></th>
         <th scope="col"><%= _('Template') %>&nbsp;<%= paginable_sort_link('templates.title') %></th>
-        <th scope="col"><%= _('Organisation') %></th>
+        <th scope="col"><%= _('Organisation') %>&nbsp;<%= paginable_sort_link('orgs.name') %></th>
         <th scope="col"><%= _('Owner') %></th>
         <th scope="col" class="date-column"><%= _('Updated') %>&nbsp;<%= paginable_sort_link('plans.updated_at') %></th>
         <th scope="col"><%= _('Visibility') %></th>

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -457,7 +457,7 @@ describe Plan do
 
     context "when Plan title matches term" do
 
-      let!(:plan)  { create(:plan, title: "foolike title") }
+      let!(:plan)  { create(:plan, :creator, title: "foolike title") }
 
       it { is_expected.to include(plan) }
 
@@ -467,19 +467,38 @@ describe Plan do
 
       let!(:template) { create(:template, title: "foolike title") }
 
-      let!(:plan)  { create(:plan, template: template) }
+      let!(:plan)  { create(:plan, :creator, template: template) }
 
       it { is_expected.to include(plan) }
 
     end
 
+    context "when Organisation name matches term" do
+
+      let!(:plan)  { create(:plan, :creator, description: "foolike desc") }
+
+      let!(:org) { create(:org, name: 'foolike name') }
+
+      before do
+        user = plan.owner
+        user.org = org
+        user.save
+      end
+
+      it "returns organisation name" do
+          expect(subject).to include(plan)
+      end
+
+    end
+
     context "when neither title matches term" do
 
-      let!(:plan)  { create(:plan, description: "foolike desc") }
+      let!(:plan)  { create(:plan, :creator, description: "foolike desc") }
 
       it { is_expected.not_to include(plan) }
 
     end
+
 
   end
 


### PR DESCRIPTION
Fixes #2346  .

Changes proposed in this PR:
-These changes will allow a super admin to view, search and sort all plans in the data base. The "download" button and the "view all' link have been deactivated as this would overload the code and it would take several sec if not minutes to complete these tasks.
