### PR TITLE
Fix the stats migration to add filtered; re-commit schema (lots of ch…

### DIFF
--- a/db/migrate/20200601121822_add_filtered_to_stats.rb
+++ b/db/migrate/20200601121822_add_filtered_to_stats.rb
@@ -1,4 +1,4 @@
-class AddFilteredToStats < ActiveRecord::Migration
+class AddFilteredToStats < ActiveRecord::Migration[4.2]
   def change
     add_column :stats, :filtered, :boolean, default: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "versionable_id", limit: 36
-    t.index ["org_id"], name: "fk_rails_aca7521f72"
     t.index ["question_id"], name: "index_annotations_on_question_id"
     t.index ["versionable_id"], name: "index_annotations_on_versionable_id"
   end
@@ -36,12 +35,8 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "lock_version", default: 0
-    t.string "label_id"
-    t.index ["plan_id"], name: "fk_rails_84a6005a3e"
     t.index ["plan_id"], name: "index_answers_on_plan_id"
-    t.index ["question_id"], name: "fk_rails_3d5ed4418f"
     t.index ["question_id"], name: "index_answers_on_question_id"
-    t.index ["user_id"], name: "fk_rails_584be190c2"
   end
 
   create_table "answers_question_options", id: false, force: :cascade do |t|
@@ -134,8 +129,8 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.boolean "active"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "logo_url"
-    t.string "identifier_prefix"
+    t.text "logo_url"
+    t.text "identifier_prefix"
     t.integer "context"
   end
 
@@ -168,7 +163,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["answer_id"], name: "index_notes_on_answer_id"
-    t.index ["user_id"], name: "fk_rails_7f2323ad43"
   end
 
   create_table "notification_acknowledgements", id: :serial, force: :cascade do |t|
@@ -195,13 +189,11 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
 
   create_table "org_identifiers", id: :serial, force: :cascade do |t|
     t.string "identifier"
-    t.integer "identifier_scheme_id"
     t.string "attrs"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "org_id"
-    t.index ["identifier_scheme_id"], name: "fk_rails_189ad2e573"
-    t.index ["org_id"], name: "fk_rails_36323c0674"
+    t.integer "identifier_scheme_id"
   end
 
   create_table "org_token_permissions", id: :serial, force: :cascade do |t|
@@ -210,7 +202,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["org_id"], name: "index_org_token_permissions_on_org_id"
-    t.index ["token_permission_type_id"], name: "fk_rails_2aa265f538"
   end
 
   create_table "orgs", id: :serial, force: :cascade do |t|
@@ -228,13 +219,11 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.string "contact_email"
     t.integer "org_type", default: 0, null: false
     t.text "links"
+    t.string "contact_name"
     t.boolean "feedback_enabled", default: false
     t.string "feedback_email_subject"
     t.text "feedback_email_msg"
-    t.string "contact_name"
     t.boolean "managed", default: false, null: false
-    t.index ["language_id"], name: "fk_rails_5640112cab"
-    t.index ["region_id"], name: "fk_rails_5a6adf6bab"
   end
 
   create_table "perms", id: :serial, force: :cascade do |t|
@@ -281,7 +270,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "start_date"
     t.datetime "end_date"
     t.integer "api_client_id"
-    t.index ["org_id"], name: "fk_rails_eda8ce4bca"
     t.index ["template_id"], name: "index_plans_on_template_id"
   end
 
@@ -289,22 +277,11 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.integer "guidance_group_id"
     t.integer "plan_id"
     t.index ["guidance_group_id", "plan_id"], name: "index_plans_guidance_groups_on_guidance_group_id_and_plan_id"
-    t.index ["guidance_group_id"], name: "fk_rails_ec1c5524d7"
-    t.index ["plan_id"], name: "fk_rails_13d0671430"
   end
 
   create_table "prefs", id: :serial, force: :cascade do |t|
     t.text "settings"
     t.integer "user_id"
-  end
-
-  create_table "question_format_labels", id: false, force: :cascade do |t|
-    t.integer "id"
-    t.string "description"
-    t.integer "question_id"
-    t.integer "number"
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
   create_table "question_formats", id: :serial, force: :cascade do |t|
@@ -339,7 +316,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.boolean "option_comment_display", default: true
     t.boolean "modifiable"
     t.string "versionable_id", limit: 36
-    t.index ["question_format_id"], name: "fk_rails_4fbc38c8c7"
     t.index ["section_id"], name: "index_questions_on_section_id"
     t.index ["versionable_id"], name: "index_questions_on_versionable_id"
   end
@@ -391,10 +367,10 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
   end
 
   create_table "settings", id: :serial, force: :cascade do |t|
-    t.string "var"
+    t.string "var", null: false
     t.text "value"
     t.integer "target_id", null: false
-    t.string "target_type"
+    t.string "target_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -467,7 +443,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "updated_at"
     t.integer "user_id"
     t.integer "identifier_scheme_id"
-    t.index ["identifier_scheme_id"], name: "fk_rails_fe95df7db0"
     t.index ["user_id"], name: "index_user_identifiers_on_user_id"
   end
 
@@ -477,7 +452,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.string "email", limit: 80, default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "encrypted_password"
+    t.string "encrypted_password", default: ""
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -501,27 +476,26 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.string "invited_by_type"
     t.integer "language_id"
     t.string "recovery_email"
-    t.string "ldap_password"
-    t.string "ldap_username"
     t.boolean "active", default: true
     t.integer "department_id"
     t.datetime "last_api_access"
-    t.index ["department_id"], name: "fk_rails_f29bf9cdf2"
-    t.index ["email"], name: "index_users_on_email"
-    t.index ["language_id"], name: "fk_rails_45f4f12508"
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["org_id"], name: "index_users_on_org_id"
   end
 
   create_table "users_perms", id: false, force: :cascade do |t|
     t.integer "user_id"
     t.integer "perm_id"
-    t.index ["perm_id"], name: "fk_rails_457217c31c"
     t.index ["user_id"], name: "index_users_perms_on_user_id"
   end
 
+  add_foreign_key "annotations", "orgs"
+  add_foreign_key "annotations", "questions"
   add_foreign_key "answers", "plans"
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "users"
+  add_foreign_key "answers_question_options", "answers"
+  add_foreign_key "answers_question_options", "question_options"
   add_foreign_key "conditions", "questions"
   add_foreign_key "guidance_groups", "orgs"
   add_foreign_key "guidances", "guidance_groups"
@@ -543,6 +517,8 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
   add_foreign_key "question_options", "questions"
   add_foreign_key "questions", "question_formats"
   add_foreign_key "questions", "sections"
+  add_foreign_key "questions_themes", "questions"
+  add_foreign_key "questions_themes", "themes"
   add_foreign_key "roles", "plans"
   add_foreign_key "roles", "users"
   add_foreign_key "sections", "phases"
@@ -555,4 +531,6 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
   add_foreign_key "users", "departments"
   add_foreign_key "users", "languages"
   add_foreign_key "users", "orgs"
+  add_foreign_key "users_perms", "perms"
+  add_foreign_key "users_perms", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "annotations", id: :integer, force: :cascade do |t|
+  create_table "annotations", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.integer "org_id"
     t.text "text"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["versionable_id"], name: "index_annotations_on_versionable_id"
   end
 
-  create_table "answers", id: :integer, force: :cascade do |t|
+  create_table "answers", id: :serial, force: :cascade do |t|
     t.text "text"
     t.integer "plan_id"
     t.integer "user_id"
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["answer_id"], name: "index_answers_question_options_on_answer_id"
   end
 
-  create_table "api_clients", id: :integer, force: :cascade do |t|
+  create_table "api_clients", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "description"
     t.string "homepage"
@@ -64,25 +64,25 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["name"], name: "index_api_clients_on_name"
   end
 
-  create_table "conditions", id: :integer, force: :cascade do |t|
-    t.integer  "question_id"
-    t.text     "option_list"
-    t.integer  "action_type"
-    t.integer  "number"
-    t.text     "remove_data"
-    t.text     "webhook_data"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+  create_table "conditions", id: :serial, force: :cascade do |t|
+    t.integer "question_id"
+    t.text "option_list"
+    t.integer "action_type"
+    t.integer "number"
+    t.text "remove_data"
+    t.text "webhook_data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["question_id"], name: "index_conditions_on_question_id"
   end
 
-  create_table "contributors", id: :integer, force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
-    t.string   "phone"
-    t.integer  "roles",      null: false
-    t.integer  "org_id"
-    t.integer  "plan_id",    null: false
+  create_table "contributors", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "email"
+    t.string "phone"
+    t.integer "roles", null: false
+    t.integer "org_id"
+    t.integer "plan_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["email"], name: "index_contributors_on_email"
@@ -91,16 +91,16 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["roles"], name: "index_contributors_on_roles"
   end
 
-  create_table "departments", id: :integer, force: :cascade do |t|
-    t.string   "name"
-    t.string   "code"
-    t.integer  "org_id"
+  create_table "departments", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "code"
+    t.integer "org_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["org_id"], name: "index_departments_on_org_id"
   end
 
-  create_table "exported_plans", id: :integer, force: :cascade do |t|
+  create_table "exported_plans", id: :serial, force: :cascade do |t|
     t.integer "plan_id"
     t.integer "user_id"
     t.string "format"
@@ -109,7 +109,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.integer "phase_id"
   end
 
-  create_table "guidance_groups", id: :integer, force: :cascade do |t|
+  create_table "guidance_groups", id: :serial, force: :cascade do |t|
     t.string "name"
     t.integer "org_id"
     t.datetime "created_at", null: false
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["org_id"], name: "index_guidance_groups_on_org_id"
   end
 
-  create_table "guidances", id: :integer, force: :cascade do |t|
+  create_table "guidances", id: :serial, force: :cascade do |t|
     t.text "text"
     t.integer "guidance_group_id"
     t.datetime "created_at", null: false
@@ -128,23 +128,23 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["guidance_group_id"], name: "index_guidances_on_guidance_group_id"
   end
 
-  create_table "identifier_schemes", id: :integer, force: :cascade do |t|
+  create_table "identifier_schemes", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "description"
     t.boolean "active"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "logo_url"
-    t.text     "identifier_prefix"
-    t.integer  "context"
+    t.string "logo_url"
+    t.string "identifier_prefix"
+    t.integer "context"
   end
 
-  create_table "identifiers", id: :integer, force: :cascade do |t|
-    t.string   "value",                null: false
-    t.text     "attrs"
-    t.integer  "identifier_scheme_id"
-    t.integer  "identifiable_id"
-    t.string   "identifiable_type"
+  create_table "identifiers", id: :serial, force: :cascade do |t|
+    t.string "value", null: false
+    t.text "attrs"
+    t.integer "identifier_scheme_id"
+    t.integer "identifiable_id"
+    t.string "identifiable_type"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["identifiable_type", "identifiable_id"], name: "index_identifiers_on_identifiable_type_and_identifiable_id"
@@ -152,14 +152,14 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["identifier_scheme_id", "value"], name: "index_identifiers_on_identifier_scheme_id_and_value"
   end
 
-  create_table "languages", id: :integer, force: :cascade do |t|
-    t.string  "abbreviation"
-    t.string  "description"
-    t.string  "name"
+  create_table "languages", id: :serial, force: :cascade do |t|
+    t.string "abbreviation"
+    t.string "description"
+    t.string "name"
     t.boolean "default_language"
   end
 
-  create_table "notes", id: :integer, force: :cascade do |t|
+  create_table "notes", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.text "text"
     t.boolean "archived", default: false, null: false
@@ -171,7 +171,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["user_id"], name: "fk_rails_7f2323ad43"
   end
 
-  create_table "notification_acknowledgements", id: :integer, force: :cascade do |t|
+  create_table "notification_acknowledgements", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "notification_id"
     t.datetime "created_at"
@@ -180,7 +180,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["user_id"], name: "index_notification_acknowledgements_on_user_id"
   end
 
-  create_table "notifications", id: :integer, force: :cascade do |t|
+  create_table "notifications", id: :serial, force: :cascade do |t|
     t.integer "notification_type"
     t.string "title"
     t.integer "level"
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.boolean "enabled", default: true
   end
 
-  create_table "org_identifiers", id: :integer, force: :cascade do |t|
+  create_table "org_identifiers", id: :serial, force: :cascade do |t|
     t.string "identifier"
     t.integer "identifier_scheme_id"
     t.string "attrs"
@@ -204,7 +204,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["org_id"], name: "fk_rails_36323c0674"
   end
 
-  create_table "org_token_permissions", id: :integer, force: :cascade do |t|
+  create_table "org_token_permissions", id: :serial, force: :cascade do |t|
     t.integer "org_id"
     t.integer "token_permission_type_id"
     t.datetime "created_at"
@@ -213,35 +213,37 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["token_permission_type_id"], name: "fk_rails_2aa265f538"
   end
 
-  create_table "orgs", id: :integer, force: :cascade do |t|
-    t.string   "name"
-    t.string   "abbreviation"
-    t.string   "target_url"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.boolean  "is_other",               default: false, null: false
-    t.string   "sort_name"
-    t.integer  "region_id"
-    t.integer  "language_id"
-    t.string   "logo_uid"
-    t.string   "logo_name"
-    t.string   "contact_email"
-    t.integer  "org_type",               default: 0,     null: false
-    t.text     "links"
-    t.string   "contact_name"
-    t.boolean  "feedback_enabled",       default: false
-    t.string   "feedback_email_subject"
-    t.text     "feedback_email_msg"
-    t.boolean  "managed",                default: false, null: false
+  create_table "orgs", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "abbreviation"
+    t.string "target_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "is_other", default: false, null: false
+    t.string "sort_name"
+    t.integer "region_id"
+    t.integer "language_id"
+    t.string "logo_uid"
+    t.string "logo_name"
+    t.string "contact_email"
+    t.integer "org_type", default: 0, null: false
+    t.text "links"
+    t.boolean "feedback_enabled", default: false
+    t.string "feedback_email_subject"
+    t.text "feedback_email_msg"
+    t.string "contact_name"
+    t.boolean "managed", default: false, null: false
+    t.index ["language_id"], name: "fk_rails_5640112cab"
+    t.index ["region_id"], name: "fk_rails_5a6adf6bab"
   end
 
-  create_table "perms", id: :integer, force: :cascade do |t|
-    t.string   "name"
+  create_table "perms", id: :serial, force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "phases", id: :integer, force: :cascade do |t|
+  create_table "phases", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.integer "number"
@@ -254,35 +256,36 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["versionable_id"], name: "index_phases_on_versionable_id"
   end
 
-  create_table "plans", id: :integer, force: :cascade do |t|
+  create_table "plans", id: :serial, force: :cascade do |t|
     t.string "title"
     t.integer "template_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "grant_number"
-    t.string   "identifier"
-    t.text     "description"
-    t.string   "principal_investigator"
-    t.string   "principal_investigator_identifier"
-    t.string   "data_contact"
-    t.string   "funder_name"
-    t.integer  "visibility",                        default: 3,     null: false
-    t.string   "data_contact_email"
-    t.string   "data_contact_phone"
-    t.string   "principal_investigator_email"
-    t.string   "principal_investigator_phone"
-    t.boolean  "feedback_requested",                default: false
-    t.boolean  "complete",                          default: false
-    t.integer  "org_id"
-    t.integer  "funder_id"
-    t.integer  "grant_id"
+    t.string "grant_number"
+    t.string "identifier"
+    t.text "description"
+    t.string "principal_investigator"
+    t.string "principal_investigator_identifier"
+    t.string "data_contact"
+    t.string "funder_name"
+    t.integer "visibility", default: 3, null: false
+    t.string "data_contact_email"
+    t.string "data_contact_phone"
+    t.string "principal_investigator_email"
+    t.string "principal_investigator_phone"
+    t.boolean "feedback_requested", default: false
+    t.boolean "complete", default: false
+    t.integer "org_id"
+    t.integer "funder_id"
+    t.integer "grant_id"
     t.datetime "start_date"
     t.datetime "end_date"
-    t.integer  "api_client_id"
+    t.integer "api_client_id"
+    t.index ["org_id"], name: "fk_rails_eda8ce4bca"
     t.index ["template_id"], name: "index_plans_on_template_id"
   end
 
-  create_table "plans_guidance_groups", id: :integer, force: :cascade do |t|
+  create_table "plans_guidance_groups", id: :serial, force: :cascade do |t|
     t.integer "guidance_group_id"
     t.integer "plan_id"
     t.index ["guidance_group_id", "plan_id"], name: "index_plans_guidance_groups_on_guidance_group_id_and_plan_id"
@@ -290,7 +293,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["plan_id"], name: "fk_rails_13d0671430"
   end
 
-  create_table "prefs", id: :integer, force: :cascade do |t|
+  create_table "prefs", id: :serial, force: :cascade do |t|
     t.text "settings"
     t.integer "user_id"
   end
@@ -304,7 +307,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "updated_at"
   end
 
-  create_table "question_formats", id: :integer, force: :cascade do |t|
+  create_table "question_formats", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -313,7 +316,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.integer "formattype", default: 0
   end
 
-  create_table "question_options", id: :integer, force: :cascade do |t|
+  create_table "question_options", id: :serial, force: :cascade do |t|
     t.integer "question_id"
     t.string "text"
     t.integer "number"
@@ -325,7 +328,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["versionable_id"], name: "index_question_options_on_versionable_id"
   end
 
-  create_table "questions", id: :integer, force: :cascade do |t|
+  create_table "questions", id: :serial, force: :cascade do |t|
     t.text "text"
     t.text "default_value"
     t.integer "number"
@@ -347,14 +350,14 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["question_id"], name: "index_questions_themes_on_question_id"
   end
 
-  create_table "regions", id: :integer, force: :cascade do |t|
+  create_table "regions", id: :serial, force: :cascade do |t|
     t.string "abbreviation"
     t.string "description"
     t.string "name"
     t.integer "super_region_id"
   end
 
-  create_table "roles", id: :integer, force: :cascade do |t|
+  create_table "roles", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "plan_id"
     t.datetime "created_at"
@@ -365,7 +368,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["user_id"], name: "index_roles_on_user_id"
   end
 
-  create_table "sections", id: :integer, force: :cascade do |t|
+  create_table "sections", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.integer "number"
@@ -378,7 +381,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["versionable_id"], name: "index_sections_on_versionable_id"
   end
 
-  create_table "sessions", id: :integer, force: :cascade do |t|
+  create_table "sessions", id: :serial, force: :cascade do |t|
     t.string "session_id", limit: 64, null: false
     t.text "data"
     t.datetime "created_at"
@@ -387,7 +390,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
-  create_table "settings", id: :integer, force: :cascade do |t|
+  create_table "settings", id: :serial, force: :cascade do |t|
     t.string "var"
     t.text "value"
     t.integer "target_id", null: false
@@ -396,18 +399,18 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "stats", id: :integer, force: :cascade do |t|
-    t.integer  "count",      limit: 8, default: 0
-    t.date     "date",                                 null: false
-    t.string   "type",                                 null: false
-    t.integer  "org_id"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
-    t.text     "details"
-    t.boolean  "filtered",             default: false
+  create_table "stats", id: :serial, force: :cascade do |t|
+    t.bigint "count", default: 0
+    t.date "date", null: false
+    t.string "type", null: false
+    t.integer "org_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "details"
+    t.boolean "filtered", default: false
   end
 
-  create_table "templates", id: :integer, force: :cascade do |t|
+  create_table "templates", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.boolean "published"
@@ -428,7 +431,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["org_id"], name: "index_templates_on_org_id"
   end
 
-  create_table "themes", id: :integer, force: :cascade do |t|
+  create_table "themes", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
@@ -443,23 +446,23 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["theme_id"], name: "index_themes_in_guidance_on_theme_id"
   end
 
-  create_table "token_permission_types", id: :integer, force: :cascade do |t|
+  create_table "token_permission_types", id: :serial, force: :cascade do |t|
     t.string "token_type"
     t.text "text_description"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "trackers", id: :integer, force: :cascade do |t|
-    t.integer  "org_id"
-    t.string   "code"
+  create_table "trackers", id: :serial, force: :cascade do |t|
+    t.integer "org_id"
+    t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["org_id"], name: "index_trackers_on_org_id"
   end
 
-  create_table "user_identifiers", id: :integer, force: :cascade do |t|
-    t.string   "identifier"
+  create_table "user_identifiers", id: :serial, force: :cascade do |t|
+    t.string "identifier"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "user_id"
@@ -468,7 +471,7 @@ ActiveRecord::Schema.define(version: 2020_06_01_121822) do
     t.index ["user_id"], name: "index_user_identifiers_on_user_id"
   end
 
-  create_table "users", id: :integer, force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "firstname"
     t.string "surname"
     t.string "email", limit: 80, default: "", null: false


### PR DESCRIPTION
After pulling in the development db changes, my environment was complaining about the migration missing it's version tag.  
Additionally re-committed schema.rb 

I've noticed that it's changing the ID from `integer` to `serial` which appears to be a difference in rails-version migrations:
https://stackoverflow.com/a/54694863
