### PR TITLE
Bugfix: Template creation was failing due to invalid visibility value

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -150,8 +150,12 @@ module OrgAdmin
     # POST /org_admin/templates
     def create
       authorize Template
+      args = template_params
+      # Swap in the appropriate visibility enum value for the checkbox value
+      args[:visibility] = args.fetch(:visibility, "0") == "1" ? "organisationally_visible" : "publicly_visible"
+
       # creates a new template with version 0 and new family_id
-      @template = Template.new(template_params)
+      @template = Template.new(args)
       @template.org_id = current_user.org.id
       @template.locale = current_org.language.abbreviation
       @template.links = if params["template-links"].present?


### PR DESCRIPTION
Fixes #2458 .

This only impacts Orgs that have multiple Org types (e.g. both a Funder and an Institution). 

Changes proposed in this PR:
- Add line back into the templates controller that converts the `:visibility` checkbox from a '0' or '1' into `organizationally_visible` or `publicly_visible`.

