### PR TITLE
hackathon bug fixes

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -24,7 +24,8 @@ module Api
               plans = Plan.where(id: nil).limit(1)
             end
 
-          elsif client.is_a?(ApiClient) && plans.first.api_client_id != client.id
+          elsif client.is_a?(ApiClient) && plans.first.api_client_id != client.id &&
+                !plans.first.publicly_visible?
             # Kaminari pagination requires an ActiveRecord resultset :/
             plans = Plan.where(id: nil).limit(1)
           end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -133,7 +133,7 @@ module Api
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def contributor_to_user(contributor:)
         identifiers = contributor.identifiers.map do |id|
-          { name: id.identifier_scheme.name, value: id.value }
+          { name: id.identifier_scheme&.name, value: id.value }
         end
         user = User.from_identifiers(array: identifiers) if identifiers.any?
         user = User.find_by(email: contributor.email) unless user.present?

--- a/app/services/api/v1/deserialization/contributor.rb
+++ b/app/services/api/v1/deserialization/contributor.rb
@@ -12,7 +12,7 @@ module Api
 
           # Convert the incoming JSON into a Contributor
           #   {
-          #     "roles": [
+          #     "role": [
           #       "https://dictionary.casrai.org/Contributor_Roles/Project_administration"
           #     ],
           #     "name": "Jane Doe",
@@ -54,7 +54,7 @@ module Api
             return false unless json.present?
             return false unless json[:name].present? || json[:mbox].present?
 
-            is_contact ? true : json[:roles].present?
+            is_contact ? true : json[:role].present?
           end
 
           # Find or initialize the Contributor
@@ -125,9 +125,9 @@ module Api
           # Assign the specified roles
           def assign_roles(contributor:, json: {})
             return nil unless contributor.present?
-            return contributor unless json.present? && json[:roles].present?
+            return contributor unless json.present? && json[:role].present?
 
-            json.fetch(:roles, []).each do |url|
+            json.fetch(:role, []).each do |url|
               role = translate_role(role: url)
               contributor.send(:"#{role}=", true) if role.present?
             end

--- a/app/services/api/v1/deserialization/dataset.rb
+++ b/app/services/api/v1/deserialization/dataset.rb
@@ -19,6 +19,15 @@ module Api
           #        "type": "doi",
           #        "identifier": "https://doix.org/10.1234.123abc/y3"
           #      }
+          #    },
+          #      "distribution": [
+          #        {
+          #          "title": "PDF - Testing our maDMP JSON export",
+          #          "data_access": "open",
+          #          "download_url": "http://dmproadmap.org/plans/44247/export.pdf",
+          #          "format": ["application/pdf"]
+          #        }
+          #      ]
           #    }
           def deserialize!(json: {})
             return nil unless json.present? && json[:title].present?

--- a/app/services/api/v1/deserialization/funding.rb
+++ b/app/services/api/v1/deserialization/funding.rb
@@ -50,6 +50,8 @@ module Api
             grant = Api::V1::Deserialization::Identifier.deserialize!(
               identifiable: plan, json: json[:grant_id]
             )
+            return plan unless grant.present?
+
             plan.update(grant_id: grant.id)
             plan
           end

--- a/app/services/api/v1/deserialization/plan.rb
+++ b/app/services/api/v1/deserialization/plan.rb
@@ -14,7 +14,7 @@ module Api
           # Convert the incoming JSON into a Plan
           #   {
           #     "dmp": {
-          #       "created": "2020-03-26 11:52:00 UTC",
+          #       "created": "2020-03-26T11:52:00Z",
           #       "title": "Brain impairment caused by COVID-19",
           #       "description": "DMP for COVID-19 Brain analysis",
           #       "language": "eng",
@@ -30,8 +30,8 @@ module Api
           #       "project": [{
           #         "title": "Brain impairment caused by COVID-19",
           #         "description": "Brain stem comparisons of COVID-19 patients",
-          #         "start": "2020-03-01 12:33:44 UTC",
-          #         "end": "2023-03-31 12:33:44 UTC",
+          #         "start": "2020-03-01T12:33:44Z",
+          #         "end": "2023-03-31T12:33:44Z",
           #         "funding": [{
           #           "$ref": "SEE Funding.deserialize! for details"
           #         }]
@@ -115,14 +115,15 @@ module Api
 
           # Deserialize the project information and attach to Plan
           # rubocop:disable Metrics/AbcSize
+          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           def deserialize_project(plan:, json: {})
             return plan unless json.present? &&
                                json[:project].present? &&
                                json[:project].is_a?(Array)
 
             project = json.fetch(:project, [{}]).first
-            plan.start_date = project[:start]
-            plan.end_date = project[:end]
+            plan.start_date = Time.new(project[:start]).utc if project[:start].present?
+            plan.end_date = Time.new(project[:end]).utc if project[:end].present?
             return plan unless project[:funding].present?
 
             funding = project.fetch(:funding, []).first
@@ -130,6 +131,7 @@ module Api
 
             Api::V1::Deserialization::Funding.deserialize!(plan: plan, json: funding)
           end
+          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           # rubocop:enable Metrics/AbcSize
 
           # Deserialize the contact as a Contributor

--- a/app/views/api/v1/_standard_response.json.jbuilder
+++ b/app/views/api/v1/_standard_response.json.jbuilder
@@ -13,7 +13,7 @@ json.ignore_nil!
 
 json.application @application
 json.source "#{request.method} #{request.path}"
-json.time Time.now.utc.to_s
+json.time Time.now.to_formatted_s(:iso8601)
 json.caller @caller
 json.code response.status
 json.message Rack::Utils::HTTP_STATUS_CODES[response.status]

--- a/app/views/api/v1/datasets/_show.json.jbuilder
+++ b/app/views/api/v1/datasets/_show.json.jbuilder
@@ -11,3 +11,12 @@ json.sensitive_data "unknown"
 json.dataset_id do
   json.partial! "api/v1/identifiers/show", identifier: presenter.identifier
 end
+
+json.distribution [plan] do |distribution|
+  json.title "PDF - #{distribution.title}"
+  json.data_access "open"
+  json.download_url plan_export_url(distribution, format: :pdf)
+  json.format do
+    json.array! ["application/pdf"]
+  end
+end

--- a/app/views/api/v1/plans/_project.json.jbuilder
+++ b/app/views/api/v1/plans/_project.json.jbuilder
@@ -4,8 +4,12 @@
 
 json.title plan.title
 json.description plan.description
-json.start plan.start_date&.utc&.to_s
-json.end plan.end_date&.utc&.to_s
+
+start_date = plan.start_date || Time.now
+json.start start_date.to_formatted_s(:iso8601)
+
+end_date = plan.end_date || Time.now + 2.years
+json.end end_date&.to_formatted_s(:iso8601)
 
 if plan.funder.present? || plan.grant_id.present?
   json.funding [plan] do

--- a/app/views/api/v1/plans/_show.json.jbuilder
+++ b/app/views/api/v1/plans/_show.json.jbuilder
@@ -12,8 +12,8 @@ json.description plan.description
 json.language Api::V1::LanguagePresenter.three_char_code(
   lang: ApplicationService.default_language
 )
-json.created plan.created_at.utc.to_s
-json.modified plan.updated_at.utc.to_s
+json.created plan.created_at.to_formatted_s(:iso8601)
+json.modified plan.updated_at.to_formatted_s(:iso8601)
 
 # TODO: Update this to pull from the appropriate question once the work is complete
 json.ethical_issues_exist "unknown"

--- a/app/views/api/v1/templates/index.json.jbuilder
+++ b/app/views/api/v1/templates/index.json.jbuilder
@@ -9,8 +9,8 @@ json.items @items do |template|
     json.title presenter.title
     json.description template.description
     json.version template.version
-    json.created template.created_at.utc.to_s
-    json.modified template.updated_at.utc.to_s
+    json.created template.created_at.to_formatted_s(:iso8601)
+    json.modified template.updated_at.to_formatted_s(:iso8601)
 
     json.affiliation do
       json.partial! "api/v1/orgs/show", org: template.org

--- a/app/views/api/v1/token.json.jbuilder
+++ b/app/views/api/v1/token.json.jbuilder
@@ -6,4 +6,4 @@ json.ignore_nil!
 json.access_token @token
 json.token_type @token_type
 json.expires_in @expiration
-json.created_at Time.now.utc.to_s
+json.created_at Time.now.to_formatted_s(:iso8601)

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -5,7 +5,7 @@
   contact_us = (Rails.configuration.branding[:organisation][:contact_us_url] || contact_us_url)
   email_subject = _('Query or feedback related to %{tool_name}') %{ :tool_name => tool_name }
   user_name = User.find_by(email: @resource.email).nil? ?  @resource.email : User.find_by(email: @resource.email).name(false)
-  inviter_name = @resource.is_a?(User) ? @resource.invited_by.name(false) : @resource.invited_by.name
+  inviter_name = @resource.invited_by.name
 %>
 <% FastGettext.with_locale FastGettext.default_locale do %>
   <p>

--- a/spec/requests/api/v1/plans_controller.rb
+++ b/spec/requests/api/v1/plans_controller.rb
@@ -43,8 +43,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
       before(:each) do
         stub_ror_service
         mock_identifier_schemes
-
-        create(:template, is_default: true, published: true)
+        create(:template, :publicly_visible, is_default: true, published: true)
       end
 
       context "minimal JSON" do
@@ -238,7 +237,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
               expect(@subject.email).to eql(@original[:mbox])
             end
             it "set the Contributor roles" do
-              expected = @original[:roles].map do |role|
+              expected = @original[:role].map do |role|
                 role.gsub("#{Contributor::ONTOLOGY_BASE_URL}/", "")
               end
               expect(@subject.send(:"#{expected.first.downcase}?")).to eql(true)
@@ -323,7 +322,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
 
     describe "GET /api/v1/plan/:id - show" do
       it "returns the plan" do
-        plan = create(:plan, org: Org.last)
+        plan = create(:plan, :creator, :organisationally_visible, org: Org.last)
         get api_v1_plan_path(plan)
         expect(response.code).to eql("200")
         expect(response).to render_template("api/v1/plans/index")
@@ -336,7 +335,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
       end
       it "returns a 404 if the user does not have access" do
         org2 = create(:org)
-        plan = create(:plan, org: org2)
+        plan = create(:plan, :creator, :organisationally_visible, org: org2)
         get api_v1_plan_path(plan)
         expect(response.code).to eql("404")
         expect(response).to render_template("api/v1/error")

--- a/spec/requests/api/v1/templates_controller_spec.rb
+++ b/spec/requests/api/v1/templates_controller_spec.rb
@@ -21,20 +21,20 @@ RSpec.describe Api::V1::TemplatesController, type: :request do
       end
 
       it "returns a public published template" do
-        create(:template, :publicly_visible, :published)
+        create(:template, :publicly_visible, published: true, customization_of: nil)
         get api_v1_templates_path
         expect(assigns(:items).length).to eql(1)
       end
 
       it "does not return an unpublished template" do
-        create(:template, :publicly_visible, published: false)
+        create(:template, :publicly_visible, published: false, customization_of: nil)
         get api_v1_templates_path
         expect(assigns(:items).length).to eql(0)
       end
 
       it "does not return an organizational template" do
         get api_v1_templates_path
-        create(:template, :organisationally_visible, :published)
+        create(:template, :organisationally_visible, :published, customization_of: nil)
         get api_v1_templates_path
         expect(assigns(:items).length).to eql(0)
       end
@@ -57,20 +57,21 @@ RSpec.describe Api::V1::TemplatesController, type: :request do
       end
 
       it "returns a public published template" do
-        create(:template, :publicly_visible, :published)
+        create(:template, :publicly_visible, :published, customization_of: nil)
         get api_v1_templates_path
         expect(assigns(:items).length).to eql(1)
       end
 
       it "returns a organizational published template (for user's org)" do
-        create(:template, :organisationally_visible, :published, org: Org.last)
+        create(:template, :organisationally_visible, :published, org: Org.last,
+                                                                 customization_of: nil)
         get api_v1_templates_path
         expect(assigns(:items).length).to eql(1)
       end
 
       it "does not return an unpublished template" do
         create(:template, :organisationally_visible, published: false,
-                                                     org: Org.last)
+                                                     org: Org.last, customization_of: nil)
         get api_v1_templates_path
         expect(assigns(:items).length).to eql(0)
       end
@@ -78,7 +79,8 @@ RSpec.describe Api::V1::TemplatesController, type: :request do
       it "does not return another Org's organizational template" do
         org2 = create(:org)
         get api_v1_templates_path
-        create(:template, :organisationally_visible, :published, org: org2)
+        create(:template, :organisationally_visible, published: true, org: org2,
+                                                     customization_of: nil)
         get api_v1_templates_path
         expect(assigns(:items).length).to eql(0)
       end

--- a/spec/services/api/v1/deserialization/contributor_spec.rb
+++ b/spec/services/api/v1/deserialization/contributor_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Api::V1::Deserialization::Contributor do
                                       identifier_scheme: @scheme,
                                       value: SecureRandom.uuid)
     @contributor.reload
-    @json = { name: @name, mbox: @email, roles: [@role] }
+    @json = { name: @name, mbox: @email, role: [@role] }
   end
 
   describe "#deserialize!(json: {})" do
@@ -60,28 +60,28 @@ RSpec.describe Api::V1::Deserialization::Contributor do
         expect(result).to eql(false)
       end
       it "returns false if :name and :mbox are not present" do
-        json = { roles: [@role] }
+        json = { role: [@role] }
         result = described_class.send(:valid?, is_contact: true, json: json)
         expect(result).to eql(false)
       end
       context "Contact" do
-        it "returns true without :roles" do
+        it "returns true without :role" do
           json = { name: @name, mbox: @email }
           result = described_class.send(:valid?, is_contact: true, json: json)
           expect(result).to eql(true)
         end
-        it "returns true with :roles" do
+        it "returns true with :role" do
           result = described_class.send(:valid?, is_contact: true, json: @json)
           expect(result).to eql(true)
         end
       end
       context "Contributor" do
-        it "returns false without :roles" do
+        it "returns false without :role" do
           json = { name: @name, mbox: @email }
           result = described_class.send(:valid?, is_contact: false, json: json)
           expect(result).to eql(false)
         end
-        it "returns true with :roles" do
+        it "returns true with :role" do
           result = described_class.send(:valid?, is_contact: false, json: @json)
           expect(result).to eql(true)
         end
@@ -116,7 +116,7 @@ RSpec.describe Api::V1::Deserialization::Contributor do
       end
       it "assigns the contributor role" do
         role = @contributor.all_roles[1].to_s
-        json = { name: Faker::TvShows::Simpsons.character, roles: [role] }
+        json = { name: Faker::TvShows::Simpsons.character, role: [role] }
         result = described_class.send(:marshal_contributor, plan_id: @plan.id,
                                                             is_contact: false,
                                                             json: json)
@@ -217,14 +217,14 @@ RSpec.describe Api::V1::Deserialization::Contributor do
                                                      json: nil)
         expect(result).to eql(@contributor)
       end
-      it "returns the Contributor as-is if json :roles is not present" do
+      it "returns the Contributor as-is if json :role is not present" do
         json = { name: @name }
         result = described_class.send(:assign_roles, contributor: @contributor,
                                                      json: json)
         expect(result).to eql(@contributor)
       end
       it "ignores unknown/undefined roles" do
-        @json[:roles] << Faker::Lorem.word
+        @json[:role] << Faker::Lorem.word
         result = described_class.send(:assign_roles, contributor: @contributor,
                                                      json: @json)
         expect(result.selected_roles).to eql(@contributor.selected_roles)

--- a/spec/services/api/v1/deserialization/plan_spec.rb
+++ b/spec/services/api/v1/deserialization/plan_spec.rb
@@ -31,19 +31,19 @@ RSpec.describe Api::V1::Deserialization::Plan do
       contributor: [
         {
           name: Faker::TvShows::Simpsons.unique.character,
-          roles: ["#{Contributor::ONTOLOGY_BASE_URL}/#{contrib.all_roles.first}"]
+          role: ["#{Contributor::ONTOLOGY_BASE_URL}/#{contrib.all_roles.first}"]
         },
         {
           name: Faker::TvShows::Simpsons.unique.character,
-          roles: [contrib.all_roles.last.to_s]
+          role: [contrib.all_roles.last.to_s]
         }
       ],
       project: [
         {
           title: Faker::Lorem.sentence,
           description: Faker::Lorem.paragraph,
-          start: Time.now.utc.to_s,
-          end: (Time.now + 2.years).utc.to_s,
+          start: Time.now.to_formatted_s(:iso8601),
+          end: (Time.now + 2.years).to_formatted_s(:iso8601),
           funding: [
             { name: Faker::Movies::StarWars.planet }
           ]
@@ -177,18 +177,23 @@ RSpec.describe Api::V1::Deserialization::Plan do
         expect(result.start_date).to eql(nil)
       end
       it "returns the Plan as-is if the json :project is not an array" do
-        json = { title: Faker::Lorem.sentence, project: { start: Time.now.utc.to_s } }
+        json = {
+          title: Faker::Lorem.sentence,
+          project: { start: Time.now.to_formatted_s(:iso8601) }
+        }
         result = described_class.send(:deserialize_project, plan: @plan, json: json)
         expect(result).to eql(@plan)
         expect(result.start_date).to eql(nil)
       end
       it "assigns the start_date of the Plan" do
         result = described_class.send(:deserialize_project, plan: @plan, json: @json)
-        expect(result.start_date.utc.to_s).to eql(@json[:project].first[:start])
+        expected = Time.new(@json[:project].first[:start]).utc.to_formatted_s(:iso8601)
+        expect(result.start_date.to_formatted_s(:iso8601)).to eql(expected)
       end
       it "assigns the end_date of the Plan" do
         result = described_class.send(:deserialize_project, plan: @plan, json: @json)
-        expect(result.end_date.utc.to_s).to eql(@json[:project].first[:end])
+        expected = Time.new(@json[:project].first[:end]).utc.to_formatted_s(:iso8601)
+        expect(result.end_date.to_formatted_s(:iso8601)).to eql(expected)
       end
       it "does not call the deserializer for Funding if :funding is not present" do
         @json[:project].first[:funding] = nil

--- a/spec/support/mocks/api_json_samples.rb
+++ b/spec/support/mocks/api_json_samples.rb
@@ -79,7 +79,7 @@ module Mocks
         "items": [
           {
             "dmp": {
-              "created": (Time.now - 3.months).utc.to_s,
+              "created": (Time.now - 3.months).to_formatted_s(:iso8601),
               "title": Faker::Lorem.sentence,
               "description": Faker::Lorem.paragraph,
               "language": Api::V1::LanguagePresenter.three_char_code(lang: lang),
@@ -104,7 +104,7 @@ module Mocks
                 }
               },
               "contributor": [{
-                "roles": [
+                "role": [
                   "https://dictionary.casrai.org/Contributor_Roles/Project_administration",
                   "https://dictionary.casrai.org/Contributor_Roles/Investigation"
                 ],
@@ -123,7 +123,7 @@ module Mocks
                   "identifier": SecureRandom.uuid
                 }
               }, {
-                "roles": [
+                "role": [
                   "https://dictionary.casrai.org/Contributor_Roles/Investigation"
                 ],
                 "name": contact[:name],
@@ -144,8 +144,8 @@ module Mocks
               "project": [{
                 "title": Faker::Lorem.sentence,
                 "description": Faker::Lorem.paragraph,
-                "start": (Time.now + 3.months).utc.to_s,
-                "end": (Time.now + 2.years).utc.to_s,
+                "start": (Time.now + 3.months).to_formatted_s(:iso8601),
+                "end": (Time.now + 2.years).to_formatted_s(:iso8601),
                 "funding": [{
                   "name": Faker::Movies::StarWars.droid,
                   "funder_id": {

--- a/spec/views/api/v1/plans/_project.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/plans/_project.json.jbuilder_spec.rb
@@ -18,10 +18,10 @@ describe "api/v1/plans/_project.json.jbuilder" do
       expect(@json[:description]).to eql(@plan.description)
     end
     it "includes :start" do
-      expect(@json[:start]).to eql(@plan.start_date.utc.to_s)
+      expect(@json[:start]).to eql(@plan.start_date.to_formatted_s(:iso8601))
     end
     it "includes :end" do
-      expect(@json[:end]).to eql(@plan.end_date.utc.to_s)
+      expect(@json[:end]).to eql(@plan.end_date.to_formatted_s(:iso8601))
     end
 
     it "includes the :funder" do

--- a/spec/views/api/v1/plans/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/plans/_show.json.jbuilder_spec.rb
@@ -33,10 +33,10 @@ describe "api/v1/plans/_show.json.jbuilder" do
       expect(@json[:language]).to eql(expected)
     end
     it "includes the :created" do
-      expect(@json[:created]).to eql(@plan.created_at.utc.to_s)
+      expect(@json[:created]).to eql(@plan.created_at.to_formatted_s(:iso8601))
     end
     it "includes the :modified" do
-      expect(@json[:modified]).to eql(@plan.updated_at.utc.to_s)
+      expect(@json[:modified]).to eql(@plan.updated_at.to_formatted_s(:iso8601))
     end
 
     it "returns the URL of the plan as the :dmp_id if no DOI is defined" do

--- a/spec/views/api/v1/templates/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/templates/index.json.jbuilder_spec.rb
@@ -42,10 +42,10 @@ describe "api/v1/templates/index.json.jbuilder" do
       expect(@template[:version]).to eql(@template1.version)
     end
     it "includes the :created" do
-      expect(@template[:created]).to eql(@template1.created_at.utc.to_s)
+      expect(@template[:created]).to eql(@template1.created_at.to_formatted_s(:iso8601))
     end
     it "includes the :modified" do
-      expect(@template[:modified]).to eql(@template1.updated_at.utc.to_s)
+      expect(@template[:modified]).to eql(@template1.updated_at.to_formatted_s(:iso8601))
     end
     it "includes the :affiliation" do
       expect(@template[:affiliation][:name]).to eql(@template1.org.name)


### PR DESCRIPTION
- Update to plan permissions to allow an ApiClient to retrieve publicly visible plans
- Fixed an issue in the plans_controller when the contributor identifier does not map to an IdentifierScheme (e.g. `{ type: "other", identifier: "12345" }`)
- Fixed contributor deserializer which referenced `roles` instead of `role`
- Added a nil check to the funding deserializer to allow empty `grant_id`
- Added a `distribution` to the `dataset` in the JSON output that contains the `download_url` which points to the plans pdf export url