### PR TITLE
change uniq to distinct where used in query

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
 
   def errors_for_display(obj)
     if obj.present? && obj.errors.any?
-      msgs = obj.errors.full_messages.uniq.collect { |msg| "<li>#{msg}</li>" }
+      msgs = obj.errors.full_messages.distinct.collect { |msg| "<li>#{msg}</li>" }
       "<ul>#{msgs.join('')}</li></ul>"
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
 
   def errors_for_display(obj)
     if obj.present? && obj.errors.any?
-      msgs = obj.errors.full_messages.distinct.collect { |msg| "<li>#{msg}</li>" }
+      msgs = obj.errors.full_messages.uniq.collect { |msg| "<li>#{msg}</li>" }
       "<ul>#{msgs.join('')}</li></ul>"
     end
   end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -31,9 +31,9 @@ class PlansController < ApplicationController
     # Get all of the available funders and non-funder orgs
     @funders = Org.funder
                   .joins(:templates)
-                  .where(templates: { published: true }).uniq.sort_by(&:name)
+                  .where(templates: { published: true }).distinct.sort_by(&:name)
     @orgs = (Org.organisation + Org.institution + Org.managing_orgs).flatten
-                                                                    .uniq.sort_by(&:name)
+                                                                    .distinct.sort_by(&:name)
 
     # Get the current user's org
     @default_org = current_user.org if @orgs.include?(current_user.org)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -33,7 +33,7 @@ class PlansController < ApplicationController
                   .joins(:templates)
                   .where(templates: { published: true }).distinct.sort_by(&:name)
     @orgs = (Org.organisation + Org.institution + Org.managing_orgs).flatten
-                                                                    .distinct.sort_by(&:name)
+                                                                    .uniq.sort_by(&:name)
 
     # Get the current user's org
     @default_org = current_user.org if @orgs.include?(current_user.org)


### PR DESCRIPTION
Fixes #2473 .

Changes proposed in this PR:
- changes uniq to distinct where used in query

I scanned all files in the tree for "uniq" and checked each individually. Most of them follow "pluck" which means they are working on an array rather than part of a query. As far as I can see uniq on array is the same in Rails 5. Hence not a lot here.
