### PR TITLE
rails 5 needs version number for migration

### DIFF
--- a/db/migrate/20200207212113_create_api_clients.rb
+++ b/db/migrate/20200207212113_create_api_clients.rb
@@ -1,4 +1,4 @@
-class CreateApiClients < ActiveRecord::Migration
+class CreateApiClients < ActiveRecord::Migration[4.2]
   def change
     create_table :api_clients do |t|
       t.string :name, null: false, index: true

--- a/db/migrate/20200213203124_add_last_api_access_to_users.rb
+++ b/db/migrate/20200213203124_add_last_api_access_to_users.rb
@@ -1,4 +1,4 @@
-class AddLastApiAccessToUsers < ActiveRecord::Migration
+class AddLastApiAccessToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :last_api_access, :datetime
   end

--- a/db/migrate/20200218213103_create_contributors.rb
+++ b/db/migrate/20200218213103_create_contributors.rb
@@ -1,4 +1,4 @@
-class CreateContributors < ActiveRecord::Migration
+class CreateContributors < ActiveRecord::Migration[4.2]
   def change
     create_table :contributors do |t|
       t.string :name

--- a/db/migrate/20200218213414_add_start_and_end_dates_to_plans.rb
+++ b/db/migrate/20200218213414_add_start_and_end_dates_to_plans.rb
@@ -1,4 +1,4 @@
-class AddStartAndEndDatesToPlans < ActiveRecord::Migration
+class AddStartAndEndDatesToPlans < ActiveRecord::Migration[4.2]
   def change
     add_column :plans, :grant_id, :integer, index: true
     add_column :plans, :start_date, :datetime

--- a/db/migrate/20200313153356_add_versionable_to_question_options.rb
+++ b/db/migrate/20200313153356_add_versionable_to_question_options.rb
@@ -1,4 +1,4 @@
-class AddVersionableToQuestionOptions < ActiveRecord::Migration
+class AddVersionableToQuestionOptions < ActiveRecord::Migration[4.2]
   def change
     add_column :question_options, :versionable_id, :string, limit: 36
 

--- a/db/migrate/20200323213847_add_api_client_id_to_plans.rb
+++ b/db/migrate/20200323213847_add_api_client_id_to_plans.rb
@@ -1,4 +1,4 @@
-class AddApiClientIdToPlans < ActiveRecord::Migration
+class AddApiClientIdToPlans < ActiveRecord::Migration[4.2]
   def change
     add_column :plans, :api_client_id, :integer, index: true
   end


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:
- add version number into migrations. Needed for rails 5.
