### PR TITLE
Issue/2158

### DIFF
--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ClassLength
 class UsageController < ApplicationController
 
   after_action :verify_authorized
 
+  # rubocop:disable Metrics/AbcSize
   # GET /usage
   def index
     authorize :usage
@@ -13,10 +15,13 @@ class UsageController < ApplicationController
     plan_data(args: args, as_json: true)
     total_plans(args: min_max_dates(args: args))
     total_users(args: min_max_dates(args: args))
-    #TODO: pull this in from branding.yml
+    # TODO: pull this in from branding.yml
     @separators = [",", "|", "#"]
     @funder = current_user.org.funder?
+    @filtered = args[:filtered]
+    puts "#{@filtered} #{params[:filtered].present?}"
   end
+  # rubocop:enable Metrics/AbcSize
 
   # POST /usage_plans_by_template
   def plans_by_template
@@ -25,6 +30,7 @@ class UsageController < ApplicationController
     authorize :usage
 
     args = default_query_args
+    puts args[:filtered]
     if usage_params["template_plans_range"].present?
       args[:start_date] = usage_params["template_plans_range"]
     end
@@ -37,7 +43,7 @@ class UsageController < ApplicationController
     # for global usage
     authorize :usage
 
-    data = Org::TotalCountStatService.call
+    data = Org::TotalCountStatService.call(filtered: parse_filtered) # TODO: Update
     sep = sep_param
     data_csvified = Csvable.from_array_of_hashes(data, true, sep)
 
@@ -48,13 +54,15 @@ class UsageController < ApplicationController
   def org_statistics
     authorize :usage
 
-    data = Org::MonthlyUsageService.call(current_user)
+    data = Org::MonthlyUsageService.call(current_user, filtered: parse_filtered)
     sep = sep_param
     data_csvified = Csvable.from_array_of_hashes(data, true, sep)
 
     send_data(data_csvified, filename: "totals.csv")
   end
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   # GET /usage_yearly_users
   def yearly_users
     # This action is triggered when a user clicks on the 'download csv' button
@@ -63,7 +71,7 @@ class UsageController < ApplicationController
 
     user_data(args: default_query_args)
     sep = sep_param
-    send_data(CSV.generate({:col_sep => sep}) do |csv|
+    send_data(CSV.generate(col_sep: sep) do |csv|
       csv << [_("Month"), _("No. Users joined")]
       total = 0
       @users_per_month.each do |data|
@@ -73,7 +81,11 @@ class UsageController < ApplicationController
       csv << [_("Total"), total]
     end, filename: "users_joined.csv")
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   # GET /usage_yearly_plans
   def yearly_plans
     # This action is triggered when a user clicks on the 'download csv' button
@@ -82,7 +94,7 @@ class UsageController < ApplicationController
 
     plan_data(args: default_query_args)
     sep = sep_param
-    send_data(CSV.generate({:col_sep => sep}) do |csv|
+    send_data(CSV.generate(col_sep: sep) do |csv|
       csv << [_("Month"), _("No. Completed Plans")]
       total = 0
       @plans_per_month.each do |data|
@@ -92,6 +104,8 @@ class UsageController < ApplicationController
       csv << [_("Total"), total]
     end, filename: "completed_plans.csv")
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   # GET /usage_all_plans_by_template
   def all_plans_by_template
@@ -102,10 +116,11 @@ class UsageController < ApplicationController
     args = default_query_args
     args[:start_date] = first_plan_date
     sep = sep_param
-    {:col_sep => sep}
 
     plan_data(args: args, sort: :desc)
+    # rubocop:disable Metrics/LineLength
     data_csvified = StatCreatedPlan.to_csv(@plans_per_month, details: { by_template: true, sep: sep })
+    # rubocop:enable Metrics/LineLength
     send_data(data_csvified, filename: "created_plan_by_template.csv")
   end
 
@@ -113,7 +128,7 @@ class UsageController < ApplicationController
 
   def usage_params
     params.require(:usage).permit(:template_plans_range, :org_id, :start_date,
-                                  :end_date, :topic)
+                                  :end_date, :topic, :filtered)
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
@@ -144,13 +159,18 @@ class UsageController < ApplicationController
     {
       org: current_user.org,
       start_date: Date.today.months_ago(12).end_of_month.strftime("%Y-%m-%d"),
-      end_date: Date.today.last_month.end_of_month.strftime("%Y-%m-%d")
+      end_date: Date.today.last_month.end_of_month.strftime("%Y-%m-%d"),
+      filtered: parse_filtered
     }
+  end
+
+  def parse_filtered
+    params[:filtered].present? && params[:filtered] == "true"
   end
 
   # set the csv separator or default to comma
   def sep_param
-    params["sep"] || ','
+    params["sep"] || ","
   end
 
   def min_max_dates(args:)
@@ -160,16 +180,16 @@ class UsageController < ApplicationController
   end
 
   def user_data(args:, as_json: false, sort: :asc)
-    @users_per_month = StatJoinedUser.monthly_range(args)
+    @users_per_month = StatJoinedUser.monthly_range(args.except(:filtered))
                                      .order(date: sort)
-    @users_per_month = @users_per_month.map { |rec| rec.to_json } if as_json
+    @users_per_month = @users_per_month.map(&:to_json) if as_json
   end
 
   def plan_data(args:, as_json: false, sort: :asc)
     @plans_per_month = StatCreatedPlan.monthly_range(args)
                                       .where.not(details: "{\"by_template\":[]}")
                                       .order(date: sort)
-    @plans_per_month = @plans_per_month.map { |rec| rec.to_json } if as_json
+    @plans_per_month = @plans_per_month.map(&:to_json) if as_json
   end
 
   def total_plans(args:)
@@ -177,7 +197,7 @@ class UsageController < ApplicationController
   end
 
   def total_users(args:)
-    @total_org_users = StatJoinedUser.monthly_range(args).sum(:count)
+    @total_org_users = StatJoinedUser.monthly_range(args.except(:filtered)).sum(:count)
   end
 
   def first_plan_date
@@ -186,3 +206,4 @@ class UsageController < ApplicationController
   end
 
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -19,7 +19,6 @@ class UsageController < ApplicationController
     @separators = [",", "|", "#"]
     @funder = current_user.org.funder?
     @filtered = args[:filtered]
-    puts "#{@filtered} #{params[:filtered].present?}"
   end
   # rubocop:enable Metrics/AbcSize
 
@@ -30,7 +29,6 @@ class UsageController < ApplicationController
     authorize :usage
 
     args = default_query_args
-    puts args[:filtered]
     if usage_params["template_plans_range"].present?
       args[:start_date] = usage_params["template_plans_range"]
     end

--- a/app/javascript/views/usage/index.js
+++ b/app/javascript/views/usage/index.js
@@ -2,6 +2,12 @@ import { isObject, isUndefined } from '../../utils/isType';
 import { initializeCharts, createChart, drawHorizontalBar } from '../../utils/charts';
 
 $(() => {
+  // handles the checkbox for filtered-plans
+  $('#filter_plans_form').on('click, change', 'input[type="checkbox"]', (e) => {
+    const form = $(e.target).closest('form');
+    form.submit();
+  });
+
   // fns to handle the separator character menu
   // for CSV download
   const changeStatFnGen = (str) => {

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -207,6 +207,11 @@ class Plan < ActiveRecord::Base
     end
   }
 
+  ##
+  # Defines the filter_logic used in the statistics objects.
+  # For now, we filter out any test plans
+  scope :stats_filter, -> { where.not(visibility: visibilities[:is_test])}
+
   # Retrieves plan, template, org, phases, sections and questions
   scope :overview, lambda { |id|
     includes(:phases, :sections, :questions, template: [:org]).find(id)

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -8,6 +8,7 @@
 #  count      :bigint(8)        default(0)
 #  date       :date             not null
 #  details    :text
+#  filtered   :boolean          default(FALSE)
 #  type       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -21,7 +21,7 @@ class Stat < ActiveRecord::Base
 
   belongs_to :org
 
-  validates_uniqueness_of :type, scope: [:date, :org_id]
+  validates_uniqueness_of :type, scope: [:date, :org_id, :filtered]
 
   class << self
 

--- a/app/models/stat_created_plan.rb
+++ b/app/models/stat_created_plan.rb
@@ -8,6 +8,7 @@
 #  count      :bigint(8)        default(0)
 #  date       :date             not null
 #  details    :text
+#  filtered   :boolean          default(FALSE)
 #  type       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/stat_exported_plan.rb
+++ b/app/models/stat_exported_plan.rb
@@ -5,9 +5,10 @@
 # Table name: stats
 #
 #  id         :integer          not null, primary key
-#  count      :integer          default(0)
+#  count      :bigint(8)        default(0)
 #  date       :date             not null
 #  details    :text
+#  filtered   :boolean          default(FALSE)
 #  type       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/stat_exported_plan/create_or_update.rb
+++ b/app/models/stat_exported_plan/create_or_update.rb
@@ -6,13 +6,14 @@ class StatExportedPlan
 
     class << self
 
-      def do(start_date:, end_date:, org:)
-        count = exported_plans(start_date: start_date, end_date: end_date, org_id: org.id)
-        attrs = { date: end_date.to_date, count: count, org_id: org.id }
+      def do(start_date:, end_date:, org:, filtered: false)
+        count = exported_plans(start_date: start_date, end_date: end_date, org_id: org.id, filtered: filtered)
+        attrs = { date: end_date.to_date, count: count, org_id: org.id, filtered: filtered}
 
         stat_exported_plan = StatExportedPlan.find_by(
           date: attrs[:date],
-          org_id: attrs[:org_id]
+          org_id: attrs[:org_id],
+          filtered: attrs[:filtered]
         )
 
         if stat_exported_plan.present?
@@ -28,16 +29,19 @@ class StatExportedPlan
         User.where(users: {org_id: org_id })
       end
 
-      def org_plan_ids(org_id)
-        Role.joins(:user)
+      def org_plan_ids(org_id:, filtered:)
+        plans = Plan.all
+        plans = plans.stats_filter if filtered
+        Role.joins(:plan, :user)
             .creator
             .merge(users(org_id))
+            .merge(plans)
             .pluck(:plan_id)
             .uniq
       end
 
-      def exported_plans(start_date:, end_date:, org_id:)
-        ExportedPlan.where(plan_id: org_plan_ids(org_id))
+      def exported_plans(start_date:, end_date:, org_id:, filtered:)
+        ExportedPlan.where(plan_id: org_plan_ids(org_id: org_id, filtered: filtered))
             .where(created_at: start_date..end_date)
             .count
       end

--- a/app/models/stat_joined_user.rb
+++ b/app/models/stat_joined_user.rb
@@ -8,6 +8,7 @@
 #  count      :bigint(8)        default(0)
 #  date       :date             not null
 #  details    :text
+#  filtered   :boolean          default(FALSE)
 #  type       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/stat_joined_user/create_or_update.rb
+++ b/app/models/stat_joined_user/create_or_update.rb
@@ -6,13 +6,14 @@ class StatJoinedUser
 
     class << self
 
-      def do(start_date:, end_date:, org:)
+      def do(start_date:, end_date:, org:, filtered: false)
         count = count_users(start_date: start_date, end_date: end_date, org_id: org.id)
-        attrs = { date: end_date.to_date, count: count, org_id: org.id }
+        attrs = { date: end_date.to_date, count: count, org_id: org.id, filtered: filtered }
 
         stat_joined_user = StatJoinedUser.find_by(
           date: attrs[:date],
-          org_id: attrs[:org_id]
+          org_id: attrs[:org_id],
+          filtered: attrs[:filtered]
         )
 
         if stat_joined_user.present?

--- a/app/models/stat_shared_plan.rb
+++ b/app/models/stat_shared_plan.rb
@@ -5,9 +5,10 @@
 # Table name: stats
 #
 #  id         :integer          not null, primary key
-#  count      :integer          default(0)
+#  count      :bigint(8)        default(0)
 #  date       :date             not null
 #  details    :text
+#  filtered   :boolean          default(FALSE)
 #  type       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/services/org/create_created_plan_service.rb
+++ b/app/services/org/create_created_plan_service.rb
@@ -26,6 +26,13 @@ class Org
               end_date: end_date,
               org: org
             )
+            # 2nd call to pull stats on just 'real' plans
+            StatCreatedPlan::CreateOrUpdate.do(
+              start_date: start_date,
+              end_date: end_date,
+              org: org,
+              filtered: true
+            )
           end
         end
       end

--- a/app/services/org/create_exported_plan_service.rb
+++ b/app/services/org/create_exported_plan_service.rb
@@ -5,6 +5,7 @@ import OrgDateRangeable
 import StatExportedPlan
 import StatExportedPlan::CreateOrUpdate
 import Role
+import Plan
 import User
 import ExportedPlan
 
@@ -23,6 +24,12 @@ class Org
               start_date: start_date,
               end_date: end_date,
               org: org
+            )
+            StatExportedPlan::CreateOrUpdate.do(
+              start_date: start_date,
+              end_date: end_date,
+              org: org,
+              filtered: true
             )
           end
         end

--- a/app/services/org/create_last_month_created_plan_service.rb
+++ b/app/services/org/create_last_month_created_plan_service.rb
@@ -29,6 +29,12 @@ class Org
               end_date: last[:end_date],
               org: org
             )
+            StatCreatedPlan::CreateOrUpdate.do(
+              start_date: last[:start_date],
+              end_date: last[:end_date],
+              org: org,
+              filtered: true
+            )
           end
         end
       end

--- a/app/services/org/create_last_month_exported_plan_service.rb
+++ b/app/services/org/create_last_month_exported_plan_service.rb
@@ -5,6 +5,7 @@ import OrgDateRangeable
 import StatExportedPlan
 import StatExportedPlan::CreateOrUpdate
 import Role
+import Plan
 import User
 import ExportedPlan
 
@@ -25,6 +26,12 @@ class Org
               start_date: last[:start_date],
               end_date: last[:end_date],
               org: org
+            )
+            StatExportedPlan::CreateOrUpdate.do(
+              start_date: last[:start_date],
+              end_date: last[:end_date],
+              org: org,
+              filtered: true
             )
           end
         end

--- a/app/services/org/create_last_month_shared_plan_service.rb
+++ b/app/services/org/create_last_month_shared_plan_service.rb
@@ -5,6 +5,7 @@ import OrgDateRangeable
 import StatSharedPlan
 import StatSharedPlan::CreateOrUpdate
 import User
+import Plan
 import Role
 
 class Org
@@ -24,6 +25,12 @@ class Org
               start_date: last[:start_date],
               end_date: last[:end_date],
               org: org
+            )
+            StatSharedPlan::CreateOrUpdate.do(
+              start_date: last[:start_date],
+              end_date: last[:end_date],
+              org: org,
+              filtered: true
             )
           end
         end

--- a/app/services/org/create_shared_plan_service.rb
+++ b/app/services/org/create_shared_plan_service.rb
@@ -5,6 +5,7 @@ import OrgDateRangeable
 import StatSharedPlan
 import StatSharedPlan::CreateOrUpdate
 import User
+import Plan
 import Role
 
 class Org
@@ -22,6 +23,12 @@ class Org
               start_date: start_date,
               end_date: end_date,
               org: org
+            )
+            StatSharedPlan::CreateOrUpdate.do(
+              start_date: start_date,
+              end_date: end_date,
+              org: org,
+              filtered: true
             )
           end
         end

--- a/app/services/org/monthly_usage_service.rb
+++ b/app/services/org/monthly_usage_service.rb
@@ -6,11 +6,11 @@ class Org
 
     class << self
 
-      def call(current_user)
-        total = build_from_joined_user(current_user)
-        build_from_created_plan(current_user, total)
-        build_from_shared_plan(current_user, total)
-        build_from_exported_plan(current_user, total)
+      def call(current_user, filtered: false)
+        total = build_from_joined_user(current_user, filtered)
+        build_from_created_plan(current_user, filtered, total)
+        build_from_shared_plan(current_user, filtered, total)
+        build_from_exported_plan(current_user, filtered, total)
         total.values
       end
 
@@ -41,29 +41,37 @@ class Org
         acc
       end
 
-      def build_from_joined_user(current_user, total = {})
-        joined_users = Stat::StatJoinedUser.monthly_range(org: current_user.org).order(:date)
+      def build_from_joined_user(current_user, filtered, total = {})
+        # rubocop:disable Metrics/LineLength
+        joined_users = Stat::StatJoinedUser.monthly_range(org: current_user.org, filtered: filtered).order(:date)
+        # rubocop:enable Metrics/LineLength
         joined_users.reduce(total) do |acc, rec|
           reducer_body(acc, rec, :new_users)
         end
       end
 
-      def build_from_created_plan(current_user, total = {})
-        created_plans = Stat::StatCreatedPlan.monthly_range(org: current_user.org).order(:date)
+      def build_from_created_plan(current_user, filtered, total = {})
+        # rubocop:disable Metrics/LineLength
+        created_plans = Stat::StatCreatedPlan.monthly_range(org: current_user.org, filtered: filtered).order(:date)
+        # rubocop:enable Metrics/LineLength
         created_plans.reduce(total) do |acc, rec|
           reducer_body(acc, rec, :new_plans)
         end
       end
 
-      def build_from_shared_plan(current_user, total = {})
-        shared_plans = Stat::StatSharedPlan.monthly_range(org: current_user.org).order(:date)
+      def build_from_shared_plan(current_user, filtered, total = {})
+        # rubocop:disable Metrics/LineLength
+        shared_plans = Stat::StatSharedPlan.monthly_range(org: current_user.org, filtered: filtered).order(:date)
+        # rubocop:enable Metrics/LineLength
         shared_plans.reduce(total) do |acc, rec|
           reducer_body(acc, rec, :plans_shared)
         end
       end
 
-      def build_from_exported_plan(current_user, total = {})
-        exported_plans = Stat::StatExportedPlan.monthly_range(org: current_user.org).order(:date)
+      def build_from_exported_plan(current_user, filtered, total = {})
+        # rubocop:disable Metrics/LineLength
+        exported_plans = Stat::StatExportedPlan.monthly_range(org: current_user.org, filtered: filtered).order(:date)
+        # rubocop:enable Metrics/LineLength
         exported_plans.reduce(total) do |acc, rec|
           reducer_body(acc, rec, :downloads)
         end

--- a/app/services/org/total_count_created_plan_service.rb
+++ b/app/services/org/total_count_created_plan_service.rb
@@ -6,15 +6,16 @@ class Org
 
     class << self
 
-      def call(org = nil)
-        return for_orgs unless org.present?
-        for_org(org)
+      def call(org = nil, filtered: false)
+        return for_orgs(filtered) unless org.present?
+        for_org(org, filtered)
       end
 
       private
 
-      def for_orgs
+      def for_orgs(filtered)
         result = ::StatCreatedPlan
+          .where(filtered: filtered)
           .includes(:org)
           .select(:"orgs.name", :count)
           .group(:"orgs.name")
@@ -24,8 +25,8 @@ class Org
         end
       end
 
-      def for_org(org)
-        result = ::StatCreatedPlan.where(org: org).sum(:count)
+      def for_org(org, filtered)
+        result = ::StatCreatedPlan.where(org: org, filtered: filtered).sum(:count)
         build_model(org_name: org.name, count: result)
       end
 

--- a/app/services/org/total_count_joined_user_service.rb
+++ b/app/services/org/total_count_joined_user_service.rb
@@ -6,15 +6,16 @@ class Org
 
     class << self
 
-      def call(org = nil)
-        return for_orgs unless org.present?
-        for_org(org)
+      def call(org = nil, filtered: false)
+        return for_orgs(filtered) unless org.present?
+        for_org(org, filtered)
       end
 
       private
 
-      def for_orgs
+      def for_orgs(filtered)
         result = ::StatJoinedUser
+          .where(filtered: filtered)
           .includes(:org)
           .select(:"orgs.name", :count)
           .group(:"orgs.name")
@@ -24,8 +25,8 @@ class Org
         end
       end
 
-      def for_org(org)
-        result = ::StatJoinedUser.where(org: org).sum(:count)
+      def for_org(org, filtered)
+        result = ::StatJoinedUser.where(org: org, filtered: filtered).sum(:count)
         build_model(org_name: org.name, count: result)
       end
 

--- a/app/services/org/total_count_stat_service.rb
+++ b/app/services/org/total_count_stat_service.rb
@@ -6,9 +6,9 @@ class Org
 
     class << self
 
-      def call
+      def call(filtered: false)
         total = build_from_joined_user
-        build_from_created_plan(total)
+        build_from_created_plan(filtered, total)
         total.values
       end
 
@@ -38,14 +38,15 @@ class Org
       end
 
       def build_from_joined_user(total = {})
+        # Users have no concept of filtering (at the moment)
         joined_user_count = Org::TotalCountJoinedUserService.call
         joined_user_count.reduce(total) do |acc, count|
           reducer_body(acc, count, :total_users)
         end
       end
 
-      def build_from_created_plan(total = {})
-        created_plan_count = Org::TotalCountCreatedPlanService.call
+      def build_from_created_plan(filtered, total = {})
+        created_plan_count = Org::TotalCountCreatedPlanService.call(filtered: filtered)
         created_plan_count.reduce(total) do |acc, count|
           reducer_body(acc, count, :total_plans)
         end

--- a/app/views/usage/_total_usage.html.erb
+++ b/app/views/usage/_total_usage.html.erb
@@ -9,6 +9,12 @@
     <div class="col-xs-6">
       <i class="fa fa-files-o f-large"></i>
       <p  class="fontsize-h4"><%= plan_count.to_i %> Total plans</p>
+      <%= form_tag('/usage', method: :get, id: :filter_plans_form) do |f| %>
+        <%= label_tag :filtered do %>
+          <%= check_box_tag(:filtered, "true", @filtered)  %>
+          <%=  _("Excluding Test Plans") %>
+        <% end %>
+      <% end %>
     </div>
   </div>
   <% if @funder.present? %>
@@ -27,14 +33,14 @@
   </div>
   <% if current_user.can_super_admin? %>
     <div class="col-md-3">
-      <%= link_to usage_global_statistics_path(sep: ","), class: "stat btn btn-default #{'pull-right' if @funder.present?}", role: 'button', target: '_blank' do %>
+      <%= link_to usage_global_statistics_path(sep: ",", filtered: @filtered), class: "stat btn btn-default #{'pull-right' if @funder.present?}", role: 'button', target: '_blank' do %>
         <%= _('Download global usage') %> <i class="fa fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
   <% end %>
   <% unless @funder.present? %>
     <div class="col-md-3">
-      <%= link_to usage_org_statistics_path(sep: ","), class: 'stat btn btn-default pull-right', role: 'button', target: '_blank' do %>
+      <%= link_to usage_org_statistics_path(sep: ",", filtered: @filtered), class: 'stat btn btn-default pull-right', role: 'button', target: '_blank' do %>
         <%= _('Download Monthly Usage') %> <i class="fa fa-download" aria-hidden="true"></i>
       <% end %>
     </div>

--- a/app/views/usage/_user_statistics.html.erb
+++ b/app/views/usage/_user_statistics.html.erb
@@ -34,7 +34,7 @@
       <p class="bold fontsize-h4"><%= _('No. plans during last year') %></p>
     </div>
     <div class="pull-right">
-      <%= link_to usage_yearly_plans_path(sep: ","), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
+      <%= link_to usage_yearly_plans_path(sep: ",", filtered: @filtered), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
         <%= _('Download') %> <i class="fa fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
@@ -70,6 +70,9 @@
                       <%= f.select :template_plans_range, plans_per_template_ranges.reverse, {}, { class: "form-control" } %>
                     </li>
                     <li>
+                      <%= hidden_field_tag :filtered, @filtered %>
+                    </li>
+                    <li>
                       <%= f.submit _('Go'), class: 'btn btn-default mt-25' %>
                     </li>
                   </ul>
@@ -78,7 +81,7 @@
             </li>
             <li>
               <div class="form-group">
-                <%= link_to usage_all_plans_by_template_path(sep: ","), class: 'btn btn-default stat', role: 'button', target: '_blank' do %>
+                <%= link_to usage_all_plans_by_template_path(sep: ",", filtered: @filtered), class: 'btn btn-default stat', role: 'button', target: '_blank' do %>
                   <%= _('Download all') %> <i class="fa fa-download" aria-hidden="true"></i>
                 <% end %>
              </div>

--- a/db/migrate/20200601121822_add_filtered_to_stats.rb
+++ b/db/migrate/20200601121822_add_filtered_to_stats.rb
@@ -1,0 +1,5 @@
+class AddFilteredToStats < ActiveRecord::Migration
+  def change
+    add_column :stats, :filtered, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -526,6 +526,8 @@ ActiveRecord::Schema.define(version: 20200601121822) do
   add_foreign_key "answers_question_options", "answers"
   add_foreign_key "answers_question_options", "question_options"
   add_foreign_key "conditions", "questions"
+  add_foreign_key "contributors", "plans"
+  add_foreign_key "contributors", "orgs"
   add_foreign_key "guidance_groups", "orgs"
   add_foreign_key "guidances", "guidance_groups"
   add_foreign_key "notes", "answers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200514102523) do
+ActiveRecord::Schema.define(version: 20200601121822) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,21 @@ ActiveRecord::Schema.define(version: 20200514102523) do
   end
 
   add_index "answers_question_options", ["answer_id"], name: "index_answers_question_options_on_answer_id", using: :btree
+
+  create_table "api_clients", force: :cascade do |t|
+    t.string   "name",          null: false
+    t.string   "description"
+    t.string   "homepage"
+    t.string   "contact_name"
+    t.string   "contact_email", null: false
+    t.string   "client_id",     null: false
+    t.string   "client_secret", null: false
+    t.date     "last_access"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "api_clients", ["name"], name: "index_api_clients_on_name", using: :btree
 
   create_table "conditions", force: :cascade do |t|
     t.integer  "question_id"
@@ -413,12 +428,13 @@ ActiveRecord::Schema.define(version: 20200514102523) do
 
   create_table "stats", force: :cascade do |t|
     t.integer  "count",      limit: 8, default: 0
-    t.date     "date",                             null: false
-    t.string   "type",                             null: false
+    t.date     "date",                                 null: false
+    t.string   "type",                                 null: false
     t.integer  "org_id"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.text     "details"
+    t.boolean  "filtered",             default: false
   end
 
   create_table "templates", force: :cascade do |t|
@@ -538,8 +554,6 @@ ActiveRecord::Schema.define(version: 20200514102523) do
   add_foreign_key "answers_question_options", "answers"
   add_foreign_key "answers_question_options", "question_options"
   add_foreign_key "conditions", "questions"
-  add_foreign_key "contributors", "plans"
-  add_foreign_key "contributors", "orgs"
   add_foreign_key "guidance_groups", "orgs"
   add_foreign_key "guidances", "guidance_groups"
   add_foreign_key "notes", "answers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,34 +77,6 @@ ActiveRecord::Schema.define(version: 20200601121822) do
 
   add_index "conditions", ["question_id"], name: "index_conditions_on_question_id", using: :btree
 
-  create_table "api_clients", force: :cascade do |t|
-    t.string   "name",          null: false
-    t.string   "description"
-    t.string   "homepage"
-    t.string   "contact_name"
-    t.string   "contact_email", null: false
-    t.string   "client_id",     null: false
-    t.string   "client_secret", null: false
-    t.date     "last_access"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-  end
-
-  add_index "api_clients", ["name"], name: "index_api_clients_on_name", using: :btree
-
-  create_table "conditions", force: :cascade do |t|
-    t.integer  "question_id"
-    t.text     "option_list"
-    t.integer  "action_type"
-    t.integer  "number"
-    t.text     "remove_data"
-    t.text     "webhook_data"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
-  end
-
-  add_index "conditions", ["question_id"], name: "index_conditions_on_question_id", using: :btree
-
   create_table "contributors", force: :cascade do |t|
     t.string   "name"
     t.string   "email"

--- a/lib/org_date_rangeable.rb
+++ b/lib/org_date_rangeable.rb
@@ -2,9 +2,11 @@
 
 module OrgDateRangeable
 
-  def monthly_range(org:, start_date: nil, end_date: Date.today.end_of_month)
-    query_string = "org_id = :org_id"
-    query_hash = { org_id: org.id }
+  # rubocop:disable Metrics/MethodLength, Metrics/LineLength
+  def monthly_range(org:, start_date: nil, end_date: Date.today.end_of_month, filtered: false)
+    # rubocop:enable Metrics/LineLength
+    query_string = "org_id = :org_id and filtered = :filtered"
+    query_hash = { org_id: org.id, filtered: filtered }
 
     unless start_date.nil?
       query_string += " and date >= :start_date"
@@ -17,9 +19,11 @@ module OrgDateRangeable
     end
     where(query_string, query_hash)
   end
+  # rubocop:enable Metrics/MethodLength
 
   class << self
 
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def split_months_from_creation(org, &block)
       starts_at = org.created_at
       ends_at = starts_at.end_of_month
@@ -37,6 +41,7 @@ module OrgDateRangeable
 
       enumerable
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   end
 

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -542,6 +542,28 @@ describe Plan do
 
   end
 
+  describe ".stats_filter" do
+
+    subject { Plan.all.stats_filter }
+
+    context "when plan visibility is test" do
+      let!(:plan) { create(:plan, :creator, :is_test) }
+
+      it { is_expected.not_to include(plan) }
+    end
+
+    context "when plan visibility is not test" do
+      let!(:p1)  { create(:plan, :creator, :publicly_visible) }
+      let!(:p2)  { create(:plan, :creator, :privately_visible) }
+      let!(:p3)  { create(:plan, :creator, :organisationally_visible) }
+
+      it { is_expected.to include(p1) }
+      it { is_expected.to include(p2) }
+      it { is_expected.to include(p3) }
+    end
+
+  end
+
   describe "#answer" do
 
     let!(:plan) { create(:plan, :creator, answers: 1) }

--- a/spec/services/org/create_created_plan_service_spec.rb
+++ b/spec/services/org/create_created_plan_service_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Org::CreateCreatedPlanService do
 
   def find_by_dates(dates:, org_id:)
     dates.map do |date|
-      StatCreatedPlan.find_by(date: date, org_id: org_id)
+      StatCreatedPlan.find_by(date: date, org_id: org_id, filtered: false)
     end
   end
 
@@ -118,7 +118,7 @@ RSpec.describe Org::CreateCreatedPlanService do
       it "monthly records are either created or updated" do
         described_class.call(org)
 
-        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org, filtered: true)
         expect(april).to have(1).items
         expect(april.first.count).to eq(2)
 
@@ -129,7 +129,7 @@ RSpec.describe Org::CreateCreatedPlanService do
 
         described_class.call(org)
 
-        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org, filtered: true)
         expect(april).to have(1).items
         expect(april.first.count).to eq(3)
       end
@@ -181,7 +181,7 @@ RSpec.describe Org::CreateCreatedPlanService do
 
         described_class.call
 
-        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org, filtered: true)
         expect(april).to have(1).items
         expect(april.first.count).to eq(2)
 
@@ -192,7 +192,7 @@ RSpec.describe Org::CreateCreatedPlanService do
 
         described_class.call
 
-        april = StatCreatedPlan.where(date: "2018-04-30", org: org)
+        april = StatCreatedPlan.where(date: "2018-04-30", org: org, filtered: true)
         expect(april).to have(1).items
         expect(april.first.count).to eq(3)
       end

--- a/spec/services/org/create_last_month_created_plan_service_spec.rb
+++ b/spec/services/org/create_last_month_created_plan_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month_count = StatCreatedPlan.find_by(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id).count
+          org_id: org.id, filtered: false).count
         expect(last_month_count).to eq(3)
       end
 
@@ -62,7 +62,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month_details = StatCreatedPlan.find_by(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id).by_template
+          org_id: org.id, filtered: false).by_template
 
         expect(last_month_details).to match_array(
           [
@@ -72,12 +72,12 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
         )
       end
 
-      it "generates counts by template from today's last month" do
+      it "generates counts using template from today's last month" do
         described_class.call(org)
 
         last_month_details = StatCreatedPlan.find_by(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id).using_template
+          org_id: org.id, filtered: false).using_template
 
         expect(last_month_details).to match_array(
           [
@@ -92,7 +92,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month = StatCreatedPlan.where(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id)
+          org_id: org.id, filtered: false)
 
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(3)
@@ -106,7 +106,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month = StatCreatedPlan.where(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id)
+          org_id: org.id, filtered: false)
 
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(4)
@@ -121,7 +121,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month_count = StatCreatedPlan.find_by(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id).count
+          org_id: org.id, filtered: false).count
 
         expect(last_month_count).to eq(3)
       end
@@ -133,7 +133,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month_details = StatCreatedPlan.find_by(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id).by_template
+          org_id: org.id, filtered: false).by_template
 
         expect(last_month_details).to match_array(
           [
@@ -150,7 +150,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month_details = StatCreatedPlan.find_by(
           date: Date.today.last_month.end_of_month,
-          org_id: org.id).using_template
+          org_id: org.id, filtered: false).using_template
 
         expect(last_month_details).to match_array(
           [
@@ -167,7 +167,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
 
         last_month = StatCreatedPlan.where(
           date: Date.today.last_month.end_of_month,
-          org: org)
+          org: org, filtered: false)
 
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(3)
@@ -180,7 +180,7 @@ RSpec.describe Org::CreateLastMonthCreatedPlanService do
         described_class.call
 
         last_month = StatCreatedPlan.where(date: Date.today.last_month.end_of_month,
-                                           org: org)
+                                           org: org, filtered: false)
         expect(last_month).to have(1).items
         expect(last_month.first.count).to eq(4)
       end


### PR DESCRIPTION
Adds a `filtered` boolean to all `Stat` objects, defaulting to false.
Adds a `stats_filter` scope to `Plan` to define the filter logic
Extends each service to generate both a filtered and unfiltered stat for each month
Adds a `excluding test plans` checkbox to the usage-stats page to toggle the filtered and unfiltered stats.
Propogates the `filtered` status of the usage-dashboard through to all downloads on that page.