### PR TITLE
introduce do_not_reply_email to branding and use for feedback mailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -71,8 +71,9 @@ class UserMailer < ActionMailer::Base
     @phase     = plan.phases.first
     if recipient.active?
       FastGettext.with_locale FastGettext.default_locale do
+        sender = Rails.configuration.branding[:organisation][:do_not_reply_email] || Rails.configuration.branding[:organisation][:email]
         mail(to: recipient.email,
-             from: requestor.org.contact_email,
+             from: sender,
              subject: _("%{application_name}: Expert feedback has been provided for %{plan_title}") % {application_name: Rails.configuration.branding[:application][:name], plan_title: @plan.title})
       end
     end

--- a/config/branding.yml.sample
+++ b/config/branding.yml.sample
@@ -8,6 +8,7 @@ defaults: &defaults
     url: 'https://github.com/DMPRoadmap/roadmap/wiki'
     copywrite_name: 'Curation Centre (CC)'
     email: 'tester@cc_curation_centre.org'
+    do_not_reply_email: 'do-not-reply@cc_curation_centre.org'
     helpdesk_email: 'someone@somewhere.com'
     welcome_links:
       - link1:


### PR DESCRIPTION
Fixes https://github.com/DMPRoadmap/roadmap/issues/2521 .

Changes proposed in this PR:
- introduce new do_not_reply_email to branding.yml
- use this in feedback

The reason for the new email rather than using the existing default is that that default is used in quite a few places. Not all of these do we want to be "do-not-reply". So changing the default organisation.email to do-not-reply would not have the right effect. Hence introducing a new email address and falling back to the default email if it isn't there.
