### PR TITLE
Allow creation and management of departments from the API

### DIFF
--- a/app/controllers/api/v0/departments_controller.rb
+++ b/app/controllers/api/v0/departments_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class Api::V0::DepartmentsController < Api::V0::BaseController
+
+  before_action :authenticate
+
+  ##
+  # Create a new department based on the information passed in JSON to the API
+  def create
+    unless Api::V0::DepartmentsPolicy.new(@user, nil).index?
+      raise Pundit::NotAuthorizedError
+    end
+    @department = Department.new(org: @user.org,
+                                 code: params[:code],
+                                 name: params[:name])
+    if @department.save
+      redirect_to api_v0_departments_path
+    else
+      # the department did not save
+      self.headers["WWW-Authenticate"] = "Token realm=\"\""
+      render json: _("Departments code and name must be unique"), status: 400
+    end
+  end
+
+  ##
+  # Lists the departments for the API user's organisation
+  def index
+    unless Api::V0::DepartmentsPolicy.new(@user, nil).index?
+      raise Pundit::NotAuthorizedError
+    end
+    @departments = @user.org.departments
+  end
+
+  def users
+    unless Api::V0::DepartmentsPolicy.new(@user, nil).users?
+      raise Pundit::NotAuthorizedError
+    end
+    @users = @user.org.users.includes(:department)
+  end
+
+  def assign_users
+    @department = Department.find(params[:id])
+
+    unless Api::V0::DepartmentsPolicy.new(@user, @department).assign_users?
+      raise Pundit::NotAuthorizedError
+    end
+
+    emails = params[:users]
+    #puts emails
+    emails.each do |email|
+      user = User.find_by(email: email)
+      # Currently the validation is that the user's org matches the api users
+      # Not sure if this could/should be captured in Pundit
+      unless @user.present? && @user.org == user&.org
+        raise Pundit::NotAuthorizedError, _("user #{email} was not found on your organisation")
+      end
+
+      user.department = @department
+      user.save!
+      puts user.email
+      puts user.department
+    end
+    redirect_to users_api_v0_departments_path
+  end
+
+
+  private
+
+
+
+end

--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -23,7 +23,7 @@ class Api::V0::PlansController < Api::V0::BaseController
     # ensure user's organisation is the same as api user's
     unless plan_user.org == @user.org
       raise Pundit::NotAuthorizedError, _("user must be in your organisation")
-    ends
+    end
 
     # initialize the plan
     @plan = Plan.new

--- a/app/policies/api/v0/departments_policy.rb
+++ b/app/policies/api/v0/departments_policy.rb
@@ -1,0 +1,38 @@
+module Api
+  module V0
+    class DepartmentsPolicy < ApplicationPolicy
+      attr_reader :user, :department
+
+      def initialize(user, department)
+        raise Pundit::NotAuthorizedError, _("must be logged in") unless user
+        @user = user
+        @department = department
+      end
+
+      ##
+      # an org-admin can create a department for their organisation
+      def create?
+        @user.can_org_admin?
+      end
+
+      ##
+      # any user can view their organisation's list of departments
+      def index?
+        true
+      end
+
+      ##
+      # an org-admin user can query for a list of users in each department
+      def users?
+        @user.can_org_admin?
+      end
+
+      ##
+      # an org-admin may assign users (from their org) to a department (from their org)
+      def assign_users?
+        @user.can_org_admin? && @department.org == @user.org
+      end
+
+    end
+  end
+end

--- a/app/policies/api/v0/departments_policy.rb
+++ b/app/policies/api/v0/departments_policy.rb
@@ -30,7 +30,15 @@ module Api
       ##
       # an org-admin may assign users (from their org) to a department (from their org)
       def assign_users?
-        @user.can_org_admin? && @department.org == @user.org
+        @user.can_org_admin? &&
+        @department.present? &&
+        @department.org == @user.org
+      end
+
+      ##
+      # an org-admin may unassign users (from their org) from a department
+      def unassign_users?
+        @user.can_org_admin? 
       end
 
     end

--- a/app/views/api/v0/departments/index.json.jbuilder
+++ b/app/views/api/v0/departments/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.prettify!
+
+json.array! @departments.each do |department|
+  json.code department.code
+  json.name department.name
+  json.id   department.id
+end

--- a/app/views/api/v0/departments/users.json.jbuilder
+++ b/app/views/api/v0/departments/users.json.jbuilder
@@ -1,0 +1,10 @@
+json.prettify!
+
+json.array! @users.group_by(&:department).each do |department, users|
+  json.code department&.code
+  json.name department&.name
+  json.id   department&.id
+  json.users users.each do |u|
+    json.email u.email
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,6 +151,7 @@ Rails.application.routes.draw do
       resources :departments, only: [:create, :index] do
         collection do
           get :users
+          patch :unassign_users
         end
         member do
           patch :assign_users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,14 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: {format: :json} do
     namespace :v0 do
+      resources :departments, only: [:create, :index] do
+        collection do
+          get :users
+        end
+        member do
+          patch :assign_users
+        end
+      end
       resources :guidances, only: [:index], controller: 'guidance_groups', path: 'guidances'
       resources :plans, only: [:create, :index]
       resources :templates, only: :index


### PR DESCRIPTION
I've added 4 endpoints in v0 of the api to a new controller: `api/v0/departments_controller.rb`
- `index` displays an array of departments for any user's organization
- `create` allows an org-admin to specify a name and code to create a department
- `users` allows an org-admin to see which accounts (by email) are associated with each department.
- `assign_users` allows an org-admin to specify a list of users (`user[]` in params) to be assigned to a specific department (using the id returned by `index` and the email addresses from `users`)

