### PR TITLE
workaround for fastgettext load errors

### DIFF
--- a/app/models/concerns/validation_messages.rb
+++ b/app/models/concerns/validation_messages.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module ValidationMessages
+  # workaround for errors thrown by puma when eager loading application
+  FastGettext.add_text_domain "app", path: "config/locale", type: :po, ignore_fuzzy: true, report_warning: true
+  FastGettext.text_domain = 'app'
 
   PRESENCE_MESSAGE = _("can't be blank")
 


### PR DESCRIPTION
Fixes #2574 

The fast_gettext initialize does not run until after_initialize so that the DB and ActiveRecord are available, but a domain must be created and set before we can call translations methods.

This fixes the issue for now, but I'd like to start work on updating the translations.io PR to address this better, along with #2496 to rebuild the locales-files