### PR TITLE
API Clients table and UI administration screens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,6 +123,7 @@ class ApplicationController < ActionController::Base
 
   def obj_name_for_display(obj)
     display_name = {
+      ApiClient: _("API client"),
       ExportedPlan: _("plan"),
       GuidanceGroup: _("guidance group"),
       Note: _("comment"),

--- a/app/controllers/super_admin/api_clients_controller.rb
+++ b/app/controllers/super_admin/api_clients_controller.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module SuperAdmin
+
+  class ApiClientsController < ApplicationController
+
+    respond_to :html
+
+    helper PaginableHelper
+
+    # GET /api_clients
+    def index
+      authorize(ApiClient)
+      @api_clients = ApiClient.all.page(1)
+    end
+
+    # GET /api_clients/new
+    def new
+      authorize(ApiClient)
+      @api_client = ApiClient.new
+    end
+
+    # GET /api_clients/1/edit
+    def edit
+      @api_client = ApiClient.find(params[:id])
+      authorize(@api_client)
+    end
+
+    # POST /api_clients
+    def create
+      authorize(ApiClient)
+      @api_client = ApiClient.new(api_client_params)
+
+      if @api_client.save
+        UserMailer.api_credentials(@api_client).deliver_now()
+        msg = success_message(@api_client, _("created"))
+        msg += _(". The API credentials have been emailed to %{email}") % { email: @api_client.contact_email }
+        flash.now[:notice] = msg
+        render :edit
+      else
+        flash.now[:alert] = failure_message(@api_client, _("create"))
+        render :new
+      end
+    end
+
+    # PATCH/PUT /api_clients/:id
+    def update
+      @api_client = ApiClient.find(params[:id])
+      authorize(@api_client)
+      if @api_client.update(api_client_params)
+        flash.now[:notice] = success_message(@api_client, _("updated"))
+      else
+        flash.now[:alert] = failure_message(@api_client, _("update"))
+      end
+      render :edit
+    end
+
+    # DELETE /api_clients/:id
+    def destroy
+      api_client = ApiClient.find(params[:id])
+      authorize(api_client)
+      if api_client.destroy
+        msg = success_message(api_client, _("deleted"))
+        redirect_to super_admin_api_clients_path, notice: msg
+      else
+        flash.now[:alert] = failure_message(api_client, _("delete"))
+        render :edit
+      end
+    end
+
+    # GET /api_clients/:id/refresh_credentials/
+    def refresh_credentials
+      @api_client = ApiClient.find(params[:id])
+      if @api_client.present?
+        @api_client.generate_credentials
+        @api_client.save
+      end
+    end
+
+    # GET /api_clients/:id/email_credentials/
+    def email_credentials
+      @api_client = ApiClient.find(params[:id])
+      UserMailer.api_credentials(@api_client).deliver_now() if @api_client.present?
+    end
+
+    private
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def api_client_params
+      params.require(:api_client).permit(:name, :description, :homepage,
+                                         :contact_name, :contact_email,
+                                         :client_id, :client_secret)
+    end
+
+  end
+
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -139,4 +139,14 @@ class UserMailer < ActionMailer::Base
       end
     end
   end
+
+  def api_credentials(api_client)
+    @api_client = api_client
+    if @api_client.contact_email.present?
+      FastGettext.with_locale FastGettext.default_locale do
+        mail(to: @api_client.contact_email,
+             subject: _("%{tool_name} API changes") % { tool_name: Rails.configuration.branding[:application][:name] })
+      end
+    end
+  end
 end

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: api_clients
+#
+#  id             :integer          not null, primary key
+#  name           :string,          not null
+#  homepage       :string
+#  contact_name   :string
+#  contact_email  :string,          not null
+#  client_id      :string,          not null
+#  client_secret  :string,          not null
+#  last_access    :datetime
+#  created_at     :datetime
+#  updated_at     :datetime
+#
+# Indexes
+#
+#  index_api_clients_on_name     (name)
+#
+
+class ApiClient < ActiveRecord::Base
+
+  include DeviseInvitable::Inviter
+  include ValidationMessages
+
+  # If the Client_id or client_secret are nil generate them
+  before_validation :generate_credentials,
+                    if: Proc.new { |c| c.client_id.blank? || c.client_secret.blank? }
+
+  # Force the name to downcase
+  before_save :name_to_downcase
+
+  # ===============
+  # = Validations =
+  # ===============
+
+  validates :name, presence: { message: PRESENCE_MESSAGE },
+                   uniqueness: { case_sensitive: false,
+                                 message: UNIQUENESS_MESSAGE }
+
+  validates :contact_email, presence: { message: PRESENCE_MESSAGE },
+                            email: { allow_nil: false }
+
+  validates :client_id, presence: { message: PRESENCE_MESSAGE }
+  validates :client_secret, presence: { message: PRESENCE_MESSAGE }
+
+  # ===========================
+  # = Public instance methods =
+  # ===========================
+
+  # Override the to_s method to keep the id and secret hidden
+  def to_s
+    name
+  end
+
+  # Verify that the incoming secret matches
+  def authenticate(secret:)
+    client_secret == secret
+  end
+
+  # Generate UUIDs for the client_id and client_secret
+  def generate_credentials
+    self.client_id = SecureRandom.uuid
+    self.client_secret = SecureRandom.uuid
+  end
+
+  private
+
+  def name_to_downcase
+    self.name = self.name.downcase
+  end
+
+end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -170,6 +170,21 @@ class Org < ActiveRecord::Base
               count(users.id) as user_count")
   }
 
+  # Scope that retrieves the Org based on the Identifiers passed in
+  scope :from_identifiers, ->(identifiers) {
+    return [] unless identifiers.present? && identifiers.is_a?(Array)
+
+    out = []
+    identifiers.each do |id|
+      # Stop once we find the first match
+      break if out.any?
+
+      out << Identifier.where(identifier_scheme: id.identifier_scheme,
+                              value: id.value, identifiable_type: "Org").first
+    end
+    out.compact.map { |identifier| find_by(id: identifier.identifiable_id) }
+  }
+
   before_validation :set_default_feedback_email_subject
   before_validation :check_for_missing_logo_file
   after_create :create_guidance_group
@@ -266,6 +281,26 @@ class Org < ActiveRecord::Base
   def grant_api!(token_permission_type)
     self.token_permission_types << token_permission_type unless
       self.token_permission_types.include? token_permission_type
+  end
+
+  # Takes an array of Identifiers and create/update/delete them for this Org
+  # TODO: For some reason accepts_nested_atributes_for does not work for
+  #       polymorphic relationships, so using this instead. Reevaluate
+  #       post Rails 5 upgrade
+  def save_identifiers!(array:)
+    return false unless array.present? && array.any?
+
+    array.each do |identifier|
+      scheme = identifier.identifier_scheme
+      current = identifiers.by_scheme_name(scheme.name, "Org").first
+
+      current.destroy if current.present?
+      next unless identifier.value.present?
+
+      identifier.identifiable = self
+      identifier.save
+    end
+    true
   end
 
   private

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -170,21 +170,6 @@ class Org < ActiveRecord::Base
               count(users.id) as user_count")
   }
 
-  # Scope that retrieves the Org based on the Identifiers passed in
-  scope :from_identifiers, ->(identifiers) {
-    return [] unless identifiers.present? && identifiers.is_a?(Array)
-
-    out = []
-    identifiers.each do |id|
-      # Stop once we find the first match
-      break if out.any?
-
-      out << Identifier.where(identifier_scheme: id.identifier_scheme,
-                              value: id.value, identifiable_type: "Org").first
-    end
-    out.compact.map { |identifier| find_by(id: identifier.identifiable_id) }
-  }
-
   before_validation :set_default_feedback_email_subject
   before_validation :check_for_missing_logo_file
   after_create :create_guidance_group
@@ -281,26 +266,6 @@ class Org < ActiveRecord::Base
   def grant_api!(token_permission_type)
     self.token_permission_types << token_permission_type unless
       self.token_permission_types.include? token_permission_type
-  end
-
-  # Takes an array of Identifiers and create/update/delete them for this Org
-  # TODO: For some reason accepts_nested_atributes_for does not work for
-  #       polymorphic relationships, so using this instead. Reevaluate
-  #       post Rails 5 upgrade
-  def save_identifiers!(array:)
-    return false unless array.present? && array.any?
-
-    array.each do |identifier|
-      scheme = identifier.identifier_scheme
-      current = identifiers.by_scheme_name(scheme.name, "Org").first
-
-      current.destroy if current.present?
-      next unless identifier.value.present?
-
-      identifier.identifiable = self
-      identifier.save
-    end
-    true
   end
 
   private

--- a/app/policies/api_client_policy.rb
+++ b/app/policies/api_client_policy.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class ApiClientPolicy < ApplicationPolicy
+
+  def initialize(user, *_args)
+    raise Pundit::NotAuthorizedError, _('must be logged in') unless user
+    @user = user
+  end
+
+  def index?
+    @user.can_super_admin?
+  end
+
+  def new?
+    @user.can_super_admin?
+  end
+
+  def create?
+    @user.can_super_admin?
+  end
+
+  def edit?
+    @user.can_super_admin?
+  end
+
+  def update?
+    @user.can_super_admin?
+  end
+
+  def destroy?
+    @user.can_super_admin?
+  end
+
+  def refresh_credentials?
+    @user.can_super_admin?
+  end
+
+  def email_credentials?
+    @user.can_super_admin?
+  end
+
+end

--- a/app/views/contributors/_form.html.erb
+++ b/app/views/contributors/_form.html.erb
@@ -1,0 +1,99 @@
+<%# locals form, plan, contributor %>
+
+<%
+phone_tooltip = _("Phone numbers should only include numbers and dashes ('-').")
+roles_tooltip = _("Select each role that applies to the contributor.")
+%>
+
+<div class="form-group row"><!-- name -->
+  <div class="col-md-12">
+    <%= form.label(:name, _("Name"), class: "control-label") %>
+  </div>
+  <div class="col-md-6">
+    <%= form.text_field :name, class: "form-control", aria: { required: true } %>
+  </div>
+</div>
+
+<div class="form-group row"><!-- email -->
+  <div class="col-md-12">
+    <%= form.label(:email, _("Email"), class: "control-label") %>
+  </div>
+  <div class="col-md-4">
+    <%= form.email_field :email, class: "form-control", aria: { required: true } %>
+  </div>
+</div>
+
+<div class="form-group row"><!-- orcid -->
+  <% orcid = ContributorPresenter.orcid(contributor: contributor) %>
+  <%= form.fields_for :identifiers, orcid do |orcid_fields| %>
+    <%= orcid_fields.hidden_field :id %>
+    <%= orcid_fields.hidden_field :identifier_scheme_id,
+                                  value: orcid.identifier_scheme_id %>
+    <div class="col-md-12">
+      <%= orcid_fields.label(:value, _("ORCID"), class: "control-label") %>
+    </div>
+    <div class="col-md-4">
+      <%= orcid_fields.text_field :value, class: "form-control" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="form-group row"><!-- phone -->
+  <div class="col-md-12">
+    <%= form.label(:phone, _("Phone number"), class: "control-label") %>
+  </div>
+  <div class="col-md-4">
+    <em class="sr-only"><%= phone_tooltip %></em>
+    <%= form.phone_field :phone, class: "form-control",
+                                 title: phone_tooltip,
+                                 data: { toggle: "tooltip" },
+                                 pattern: "[0-9\-\.\(\)\+]+",
+                                 placeholder: "123-123-1234" %>
+  </div>
+</div>
+
+<div class="form-group row" id="contributor-org-controls"><!-- org -->
+  <div class="col-md-8">
+    <%= render partial: "shared/org_selectors/combined",
+               locals: { form: form,
+                         default_org: contributor.org,
+                         required: false,
+                         label: _("Affiliation") } %>
+  </div>
+</div>
+
+<div class="form-group row">
+  <div class="col-md-12">
+    <fieldset>
+      <legend>
+        <span class="red">*</span> <%= _("Roles") %>
+      </legend>
+      <p><%= roles_tooltip.html_safe %></p>
+
+      <% roles = ContributorPresenter.roles_for_radio(contributor: contributor) %>
+      <% roles.each do |hash| %>
+        <div class="col-md-4">
+          <div class="checkbox">
+            <%= form.check_box hash.keys.first.to_sym,
+                               value: hash.values.first,
+                               data: { toggle: "tooltip" },
+                               title: ContributorPresenter.role_tooltip(symbol: hash.keys.first) %>
+            <%= ContributorPresenter.role_symbol_to_string(symbol: hash.keys.first) %>
+          </div>
+        </div>
+      <% end %>
+    </fieldset>
+  </div>
+</div>
+
+<div class="form-group row">
+  <div class="col-md-6">
+    <%= form.button(_("Save"), class: "btn btn-default", type: "submit") %>
+    <% unless contributor.new_record? %>
+      <%= link_to _("Remove"), plan_contributor_path(plan, contributor),
+                             method: :delete, class: "btn btn-default" %>
+    <% end %>
+    <%= link_to _("Cancel"), plan_contributors_path(plan),
+                             class: "btn btn-default" %>
+  </div>
+</div>

--- a/app/views/contributors/edit.html.erb
+++ b/app/views/contributors/edit.html.erb
@@ -1,0 +1,27 @@
+<% title "#{@plan.title} - edit contributor" %>
+
+<div class="row">
+  <div class="col-md-12">
+    <!-- render the project title -->
+    <h1><%= @plan.title %></h1>
+  </div>
+</div>
+
+<% content_for :plan_tab_body do %>
+  <h2>
+    <%= _("Editing contributor") %>
+    <%= link_to _('View all contributors'), plan_contributors_path(@plan),
+                                            class: "btn btn-default pull-right" %>
+  </h2>
+  <div class="row">
+    <div class="col-md-12">
+      <%= form_for @contributor, url: plan_contributor_path(@plan, @contributor),
+                                 html: { method: :put } do |f| %>
+        <%= render partial: "contributors/form",
+                   locals: { form: f, plan: @plan, contributor: @contributor } %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<%= render partial: "plans/navigation", locals: { plan: @plan } %>

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -1,0 +1,37 @@
+<% title "#{@plan.title} - contributors" %>
+
+<div class="row">
+  <div class="col-md-12">
+    <!-- render the project title -->
+    <h1><%= @plan.title %></h1>
+  </div>
+</div>
+
+<% content_for :plan_tab_body do %>
+  <div class="row">
+    <div class="col-md-12">
+      <p>
+        <%= _("Please list the project’s Principle Investigator(s) and those responsible for data management.<br/>For an explanation of the various roles, please see: %{link_to_ontology}").html_safe % { link_to_ontology: link_to(Contributor::ONTOLOGY_NAME, Contributor::ONTOLOGY_LANDING_PAGE) } %>
+      </p>
+      <br/>
+
+      <% if @contributors.any? %>
+        <%= paginable_renderise partial: "/paginable/contributors/index",
+                                controller: "paginable/contributors",
+                                action: "index",
+                                scope: @contributors,
+                                locals: { plan: @plan },
+                                query_params: {
+                                  sort_field: 'contributors.name',
+                                  sort_direction: :asc } %>
+      <% else %>
+        <p><%= _("No contributors have been defined.") %></p>
+      <% end %>
+
+      <%= link_to _("Add a contributor"), new_plan_contributor_path(@plan),
+                  class: "btn btn-primary" %>
+    </div>
+  </div>
+<% end %>
+
+<%= render partial: "plans/navigation", locals: { plan: @plan } %>

--- a/app/views/contributors/new.html.erb
+++ b/app/views/contributors/new.html.erb
@@ -1,0 +1,26 @@
+<% title "#{@plan.title} - add contributor" %>
+
+<div class="row">
+  <div class="col-md-12">
+    <!-- render the project title -->
+    <h1><%= @plan.title %></h1>
+  </div>
+</div>
+
+<% content_for :plan_tab_body do %>
+  <h2>
+    <%= _("New contributor") %>
+    <%= link_to _('View all contributors'), plan_contributors_path(@plan),
+                                            class: "btn btn-default pull-right" %>
+  </h2>
+  <div class="row">
+    <div class="col-md-12">
+      <%= form_for @contributor, url: plan_contributors_path do |f| %>
+        <%= render partial: "contributors/form",
+                   locals: { form: f, plan: @plan, contributor: @contributor } %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<%= render partial: "plans/navigation", locals: { plan: @plan } %>

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -104,6 +104,9 @@
                 </li>
               <% end %>
               <% if current_user.can_super_admin? %>
+                <li <%= 'class=active' if active_page?(super_admin_api_clients_path) %>>
+                  <%= link_to(_('Api Clients'), super_admin_api_clients_path) %>
+                </li>
                 <li <%= 'class=active' if active_page?(super_admin_notifications_path) %>>
                   <%= link_to _('Notifications'), super_admin_notifications_path %>
                 </li>

--- a/app/views/paginable/contributors/_index.html.erb
+++ b/app/views/paginable/contributors/_index.html.erb
@@ -1,0 +1,74 @@
+<%# locals: plan, contributors %>
+
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th scope="col">
+        <%= _("Name") %>&nbsp;<%= paginable_sort_link("contributors.name") %>
+      </th>
+      <th scope="col" class="sorter-false"><%= _("ORCID") %></th>
+      <th scope="col">
+        <%= _("Email") %>&nbsp;<%= paginable_sort_link("contributors.email") %>
+      </th>
+      <th scope="col">
+        <%= _("Affiliation") %>&nbsp;<%= paginable_sort_link("orgs.name") %>
+      </th>
+      <th scope="col" class="sorter-false"><%= _("Roles") %></th>
+      <% if plan.administerable_by?(current_user) %>
+        <th scope="col" class="sorter-false">
+          <span aria-hidden="false" class="sr-only"><%= _("Actions") %></span>
+        </th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% ror_scheme = IdentifierScheme.by_name("ror").first %>
+    <% scope.each do |contributor| %>
+      <tr>
+        <td><%= ContributorPresenter.display_name(name: contributor.name) %></td>
+        <td>
+          <% orcid = contributor.identifier_for_scheme(scheme: "orcid") %>
+          <% if orcid.present? %>
+            <%= link_to orcid.value_without_scheme_prefix, orcid.value %>
+          <% end %>
+        </td>
+        <td><%= contributor.email %></td>
+        <td>
+          <% if contributor.org.present? %>
+            <%= contributor.org&.name %>
+            <% ror = contributor.org.identifier_for_scheme(scheme: ror_scheme) %>
+            <% if ror.present? %>
+              <% id_presenter = IdentifierPresenter.new(identifiable: contributor.org) %>
+              <br/>
+              <%= id_presenter.id_for_display(id: ror).html_safe %>
+            <% end %>
+          <% end %>
+        </td>
+        <td><%= ContributorPresenter.display_roles(roles: contributor.selected_roles) %></td>
+        <% if plan.administerable_by?(current_user) %>
+          <td>
+            <div class="dropdown">
+              <button class="btn btn-link dropdown-toggle"
+                      type="button"
+                      id="contributor-<%= contributor.id %>-actions"
+                      data-toggle="dropdown"
+                      aria-haspopup="true" aria-expanded="true">
+                <%= _('Actions') %><span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu" aria-labelledby="contributor-<%= contributor.id %>-actions">
+                <li><%= link_to _('Edit'),
+                                edit_plan_contributor_path(plan_id: plan, id: contributor) %></li>
+                <li><%= link_to _('Remove'),
+                                plan_contributor_path(plan, contributor),
+                                data: { confirm: _("You are about to delete '%{contributor_name}'. Are you sure?") % { contributor_name: contributor.name } },
+                                method: :delete %>
+                </li>
+              </ul>
+            </div>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+ </table>
+ 

--- a/app/views/super_admin/api_clients/_form.html.erb
+++ b/app/views/super_admin/api_clients/_form.html.erb
@@ -1,0 +1,79 @@
+<%
+url = @api_client.new_record? ? super_admin_api_clients_path : super_admin_api_client_path(@api_client)
+meth = @api_client.new_record? ? :post : :put
+%>
+
+<%= form_for @api_client, url: url, method: meth,
+                          html: { class: 'api_client' } do |f| %>
+  <div class="row">
+    <div class="form-group col-xs-4">
+      <%= f.label :name, _('Name'), class: 'control-label' %>
+      <%= f.text_field :name, class: 'form-control', aria: { required: true } %>
+    </div>
+    <div class="form-group col-xs-4">
+      <%= f.label :homepage, _('Homepage'), class: 'control-label' %>
+      <%= f.url_field :homepage, class: 'form-control' %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="form-group col-xs-8">
+      <%= f.label :description, _('Description'), class: 'control-label' %>
+      <%= f.text_area :description, class: 'form-control api-client-text' %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="form-group col-xs-4">
+      <%= f.label :contact_email, _('Contact Name'), class: 'control-label' %>
+      <%= f.text_field :contact_name, class: 'form-control' %>
+    </div>
+    <div class="form-group col-xs-4">
+      <%= f.label :contact_email, _('Contact Email'), class: 'control-label' %>
+      <%= f.email_field :contact_email, class: 'form-control', aria: { required: true } %>
+    </div>
+  </div>
+
+  <% unless @api_client.new_record? %>
+    <div class="row" id="api-client-credentials">
+      <div class="form-group col-xs-4">
+        <%= f.label :client_id, _('Client ID'), class: 'control-label' %>
+        <%= f.email_field :client_id, class: 'form-control', disabled: true %>
+      </div>
+      <div class="form-group col-xs-4">
+        <%= f.label :client_secret, _('Client Secret'), class: 'control-label' %>
+        <%= f.email_field :client_secret, class: 'form-control', disabled: true %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="form-group col-xs-3">
+        <%= f.label :client_id, _('Last accessed on'), class: 'control-label' %>
+        <% date = @api_client.last_access.present? ? @api_client.last_access.utc.to_s  : _("Never") %>
+        <%= f.text_field :last_access, class: 'form-control', disabled: true,
+                                       value: date %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="pull-right">
+    <%= f.button _('Save'), class: 'btn btn-default', type: 'submit' %>
+
+    <% unless @api_client.new_record? %>
+      <%= link_to _("Refresh client ID and secret"),
+                  refresh_credentials_super_admin_api_client_path(@api_client),
+                  class: "btn btn-default", remote: true %>
+
+      <%= link_to _("Email credentials to contact"),
+                  email_credentials_super_admin_api_client_path(@api_client),
+                  class: "btn btn-default", remote: true %>
+
+      <%= link_to(
+            _('Delete'),
+            super_admin_api_client_path(@api_client),
+            class: 'btn btn-default',
+            method: :delete,
+            data: { confirm: _('Are you sure you want to delete the API client: "%{name}"') % { name: @api_client.name }}) %>
+    <% end %>
+
+    <%= link_to _('Cancel'), super_admin_api_clients_path, class: 'btn btn-default', role: 'button' %>
+  </div>
+<% end %>

--- a/app/views/super_admin/api_clients/edit.html.erb
+++ b/app/views/super_admin/api_clients/edit.html.erb
@@ -1,0 +1,8 @@
+<% title _('Editing API client') %>
+<h2>
+   <%= _('Editing API Client') %>
+   <%= link_to(_('View all API clients'), super_admin_api_clients_path,
+       class: 'btn btn-default pull-right', role: 'button') %>
+ </h2>
+
+<%= render 'form' %>

--- a/app/views/super_admin/api_clients/email_credentials.js.erb
+++ b/app/views/super_admin/api_clients/email_credentials.js.erb
@@ -1,0 +1,6 @@
+var msg = '<%= _("The credentials have been sent to %{email}.") % { email: @api_client.contact_email } %>';
+
+<%# TODO: replace this with the notificationHelper.js once we move to Rails 5 %>
+var notification = document.getElementById("notification-area");
+notification.append(msg);
+notification.classList.remove('hide');

--- a/app/views/super_admin/api_clients/index.html.erb
+++ b/app/views/super_admin/api_clients/index.html.erb
@@ -1,0 +1,24 @@
+<% title _('API Clients') %>
+
+<div class="row">
+  <div class="col-md-12">
+    <h1>
+      <%= _('API Clients') %>
+      <a href="<%= new_super_admin_api_client_path %>"
+         class="btn btn-primary pull-right"><%= _('Create Api Client') %></a>
+    </h1>
+    <p>Manage API access for external applications</p>
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <!-- List of guidance groups -->
+    <%= paginable_renderise(
+      partial: '/paginable/api_clients/index',
+      controller: 'paginable/api_clients',
+      action: 'index',
+      scope: @api_clients,
+      query_params: { sort_field: 'api_clients.name', sort_direction: :asc }) %>
+    <div>
+  </div>
+</div>

--- a/app/views/super_admin/api_clients/new.html.erb
+++ b/app/views/super_admin/api_clients/new.html.erb
@@ -1,0 +1,8 @@
+<% title _('New API client') %>
+<h2>
+   <%= _('New API Client') %>
+   <%= link_to(_('View all API clients'), super_admin_api_clients_path,
+       class: 'btn btn-default pull-right', role: 'button') %>
+ </h2>
+
+<%= render 'form' %>

--- a/app/views/super_admin/api_clients/refresh_credentials.js.erb
+++ b/app/views/super_admin/api_clients/refresh_credentials.js.erb
@@ -1,0 +1,9 @@
+var msg = '<%= _("Successsfully refreshed the client credentials.") %>';
+
+var form = document.getElementById("edit_api_client_<%= @api_client.id %>");
+form.innerHTML = '<%= escape_javascript(render partial: "/super_admin/api_clients/form") %>';
+
+<%# TODO: replace this with the notificationHelper.js once we move to Rails 5 %>
+var notification = document.getElementById("notification-area");
+notification.append(msg);
+notification.classList.remove('hide');

--- a/app/views/user_mailer/api_credentials.html.erb
+++ b/app/views/user_mailer/api_credentials.html.erb
@@ -1,0 +1,27 @@
+<%
+  tool_name = Rails.configuration.branding[:application][:name]
+  helpdesk_email = Rails.configuration.branding[:organisation][:helpdesk_email]
+  api_docs = Rails.configuration.branding[:application][:api_documentation_url]
+
+  name = @api_client.contact_name.present? ? @api_client.contact_name : @api_client.contact_email %>
+%>
+
+<p><%= _("Hello %{name},") %{ name: name } %></p>
+
+<p><%= _("Please use the following credentials when accessing the %{tool_name} API.") % { tool_name: tool_name } %></p>
+<pre><code>
+  {
+    "grant_type": "client_credentials",
+    "client_id": "<%= @api_client.client_id %>",
+    "client_secret": "<%= @api_client.client_secret %>"
+  }
+</code></pre>
+
+<p><%= (_("Please refer to the API documentation at: %{api_documentation_url}") % { api_documentation_url: "<a href=\"#{api_docs}\">#{api_docs}</a>" }).html_safe %></p>
+
+<p>
+  <%= _("Do not share these credentials. They for use with the %{external_application} application. If you do share your credentials with another application we reserve the right to revoke your access to the API.") % { external_application: @api_client.name.capitalize } %>
+</p>
+<p><%= _("If you did not request access to the %{tool_name} API or did not request for your credentials to be renewed, please contact us at %{helpdesk_email}") % { tool_name: tool_name, helpdesk_email: helpdesk_email } %></p>
+
+<%= render partial: 'email_signature' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,10 @@ Rails.application.routes.draw do
     resources :departments, only: [] do
       get 'index/:page', action: :index, on: :collection, as: :index
     end
+    # Paginable actions for api_clients
+     resources :api_clients, only: [] do
+       get 'index/:page', action: :index, on: :collection, as: :index
+     end
   end
 
   resources :template_options, only: [:index], constraints: { format: /json/ }
@@ -279,11 +283,19 @@ Rails.application.routes.draw do
         get :search
       end
     end
+
     resources :notifications, except: [:show] do
       member do
         post 'enable', constraints: {format: [:json]}
       end
     end
+
+    resources :api_clients do
+       member do
+         get :email_credentials
+         get :refresh_credentials
+       end
+     end
   end
 
   get "research_projects/search", action: "search",

--- a/db/migrate/20200207212113_create_api_clients.rb
+++ b/db/migrate/20200207212113_create_api_clients.rb
@@ -1,0 +1,15 @@
+class CreateApiClients < ActiveRecord::Migration
+  def change
+    create_table :api_clients do |t|
+      t.string :name, null: false, index: true
+      t.string :description
+      t.string :homepage
+      t.string :contact_name
+      t.string :contact_email, null: false
+      t.string :client_id, null: false
+      t.string :client_secret, null: false
+      t.date   :last_access
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20200213203124_add_last_api_access_to_users.rb
+++ b/db/migrate/20200213203124_add_last_api_access_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastApiAccessToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :last_api_access, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,21 @@ ActiveRecord::Schema.define(version: 20200215190747) do
 
   add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id", using: :btree
 
+  create_table "api_clients", force: :cascade do |t|
+    t.string   "name",                      null: false
+    t.string   "description"
+    t.string   "homepage"
+    t.string   "contact_name"
+    t.string   "contact_email",             null: false
+    t.string   "client_id",                 null: false
+    t.string   "client_secret",             null: false
+    t.date     "last_access"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "api_clients", ["name"], name: "index_api_clients_on_name", using: :btree
+
   create_table "departments", force: :cascade do |t|
     t.string   "name"
     t.string   "code"
@@ -449,6 +464,7 @@ ActiveRecord::Schema.define(version: 20200215190747) do
     t.string   "recovery_email"
     t.boolean  "active",                            default: true
     t.integer  "department_id"
+    t.datetime "last_api_access"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -772,7 +772,6 @@ namespace :upgrade do
       ui.user.identifiers << Identifier.new(
         identifier_scheme: ui.identifier_scheme,
         value: ui.identifier,
-        #type: (ui.identifier_scheme.name == "orcid" ? "url" : "other"),
         attrs: {}.to_json
       )
     end

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe RegistrationsController, type: :controller do
         @user = build(:user)
 
         @controller.stubs(:org_from_params).returns(build(:org))
-        #@controller.stubs(:remove_org_selection_params)
-        #             .returns({ other_param: Faker::Lorem.word })
       end
 
       it "returns nil if the params are not present" do

--- a/spec/factories/api_clients.rb
+++ b/spec/factories/api_clients.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: api_clients
+#
+#  id             :integer          not null, primary key
+#  name           :string,          not null
+#  homepage       :string
+#  contact_name   :string
+#  contact_email  :string,          not null
+#  client_id      :string,          not null
+#  client_secret  :string,          not null
+#  last_access    :datetime
+#  created_at     :datetime
+#  updated_at     :datetime
+#
+# Indexes
+#
+#  index_api_clients_on_name     (name)
+#
+
+FactoryBot.define do
+  factory :api_client do
+    name { Faker::Lorem.unique.word }
+    homepage { Faker::Internet.url }
+    contact_name { Faker::Movies::StarWars.character }
+    contact_email { Faker::Internet.email }
+    client_id { SecureRandom.uuid }
+    client_secret { SecureRandom.uuid }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -66,6 +66,7 @@ FactoryBot.define do
       after(:create) do |user, evaluator|
         %w[modify_templates modify_guidance
            change_org_details
+           use_api
            grant_permissions].each do |perm_name|
           user.perms << Perm.find_or_create_by(name: perm_name)
         end

--- a/spec/models/api_client_spec.rb
+++ b/spec/models/api_client_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApiClient, type: :model do
+
+  context "validations" do
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:contact_email) }
+
+    # Uniqueness validation
+    it {
+      subject.name = Faker::Lorem.word
+      subject.contact_email = Faker::Internet.email
+      subject.client_id = Faker::Lorem.word
+      subject.client_secret = Faker::Lorem.word
+      is_expected.to validate_uniqueness_of(:name)
+        .case_insensitive
+        .with_message("must be unique")
+    }
+
+    # Email format validation
+    it {
+      is_expected.to allow_values("one@example.com", "foo-bar@ed.ac.uk")
+        .for(:contact_email)
+    }
+    it {
+      is_expected.not_to allow_values("example.com", "foo bar@ed.ac.uk")
+        .for(:contact_email)
+    }
+
+  end
+
+  context "Instance Methods" do
+    before(:each) do
+      @client = build(:api_client)
+    end
+
+    describe "#to_s" do
+      it "should return the name" do
+        expect(@client.to_s).to eql(@client.name)
+      end
+
+      it "should return the name through interpolation" do
+        expect("#{@client}").to eql(@client.name)
+      end
+    end
+
+    describe "#authenticate" do
+      it "returns false if no secret is specified" do
+        expect(@client.authenticate(secret: nil)).to eql(false)
+      end
+
+      it "returns false if the secrets do not match" do
+        expect(@client.authenticate(secret: SecureRandom.uuid)).to eql(false)
+      end
+
+      it "returns true if the secrets match" do
+        expect(@client.authenticate(secret: @client.client_secret)).to eql(true)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Part of #2390 

- Adds an `api_clients` to store access credentials for systems (instead of individual users)
- Adds a model for ApiClient
- Adds a controller, policy, routes and corresponding views (accessible via the Super Admin menu)
  - Main Index page (index and paginable index)
  - Edit/Add pages
  - Ability to Remove an ApiClient from the index page
  - Ability to refresh client_id and client_secret on the Edit Page
  - Ability to auto-email credentials to the contact on the Edit Page
- Adds tests 
- Added a `last_api_access` to User for future use with API V1
