### PR TITLE
Fixes issue with new API V1

### DIFF
--- a/app/services/api/v1/auth/jwt/authorization_service.rb
+++ b/app/services/api/v1/auth/jwt/authorization_service.rb
@@ -35,7 +35,9 @@ module Api
             return @api_client unless token.present? && token[:client_id].present?
 
             @api_client = ApiClient.where(client_id: token[:client_id]).first
-            @api_client
+            return @api_client if @api_client.present
+
+            @api_client = User.where(email: token[:client_id]).first
           end
           # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize
 

--- a/app/services/api/v1/auth/jwt/authorization_service.rb
+++ b/app/services/api/v1/auth/jwt/authorization_service.rb
@@ -35,7 +35,7 @@ module Api
             return @api_client unless token.present? && token[:client_id].present?
 
             @api_client = ApiClient.where(client_id: token[:client_id]).first
-            return @api_client if @api_client.present
+            return @api_client if @api_client.present?
 
             @api_client = User.where(email: token[:client_id]).first
           end


### PR DESCRIPTION
Discovered a bug that was preventing User's from authenticating. The new API allows auth via User email+api_token or via ApiClient client_id+client_secret
