### PR TITLE
bugfix to accidental commit

### DIFF
--- a/app/controllers/paginable/users_controller.rb
+++ b/app/controllers/paginable/users_controller.rb
@@ -10,7 +10,7 @@ class Paginable::UsersController < ApplicationController
     @clicked_through = params[:click_through].present?
 
     # variable containing the check box value
-    filter = params[:filter_admin] == "1"
+    @filter_admin = params[:filter_admin] == "1"
 
     if current_user.can_super_admin?
       scope = User.includes(:roles)
@@ -18,7 +18,7 @@ class Paginable::UsersController < ApplicationController
       scope = current_user.org.users.includes(:roles)
     end
 
-    if filter
+    if @filter_admin
       scope = scope.joins(:perms)
     end
 
@@ -26,7 +26,7 @@ class Paginable::UsersController < ApplicationController
     paginable_renderise(
       partial: "index",
       scope: scope,
-      query_params: { sort_field: 'users.surname', sort_direction: :asc , filter_admin: filter },
+      query_params: { sort_field: 'users.surname', sort_direction: :asc },
       view_all: !current_user.can_super_admin?
     )
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html do
         @clicked_through = params[:click_through].present?
+        @filter_admin = false
 
         if current_user.can_super_admin?
           @users = User.includes(:roles).page(1)

--- a/app/views/layouts/_paginable.html.erb
+++ b/app/views/layouts/_paginable.html.erb
@@ -8,8 +8,7 @@
     <div class="row">
       <div class="col-md-12">
         <%= render(partial: '/shared/search',
-                   locals: { search_term: search_term, view_partial: partial,
-                             checkbox_status: "" }) if searchable? || total > Kaminari.config.default_per_page %>
+                   locals: { search_term: search_term }) if searchable? || total > Kaminari.config.default_per_page %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,7 +1,4 @@
-<% # locals: { search_term, view_partial, checkbox_status } %>
-
-<% user_view = (view_partial == '/paginable/users/index') %>
-
+<%# locals: { search_term } %>
 
 <%= form_tag(paginable_base_url(1), method: :get, remote: true, class: 'form-inline paginable-action') do %>
   <div class="form-group">
@@ -11,12 +8,13 @@
       </span>
       <%= text_field_tag(:search, search_term, class: 'form-control', 'aria-labelledby': 'search',
                         spellcheck: true, 'aria-describedby': 'search-addon', 'aria-required': true) %>
-      <%- # checkbox to select all users with permissions -%>
-      <%if user_view  %>
-        <%= _('Display admin only')%>
-        <%= check_box_tag( filter_admin , value = "1", checked = checkbox_status)%>
-      <% end %>
+
     </div>
+    <%# @filter_admin is only defined on the users_index page %>
+    <% unless @filter_admin.nil?  %>
+      <%= label_tag(:filter_admin, _('Only Show Admins'), class: 'form-check-inline') %>
+      <%= check_box_tag( :filter_admin , "1", @filter_admin)%>
+    <% end %>
   </div>
   <%= submit_tag(_('Search'), class: 'btn btn-default', style: 'margin-top: 8px;') %>
 <% end %>


### PR DESCRIPTION
fixes some bugs introduced with an accidental commit to development.
Slightly refactors the methodology to use an instance variable as a ternary flag _[true/false/nil]_ instead of passing through the partial and flag-status separately.

This does not complete the work on #2352 entirely, but @martaribeiro can pick that up on Monday
The display is currently a little wierd around the checkbox, and the numbering on the bottom of the pagination-table does not seem to react to the filtering (it displays too many pages).

The user-filtering appears to be working well though.