### PR TITLE
fix issue with kaminari pagination

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -10,16 +10,16 @@
   <nav class="pagination" style="margin: 0;">
     <%= first_page_tag unless current_page.first? %>
     <%= prev_page_tag unless current_page.first? %>
-    <%# each_page do |page| %>
-      <%# if page.display_tag? %>
-        <%#= page_tag page %>
-      <%# elsif !page.was_truncated? %>
-        <%#= gap_tag %>
-      <%# end %>
-    <%# end %>
-    <%# unless current_page.out_of_range? %>
-      <%#= next_page_tag unless current_page.last? %>
-      <%#= last_page_tag unless current_page.last? %>
-    <%# end %>
+    <% each_page do |page| %>
+      <% if page.display_tag? %>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? %>
+        <%= gap_tag %>
+      <% end %>
+    <% end %>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
   </nav>
 <% end -%>

--- a/app/views/layouts/_paginable.html.erb
+++ b/app/views/layouts/_paginable.html.erb
@@ -52,7 +52,7 @@
         </div>
         <div class="pull-right">
           <% if paginable? %>
-              <%= paginate(scope, params: @paginable_params, remote: true) %>
+              <%= paginate(scope, params: paginable_params, remote: true) %>
           <% end %>
         </div>
         <div class="clearfix"></div>


### PR DESCRIPTION
Fixes #2464 

Looks like the refactor of strong params requires us to call the helper method rather than an instance variable when passing in the pagination options