### PR TITLE
fixed issue with giving OrgAdmin permission to Change Org Affiliation

### DIFF
--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -41,7 +41,7 @@ module OrgAdmin
                           .where(customization_of: nil, org_id: current_user.org.id)
       published = templates.select { |t| t.published? || t.draft? }.length
 
-      @orgs  = current_user.can_super_admin? ? Org.all : nil
+      @orgs  = current_user.can_change_org? ? Org.all : nil
       @title = if current_user.can_super_admin?
                  _("%{org_name} Templates") % { org_name: current_user.org.name }
                else

--- a/app/javascript/views/usage/index.js
+++ b/app/javascript/views/usage/index.js
@@ -14,12 +14,15 @@ $(() => {
 
   // attach listener to separator select menu
   // on change look for "stat" elements and chnage their query param
-  document.getElementById('csv-field-sep').addEventListener('click', (e) => {
-    const statElems = document.getElementsByClassName('stat');
-    const newSep = 'sep='.concat(encodeURIComponent(e.target.value));
-    const changeStatFn = changeStatFnGen(newSep);
-    Array.from(statElems).forEach(changeStatFn);
-  });
+  const fieldSep = document.getElementById('csv-field-sep');
+  if (fieldSep !== null) {
+    fieldSep.addEventListener('click', (e) => {
+      const statElems = document.getElementsByClassName('stat');
+      const newSep = 'sep='.concat(encodeURIComponent(e.target.value));
+      const changeStatFn = changeStatFnGen(newSep);
+      Array.from(statElems).forEach(changeStatFn);
+    });
+  }
 
   initializeCharts();
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,12 +228,12 @@ class User < ActiveRecord::Base
     user_identifiers.where(identifier_scheme: scheme).first
   end
 
-  # Checks if the user is a super admin. If the user has any privelege which requires
+  # Checks if the user is a super admin. If the user has ALL privelege which requires
   # them to see the super admin page then they are a super admin.
   #
   # Returns Boolean
   def can_super_admin?
-    self.can_add_orgs? || self.can_grant_api_to_orgs? || self.can_change_org?
+    can_add_orgs? && can_grant_api_to_orgs? && can_change_org?
   end
 
   # Checks if the user is an organisation admin if the user has any privlege which

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -26,7 +26,7 @@ class UserPolicy < ApplicationPolicy
 
   # Allows the user to swap their org affiliation on the fly
   def org_swap?
-    signed_in_user.can_super_admin?
+    signed_in_user.can_change_org?
   end
 
   def activate?

--- a/app/views/org_admin/templates/index.html.erb
+++ b/app/views/org_admin/templates/index.html.erb
@@ -4,7 +4,7 @@
     <h1><%= _('Templates') %></h1>
   </div>
 
-  <% if current_user.can_super_admin? %>
+  <% if current_user.can_change_org? %>
     <div class="col-md-12">
       <p>
         <%= _('If you would like to modify one of the templates below, you must first change your organisation affiliation.') %>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2853,7 +2853,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
+debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==


### PR DESCRIPTION
Fixes #2511 

- Update `can_super_admin?` to verify that user has ALL SuperAdmin permissions
- Update template page's Org Selector to care about `can_change_org?` instead of `can_super_admin?`

We may want to consider a re-eval of our permissions and policies. This was sort of an edge case scenario.

Hold off on merging this one @xsrust until we have a conversation about the scenario outlined in the ticket and any security implications created by these changes. 