### PR TITLE
Add check for existence of recaptcha flag

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -87,7 +87,9 @@ class RegistrationsController < Devise::RegistrationsController
 
       build_resource(attrs)
 
-      if verify_recaptcha(model: resource) && resource.save
+      # Determine if reCAPTCHA is enabled and if so verify it
+      use_recaptcha = Rails.configuration.branding[:application][:use_recaptcha] || false
+      if (!use_recaptcha || verify_recaptcha(model: resource)) && resource.save
         if resource.active_for_authentication?
           set_flash_message :notice, :signed_up if is_navigational_format?
           sign_up(resource_name, resource)


### PR DESCRIPTION
Discovered that a user is unable to create an account if recaptcha is not enabled. This small tweak will allow for the value to be false or undefined.
