### PR TITLE
Issue 2352 Additional filters for super-admin user index

### DIFF
--- a/app/assets/stylesheets/blocks/_labels.scss
+++ b/app/assets/stylesheets/blocks/_labels.scss
@@ -9,3 +9,8 @@
 .radio label {
   margin-right: $grid-gutter-width / 2;
 }
+
+/* Remove mandatory * from check_box_tag in Admin search */
+.form-inline span.red {
+  visibility:hidden;
+}

--- a/app/controllers/paginable/users_controller.rb
+++ b/app/controllers/paginable/users_controller.rb
@@ -19,7 +19,7 @@ class Paginable::UsersController < ApplicationController
     end
 
     if @filter_admin
-      scope = scope.joins(:perms)
+      scope = scope.joins(:perms).distinct
     end
 
 

--- a/app/javascript/utils/paginable.js
+++ b/app/javascript/utils/paginable.js
@@ -6,7 +6,6 @@ $(() => {
   const onAjaxSuccessHandler = (e, data) => {
     $(e.target).closest(paginableSelector).replaceWith($(data));
   };
-  $('.paginable-search form[data-remote="true"]').on('ajax:before', e => isValidText($(e.target).find('input[name="search"]').val()));
   // Event listener for Ajax success event captured in response to a paginable link clicked or
   // search form submitted. Note the presence of a selector for on (e.g. a[data-remote="true"])
   // so that descendant elements from .paginable-results that are added in future are also

--- a/app/javascript/utils/paginable.js
+++ b/app/javascript/utils/paginable.js
@@ -1,4 +1,3 @@
-import { isValidText } from './isValidInputType';
 
 export const paginableSelector = '.paginable';
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,8 +149,11 @@ class User < ActiveRecord::Base
               "lower(email) LIKE lower(?)",
               search_pattern, search_pattern)
       else
-        where("lower(firstname || ' ' || surname) LIKE lower(?) OR " +
-              "email LIKE lower(?)", search_pattern, search_pattern)
+        joins(:org)
+          .where("lower(firstname || ' ' || surname) LIKE lower(:search_pattern)
+              OR lower(email) LIKE lower(:search_pattern)
+              OR lower(orgs.name) LIKE lower (:search_pattern)
+              OR lower(orgs.abbreviation) LIKE lower (:search_pattern) ", search_pattern: search_pattern)
       end
     end
   }

--- a/app/views/layouts/_paginable.html.erb
+++ b/app/views/layouts/_paginable.html.erb
@@ -8,7 +8,7 @@
     <div class="row">
       <div class="col-md-12">
         <%= render(partial: '/shared/search',
-                   locals: { search_term: search_term }) if searchable? || total > Kaminari.config.default_per_page %>
+                   locals: { search_term: search_term }) if searchable? || @filter_admin || total > Kaminari.config.default_per_page %>
       </div>
     </div>
   </div>
@@ -45,7 +45,7 @@
               <% end %>
             <% end %>
           <% else %>
-            <% if searchable? %>
+            <% if searchable? || @filter_admin %>
               <%= link_to(_('Clear search results'), paginable_base_url(1), { 'data-remote': true, class: 'paginable-action' }) %>
             <% end %>
           <% end %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -14,6 +14,7 @@
     <% unless @filter_admin.nil?  %>
       <%= label_tag(:filter_admin, _('Only Show Admins'), class: 'form-check-inline') %>
       <%= check_box_tag( :filter_admin , "1", @filter_admin)%>
+      &nbsp
     <% end %>
   </div>
   <%= submit_tag(_('Search'), class: 'btn btn-default', style: 'margin-top: 8px;') %>


### PR DESCRIPTION
Fixes #2352 

Changes proposed in this PR:
To add an organisational-filter, along with a filter for permissions (to easily see all org/super-admin users on your instance) 

A solution to this problem was to allow users to search by organisation and by adding a check box that filters users with permissions. For example, a “super-admin’ can search for an UoE user with  the ability  to “add organisations”, “modify templates” and “modify guidance”. The way the filter by permissions work is by looking for users with one or more types of permissions. 

There was a javascript validation to only submit the search for when there was search text. This was stopping the permissions filter to submit. The decision to remove this validation was not only to allow the filter to work but as well to allow the user to clear the search box in order to clear the search results.  