### PR TITLE
Upgrade to Fontawesome 5 and cleanup of remaining tests

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -101,5 +101,4 @@ jobs:
 
     # Only run Integration tests if the PR or Push is to master or development branches
     - name: 'Run Rspec Integration Tests'
-      if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/development'
       run: bin/bundle exec rspec spec/features/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   flag_shih_tzu
-  font-awesome-sass
+  font-awesome-sass (~> 5.13.0)
   fuubar
   gettext
   gettext_i18n_rails

--- a/app/assets/stylesheets/blocks/_font_awesomes.scss
+++ b/app/assets/stylesheets/blocks/_font_awesomes.scss
@@ -1,8 +1,8 @@
 // Override FontAwesome icons
 
 /* FONTAWESOME STYLING */
-.fa:not(.small) {
-  font-size: 2rem;
+.fas:not(.small) {
+  font-size: 1.7rem;
 }
 .fa-reverse {
   color: $color-seccondary-text;
@@ -25,15 +25,15 @@
    fa-file-pdf-o and fa-file-word-o */
 a {
    i {
-     &.fa {
+     &.fas {
 
-       &.fa-file-pdf-o,
-       &.fa-file-word-o {
+       &.fa-file-pdf,
+       &.fa-file-word {
          color: $color-fa;
          margin: 5px;
 
          &:not(.small) {
-           font-size: 2.3em;
+           font-size: 1.9em;
          }
        }
      }

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -152,7 +152,7 @@ module Paginable
     class_name = "fa-sort"
     class_name = "fa-sort-#{sort_direction.downcase}" if @args[:sort_field] == sort_field
     <<~HTML.html_safe
-      <i class="fa #{class_name}"
+      <i class="fas #{class_name}"
          aria-hidden="true"
          style="float: right; font-size: 1.2em;">
 

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -186,7 +186,9 @@ module Paginable
     @args.except(*PAGINATION_QUERY_PARAMS).to_param
   end
 
-  def stringify_query_params(_page: 1, search: @args[:search],
+  # TODO: We would be better served here passing these arguments as a Ruby double splat
+  # rubocop:disable Lint/UnusedMethodArgument
+  def stringify_query_params(page: 1, search: @args[:search],
                              sort_field: @args[:sort_field],
                              sort_direction: nil)
 
@@ -198,6 +200,7 @@ module Paginable
     end
     query_string.to_param
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   def paginable_params
     params.permit(PAGINATION_QUERY_PARAMS)

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -30,6 +30,7 @@ class ContributorsController < ApplicationController
   # POST /plans/:plan_id/contributors
   def create
     authorize @plan
+
     args = translate_roles(hash: contributor_params)
     args = process_org(hash: args)
     args = process_orcid_for_create(hash: args)

--- a/app/controllers/org_admin/sections_controller.rb
+++ b/app/controllers/org_admin/sections_controller.rb
@@ -36,7 +36,8 @@ module OrgAdmin
       @section = Section.includes(questions: %i[annotations question_options])
                         .find(params[:id])
       @template = Template.find(params[:template_id])
-      render partial: "show", locals: { template: @template, section: @section }
+      render json: { html: render_to_string(partial: "show",
+                                            locals: { template: @template, section: @section }) }
     end
 
     # GET /org_admin/templates/[:template_id]/phases/[:phase_id]/sections/[:id]/edit

--- a/app/helpers/customizable_template_link_helper.rb
+++ b/app/helpers/customizable_template_link_helper.rb
@@ -7,8 +7,6 @@ module CustomizableTemplateLinkHelper
   def link_to_customizable_template(name, customization, template)
     name = nil unless name.present?
 
-p "NAME: #{name}, CUST: #{customization}, TMPLT: #{template}"
-
     if customization.present?
       if customization.created_at < template.created_at
         name = name.blank? ? _("Transfer customisation") : name

--- a/app/helpers/customizable_template_link_helper.rb
+++ b/app/helpers/customizable_template_link_helper.rb
@@ -7,6 +7,8 @@ module CustomizableTemplateLinkHelper
   def link_to_customizable_template(name, customization, template)
     name = nil unless name.present?
 
+p "NAME: #{name}, CUST: #{customization}, TMPLT: #{template}"
+
     if customization.present?
       if customization.created_at < template.created_at
         name = name.blank? ? _("Transfer customisation") : name

--- a/app/helpers/template_helper.rb
+++ b/app/helpers/template_helper.rb
@@ -46,7 +46,7 @@ module TemplateHelper
     link_to(plans_url(plan: params), method: :post, title: _("Create plan"),
                                      class: cls, id: id, style: style) do
       if text.nil?
-        "<span class=\"fa fa-plus-square\"></span>".html_safe
+        "<span class=\"fas fa-plus-square\"></span>".html_safe
       else
         text.html_safe
       end

--- a/app/javascript/src/answers/rdaMetadata.js
+++ b/app/javascript/src/answers/rdaMetadata.js
@@ -129,9 +129,9 @@ $(() => {
       Object.keys(standardsArray).forEach((key) => {
         // add the standard to list
         if (key === standardsArray[key]) {
-          selectedStandards.append(`<li class="${key}">${key}<button class="remove-standard"><i class="fa fa-times-circle"></i></button></li`);
+          selectedStandards.append(`<li class="${key}">${key}<button class="remove-standard"><i class="fas fa-times-circle"></i></button></li`);
         } else {
-          selectedStandards.append(`<li class="${key}">${descriptions[key].title}<button class="remove-standard"><i class="fa fa-times-circle"></i></button></li>`);
+          selectedStandards.append(`<li class="${key}">${descriptions[key].title}<button class="remove-standard"><i class="fas fa-times-circle"></i></button></li>`);
         }
       });
     });
@@ -240,7 +240,7 @@ $(() => {
         standard = standardId;
       }
     });
-    selectedStandards.append(`<li class="${standard}">${descriptions[standard].title}<button class="remove-standard"><i class="fa fa-times-circle"></i></button></li>`);
+    selectedStandards.append(`<li class="${standard}">${descriptions[standard].title}<button class="remove-standard"><i class="fas fa-times-circle"></i></button></li>`);
     const formStandards = group.next('form').find('#standards');
     // get the data for selected standards from the data attribute 'standard'
     // of the hidden field #standards within the answer form
@@ -271,7 +271,7 @@ $(() => {
     // the identifier for the standard which was selected
     const standard = target.data('standard');
     // append the standard to the displayed list of selected standards
-    selectedStandards.append(`<li class="${standard}">${descriptions[standard].title}<button class="remove-standard"><i class="fa fa-times-circle"></i></button></li>`);
+    selectedStandards.append(`<li class="${standard}">${descriptions[standard].title}<button class="remove-standard"><i class="fas fa-times-circle"></i></button></li>`);
     const formStandards = group.next('form').find('#standards');
     // get the data for selected standards from the data attribute 'standard'
     // of the hidden field #standards within the answer form
@@ -327,7 +327,7 @@ $(() => {
     const group = target.closest('.rda_metadata');
     const selectedStandards = group.find('.selected_standards .list');
     const standardName = group.find('.custom-standard-name').val();
-    selectedStandards.append(`<li class="${standardName}">${standardName}<button class="remove-standard"><i class="fa fa-times-circle"></i></button></li>`);
+    selectedStandards.append(`<li class="${standardName}">${standardName}<button class="remove-standard"><i class="fas fa-times-circle"></i></button></li>`);
     const formStandards = group.next('form').find('#standards');
     // get the data for selected standards from the data attribute 'standard'
     // of the hidden field #standards within the answer form

--- a/app/javascript/src/orgAdmin/templates/edit.js
+++ b/app/javascript/src/orgAdmin/templates/edit.js
@@ -27,7 +27,8 @@ $(() => {
       $('#template-links').val(JSON.stringify(links));
     });
   });
-  $('.edit_template').on('ajax:success', (e, data) => {
+  $('.edit_template').on('ajax:success', (e) => {
+    const data = e.detail[0];
     if (isObject(data) && isString(data.msg)) {
       if (data.status === 200) {
         renderNotice(data.msg);
@@ -37,7 +38,8 @@ $(() => {
       scrollTo('#notification-area');
     }
   });
-  $('.edit_template').on('ajax:error', (e, xhr) => {
+  $('.edit_template').on('ajax:error', (e) => {
+    const xhr = e.detail[2];
     const error = xhr.responseJSON;
     if (isObject(error) && isString(error)) {
       renderAlert(error.msg);

--- a/app/javascript/src/orgAdmin/templates/index.js
+++ b/app/javascript/src/orgAdmin/templates/index.js
@@ -2,7 +2,8 @@ import { initAutocomplete } from '../../utils/autoComplete';
 
 $(() => {
   // Update the contents of the table when user clicks on a scope link
-  $('.template-scope').on('ajax:success', 'a[data-remote="true"]', (e, data) => {
+  $('.template-scope').on('ajax:success', 'a[data-remote="true"]', (e) => {
+    const data = e.detail[0];
     $(e.target).closest('.template-scope').find('.paginable').html(data);
   });
 

--- a/app/javascript/src/plans/index.js.erb
+++ b/app/javascript/src/plans/index.js.erb
@@ -5,7 +5,7 @@ import { paginableSelector } from '../utils/paginable';
 $(() => {
   $(paginableSelector).on('ajax:success', 'input.set_test_plan', (e) => {
     const checkbox = $(e.target);
-    const data = e.detail[0];
+    const data = e.detail[0]; 
     if (data.code === 1 && data.msg && data.msg !== '') {
       notifier.renderNotice(data.msg);
     } else {

--- a/app/javascript/src/utils/notificationHelper.js
+++ b/app/javascript/src/utils/notificationHelper.js
@@ -25,7 +25,7 @@ function renderMessage(options = {}) {
 
     notificationArea.find('i, span').remove();
     notificationArea.append(`
-      <i class="fa fa-${options.icon}" aria-hidden="true"></i>
+      <i class="fas fa-${options.icon}" aria-hidden="true"></i>
       <span>${options.message}</span>
     `);
 

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -59,7 +59,7 @@ class Template < ApplicationRecord
   attribute :is_default, :boolean, default: false
   attribute :version, :integer, default: 0
   attribute :customization_of, :integer, default: nil
-  attribute :family_id, :integer, default: -> { unique_random(field_name: "family_id") }
+  attribute :family_id, :integer, default: -> { Template.new_family_id }
   attribute :links, :text, default: { funder: [], sample_plan: [] }
   # TODO: re-add visibility setting? (this is handled in org_admin/create and
   # relies on the org_id in the current callback-form)
@@ -474,20 +474,24 @@ class Template < ApplicationRecord
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   # rubocop:enable
 
+  # TODO: refactor to use UniqueRandom
+  # Generate a new random family identifier
+  def self.new_family_id
+    family_id = loop do
+      random = rand 2_147_483_647
+      break random unless Template.exists?(family_id: random)
+    end
+    family_id
+  end
+
   private
 
   # ============================
   # = Private instance methods =
   # ============================
 
-  # TODO: refactor to use UniqueRandom
-  # Generate a new random family identifier
   def new_family_id
-    family_id = loop do
-      random = rand 2_147_483_647
-      break random unless Template.exists?(family_id: random)
-    end
-    family_id
+    Template.new_family_id
   end
 
   # Only one version of a template should be published at a time, so if this

--- a/app/views/devise/registrations/_external_identifier.html.erb
+++ b/app/views/devise/registrations/_external_identifier.html.erb
@@ -9,7 +9,7 @@
           <%= _("Create or connect your ORCID iD") %>
         <% end %>
     <% elsif scheme.name.downcase == 'shibboleth' %>
-        <i class="fa fa-user" title="<%= _('Institutional credentials') %>" aria-hidden="true"></i>
+        <i class="fas fa-user" title="<%= _('Institutional credentials') %>" aria-hidden="true"></i>
         &nbsp;
         <%= link_to _('Link your institutional credentials'),
                     Rails.application.routes.url_helpers.send("user_shibboleth_omniauth_authorize_path"),
@@ -37,7 +37,7 @@
         <% unlinktext = _("Unlink your account from your organisation. You can link again at any time.") %>
         <% unlinkconf = _("Are you sure you want to unlink your institutional credentials?") %>
         <% if scheme.identifier_prefix.nil? %>
-            <i class="fa fa-user" title="<%= _('Institutional credentials') %>" aria-hidden="true"></i>
+            <i class="fas fa-user" title="<%= _('Institutional credentials') %>" aria-hidden="true"></i>
             &nbsp;
             <%= titletext %>
         <% else %>
@@ -47,7 +47,7 @@
                         title: titletext,
                         'aria-label': titletext,
                         'data-toggle': "tooltip" do %>
-                <i class="fa fa-user" title="<%= scheme.description %>" aria-hidden="true"></i>
+                <i class="fas fa-user" title="<%= scheme.description %>" aria-hidden="true"></i>
                 &nbsp;
                 <%= titletext %>
             <% end %>
@@ -56,7 +56,7 @@
         <% titletext = _("Your account has been linked to #{scheme.description}.") %>
         <% if scheme.identifier_prefix.nil? %>
             <% if scheme.logo_url.nil? %>
-                <i class="fa fa-user" title="<%= scheme.description %>" aria-hidden="true"></i>
+                <i class="fas fa-user" title="<%= scheme.description %>" aria-hidden="true"></i>
             <% else %>
                 <%= image_tag "#{scheme.logo_url}", id: 'orcid-id-logo', alt: scheme.description %>
             <% end %>
@@ -70,7 +70,7 @@
                         'aria-label': titletext,
                         'data-toggle': "tooltip" do %>
                 <% if scheme.logo_url.nil? %>
-                    <i class="fa fa-user" title="<%= scheme.description %>" aria-hidden="true"></i>
+                    <i class="fas fa-user" title="<%= scheme.description %>" aria-hidden="true"></i>
                 <% else %>
                     <%= image_tag "#{scheme.logo_url}", id: 'orcid-id-logo', alt: scheme.description %>
                 <% end %>
@@ -81,7 +81,7 @@
         <% unlinktext = _("Unlink your account from #{scheme.description}. You can link again at any time.") %>
         <% unlinkconf = _("Are you sure you want to unlink #{scheme.description} ID?") %>
     <% end %>
-    <%= link_to '<i class="fa fa-fw fa-times-circle" aria-hidden="true"></i>'.html_safe,
+    <%= link_to '<i class="fas fa-fw fa-times-circle" aria-hidden="true"></i>'.html_safe,
                 destroy_user_identifier_path(id),
                 method: :delete,
                 title: unlinktext,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,7 +16,7 @@
                 application_name: ApplicationService.application_name} %>
             </p>
             <p class="text-center fontsize-h3 color-heading-text">
-              <i class="fa fa-arrow-circle-down" aria-hidden="true"></i>
+              <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
             </p>
             <h2 class="text-center">
                 <%= _("Sign in") %>
@@ -36,7 +36,7 @@
           </p>
 
           <p class="text-center">
-            <i class="fa fa-arrow-circle-down" aria-hidden="true"></i>
+            <i class="fas fa-arrow-circle-down" aria-hidden="true"></i>
           </p>
 
           <h2 class="text-center">
@@ -56,7 +56,7 @@
       <div>
         <h2>
           <%= _("Create account") %>&nbsp;&nbsp;
-          <i class="fa fa-user-plus" aria-hidden="true">&nbsp;&nbsp;</i>
+          <i class="fas fa-user-plus" aria-hidden="true">&nbsp;&nbsp;</i>
         </h2>
         <div id="create-account-form">
           <%= render partial: 'shared/create_account_form' %>

--- a/app/views/guidance_groups/_index_by_theme.html.erb
+++ b/app/views/guidance_groups/_index_by_theme.html.erb
@@ -28,7 +28,7 @@
             <div class="panel-heading" role="tab" id="<%= "panel-heading-#{question_guidance_id}" %>">
               <h2 class="panel-title">
                 <%= theme.title %>
-                <i class="fa fa-plus pull-right" aria-hidden="true"></i>
+                <i class="fas fa-plus pull-right" aria-hidden="true"></i>
               </h2>
             </div>
           </div>

--- a/app/views/guidance_groups/_show.html.erb
+++ b/app/views/guidance_groups/_show.html.erb
@@ -20,7 +20,7 @@
         <div class="panel-heading" role="tab" id="heading-<%= i %>">
           <h2 class="panel-title">
             <%= theme %>
-            <i class="fa fa-plus pull-right" aria-hidden="true"></i>
+            <i class="fas fa-plus pull-right" aria-hidden="true"></i>
           </h2>
         </div>
       </div>

--- a/app/views/layouts/_branding.html.erb
+++ b/app/views/layouts/_branding.html.erb
@@ -31,7 +31,7 @@
                 </li><li class="org-links">
               <% end %>
               <%= link_to link['link'], :target=>'_blank', :class => 'org-a has-new-window-popup-info' do %>
-                <i class="fa fa-globe" aria-hidden="true">&nbsp;</i>
+                <i class="fas fa-globe" aria-hidden="true">&nbsp;</i>
                 <%= link['text'].blank? ? link['link'] : link['text'] %>
                 <em class="sr-only"> (new window)</em>
                 <span class="new-window-popup-info"><%= _('Opens in new window') %></span>
@@ -43,7 +43,7 @@
           <% end %>
           <% if !current_user.org.contact_email.blank? %>
             <%= mail_to current_user.org.contact_email, :class => 'org-a' do %>
-              <i class="fa fa-envelope" aria-hidden="true">&nbsp;</i>
+              <i class="fas fa-envelope" aria-hidden="true">&nbsp;</i>
               <%= current_user.org.contact_name ? current_user.org.contact_name : current_user.org.contact_email %>
             <% end %>
           <% end %>
@@ -56,7 +56,7 @@
         <% if current_user.can_org_admin? %>
           <li class="dropdown navbar-default" id="admin-dropdown">
             <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" id="admin-menu" href="#">
-              <i class="fa fa-lock" aria-hidden="true">&nbsp;</i>
+              <i class="fas fa-lock" aria-hidden="true">&nbsp;</i>
               <%= _('Admin') %>
               <span class="caret"></span>
             </a>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -27,7 +27,7 @@
           </li>
             <li class="dropdown" id="reference-dropdown">
               <a href="#" class="dropdown-toggle" role="button" id="reference-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <i class="fa fa-book" aria-hidden="true">&nbsp;</i>
+                <i class="fas fa-book" aria-hidden="true">&nbsp;</i>
                 <%= _("Reference") %>
                 <span class="caret"></span>
               </a>

--- a/app/views/layouts/_notifications.html.erb
+++ b/app/views/layouts/_notifications.html.erb
@@ -1,12 +1,12 @@
 <% notifications.each do |a| %>
   <% unless a.acknowledged?(current_user) %>
     <div class="alert alert-<%= a.level %>">
-      <span class="fa <%= fa_classes(a) %>"></span>
+      <span class="fas <%= fa_classes(a) %>"></span>
       <span class="aria-only"><strong><%= "#{a.level.capitalize}:" %></strong></span>
       <span><%= sanitize a.body %></span>
       <% if a.dismissable? %>
         <button class="close" data-dismiss="alert" data-url="<%= user_acknowledge_notification_path(a) %>" data-remote="true" data-method="post" data-params="notification_id=<%= a.id %>" aria-label="Close">
-          <span class="fa fa-times-circle" aria-hidden="true"></span>
+          <span class="fas fa-times-circle" aria-hidden="true"></span>
         </button>
       <% end %>
     </div>

--- a/app/views/layouts/_signin_signout.html.erb
+++ b/app/views/layouts/_signin_signout.html.erb
@@ -2,7 +2,7 @@
 <% if Language.many? %>
   <li class="dropdown" id="change-language">
     <a href="#" class="dropdown-toggle" role="button" id="language-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <i class="fa fa-language" aria-hidden="true">&nbsp;</i>
+      <i class="fas fa-language" aria-hidden="true">&nbsp;</i>
       <%= _('Language') %>
       <span class="caret"></span>
     </a>
@@ -20,16 +20,16 @@
 <% if user_signed_in? %>
   <li class="dropdown" id="signin-signout">
     <a href="#" class="dropdown-toggle" role="button" id="user-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      <i class="fa fa-user" aria-hidden="true">&nbsp;</i>
+      <i class="fas fa-user" aria-hidden="true">&nbsp;</i>
       <%= current_user.name(false) %>
       <span class="caret"></span>
     </a>
     <ul class="dropdown-menu inverse-dropdown" aria-labelledby="user-menu">
       <li>
-        <%= link_to '<i class="fa fa-pencil-square-o" aria-hidden="true">&nbsp;</i>&nbsp;'.html_safe + _('Edit profile'), edit_user_registration_path %>
+        <%= link_to '<i class="fas fa-pencil-square" aria-hidden="true">&nbsp;</i>&nbsp;'.html_safe + _('Edit profile'), edit_user_registration_path %>
       </li>
       <li>
-        <%= link_to '<i class="fa fa-sign-in" aria-hidden="true">&nbsp;</i>&nbsp;'.html_safe + _('Logout'), destroy_user_session_path, method: :delete %>
+        <%= link_to '<i class="fas fa-sign-in" aria-hidden="true">&nbsp;</i>&nbsp;'.html_safe + _('Logout'), destroy_user_session_path, method: :delete %>
       </li>
     </ul>
   </li>
@@ -37,7 +37,7 @@
   <% if !active_page?(root_path, true) %>
     <li>
       <a href="#header-signin" data-toggle="modal" data-target="#header-signin">
-        <i class="fa fa-sign-in" aria-hidden="true">&nbsp;</i>
+        <i class="fas fa-sign-in" aria-hidden="true">&nbsp;</i>
         <%= _('Sign in') %>
       </a>
     </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -88,7 +88,7 @@
              class="notification-area alert <%= has_alert ? 'alert-warning ' : 'alert-info ' %>
                     <%= (has_alert or has_notice) ? 'show' : 'hide' %>"
              role="<%= (has_notice ? 'status' : (has_alert ? 'alert' : '')) %>">
-          <i class="fa <%= has_alert ? ' fa-times-circle' : ' fa-check-circle' %>" aria-hidden="true"></i>
+          <i class="fas <%= has_alert ? ' fa-times-circle' : ' fa-check-circle' %>" aria-hidden="true"></i>
           <span class="aria-only"><%= has_alert ? _('Error:') : _('Notice:') %></span>
           <span><%= sanitize (has_alert ? alert : notice) %></span>
           <%= yield :errors %>

--- a/app/views/org_admin/conditions/_webhook_form.html.erb
+++ b/app/views/org_admin/conditions/_webhook_form.html.erb
@@ -10,32 +10,32 @@
       </div>
       <div class="modal-body mx-3">
         <div class="md-form mb-5">
-          <i class="fa fa-user prefix grey-text"></i>
+          <i class="fas fa-user prefix grey-text"></i>
           <%= label_tag name_start + "[webhook-name]", _('Name'), {'data-error': 'wrong', 'data-success': 'right'} %>
           <%= text_field_tag name_start + "[webhook-name]", nil, class: 'form-control validate' %>
         </div>
 
         <div class="md-form mb-5">
-          <i class="fa fa-envelope prefix grey-text"></i> <!-- mdbootstrap should have treatment for bad input for this -->
+          <i class="fas fa-envelope prefix grey-text"></i> <!-- mdbootstrap should have treatment for bad input for this -->
           <%= label_tag name_start + "[webhook-email]", _('Email'), {'data-error': 'wrong', 'data-success': 'right'} %>
           <%= email_field_tag name_start + "[webhook-email]", nil, placeholder: _('recipient_email@example.com'), class: 'form-control validate' %>
         </div>
 
         <div class="md-form mb-5">
-          <i class="fa fa-tag prefix grey-text"></i>
+          <i class="fas fa-tag prefix grey-text"></i>
           <%= label_tag name_start + "[webhook-subject]", _('Subject'), {'data-error': 'wrong', 'data-success': 'right'} %>
           <%= text_field_tag name_start + "[webhook-subject]", nil, class: 'form-control validate' %>
         </div>
 
         <div class="md-form">
-          <i class="fa fa-pencil prefix grey-text"></i>
+          <i class="fas fa-pencil prefix grey-text"></i>
           <%= label_tag name_start + "[webhook-message]", _('Message'), {'data-error': 'wrong', 'data-success': 'right'} %>
           <%= text_area_tag name_start + "[webhook-message]", nil, placeholder: _('Email content'), class: 'form-control md-textarea', rows: 4 %>
         </div>
       </div>
       <div class="modal-footer d-flex justify-content-center">
-        <button class="btn btn-default discard" data-dismiss="modal"><%= _('Discard ') %><i class="fa fa-trash-o ml-1"></i></button>
-        <button class="btn btn-default" ><%= _('Save ') %><i class="fa fa-paper-plane-o ml-1"></i></button>
+        <button class="btn btn-default discard" data-dismiss="modal"><%= _('Discard ') %><i class="fas fa-trash-o ml-1"></i></button>
+        <button class="btn btn-default" ><%= _('Save ') %><i class="fas fa-paper-plane-o ml-1"></i></button>
       </div>
     </div>
   </div>

--- a/app/views/org_admin/phases/_index.html.erb
+++ b/app/views/org_admin/phases/_index.html.erb
@@ -25,13 +25,13 @@
                    href="#collapsePhase<%= phase.id %>"
                    aria-expanded="<%= i == 0 ? 'true' : 'false' %>"
                    aria-controls="#collapsePhase<%= phase.id %>">
-                   
+
                 <div class="panel-heading" role="tab" id="<%= "headingPhase#{phase.id}" %>">
                   <div class="panel-title pull-left">
                     <%= phase.title %>
                   </div>
                   <div class="pull-right">
-                    <i class="fa fa-plus pull-right" aria-hidden="true"></i>
+                    <i class="fas fa-plus pull-right" aria-hidden="true"></i>
                   </div>
                   <div class="clearfix"></div>
                 </div>

--- a/app/views/org_admin/phases/container.html.erb
+++ b/app/views/org_admin/phases/container.html.erb
@@ -58,7 +58,7 @@
                   <div class="col-sm-6">
                     <div class='text-right text-muted'>
                       <% if template.latest? && (modifiable || template.customization_of.present?) %>
-                        <i class="fa fa-info-circle small"></i>
+                        <i class="fas fa-info-circle small"></i>
                         <%= _("Drag arrows to rearrange sections.") %>
                         <% unless phase.sections.all?(&:modifiable?) %>
                           <%= _("You may place them before or after the main template sections.") %>

--- a/app/views/org_admin/questions/_show.html.erb
+++ b/app/views/org_admin/questions/_show.html.erb
@@ -135,7 +135,7 @@
                                         role="tab"
                                         id="#headingGuidance-<%= guidance.id%>-<%= question.id %>">
                               <div class="panel-title">
-                                  <i class="fa fa-plus pull-left" aria-hidden="true"></i>
+                                  <i class="fas fa-plus pull-left" aria-hidden="true"></i>
                                 &nbsp;<%= theme.title %>
                                 <% if ggs.length > 1 %>
                                   &nbsp;(<%= guidance_group.name %>)

--- a/app/views/org_admin/sections/_index.html.erb
+++ b/app/views/org_admin/sections/_index.html.erb
@@ -61,7 +61,7 @@
               <%= _('Add a new section') %>
             </div>
             <div class="pull-right">
-              <i class="fa fa-plus pull-right" aria-hidden="true"></i>
+              <i class="fas fa-plus pull-right" aria-hidden="true"></i>
             </div>
             <div class="clearfix"></div>
           </div>

--- a/app/views/org_admin/sections/_new.html.erb
+++ b/app/views/org_admin/sections/_new.html.erb
@@ -3,4 +3,3 @@
 <% new_section = Section.new(phase_id: phase.id, number: number + 1) %>
 <%= render partial: 'org_admin/sections/form',
            locals: local_assigns.merge({ section: new_section, method: :post, url: org_admin_template_phase_sections_path(template_id: template.id, phase_id: phase.id) }) %>
-

--- a/app/views/org_admin/sections/_section.html.erb
+++ b/app/views/org_admin/sections/_section.html.erb
@@ -15,9 +15,9 @@
         <%= section.title %>
       </div>
       <div class="pull-right">
-        <i class="fa fa-plus pull-right" aria-hidden="true" title="Click to expand"></i>
+        <i class="fas fa-plus pull-right" aria-hidden="true" title="Click to expand"></i>
         <% if local_assigns[:draggable] %>
-          <i class="fa fa-arrows pull-right" aria-hidden="true"
+          <i class="fas fa-arrows pull-right" aria-hidden="true"
              title="Drag to reposition">
           </i>
         <% end %>

--- a/app/views/org_admin/templates/_row.html.erb
+++ b/app/views/org_admin/templates/_row.html.erb
@@ -11,7 +11,7 @@
     <% elsif template.draft? %>
       <% tooltip = _('This template is published changes but has unpublished changes!') %>
       <%= _('Published') %> <em class="sr-only"><%= tooltip %></em>
-    &nbsp;&nbsp;<i class="fa fa-pencil-square-o" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
+    &nbsp;&nbsp;<i class="fas fa-pencil-square" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
     <% else %>
       <%= _('Unpublished') %>
     <% end %>

--- a/app/views/org_admin/templates/_show.html.erb
+++ b/app/views/org_admin/templates/_show.html.erb
@@ -21,7 +21,7 @@
         <% tooltip = _('You have unpublished changes! Select "Publish changes" in the Actions menu when you are ready to make them available to users.') %>
         <%= template.customization_of.present? ? _('Customisations are published') :_('Published')%>
         <em class="sr-only"><%= tooltip %></em>
-        &nbsp;&nbsp;<i class="fa fa-pencil-square-o red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
+        &nbsp;&nbsp;<i class="fas fa-pencil-square red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
       <% else %>
         <%= template.customization_of.present? ? _('Customisations are unpublished') :_('Unpublished') %>
       <% end %>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -123,31 +123,24 @@
     <% if current_user.can_super_admin? %>
       <fieldset class="col-xs-8">
         <legend><%= _('Organisation Types') %></legend>
-          <div class="checkbox">
-
-<%= Org.org_types.inspect %>
-
-            <%= collection_check_boxes(:org, :org_types, Org.org_types, :id, :name) %>
-          </div>
-
-          <div class="checkbox">
-            <%= f.label :funder do %>
-              <%= f.check_box :funder, {}, org.funder?.to_s, class: 'org_types' %>
-              <%= _('Funder') %>
-            <% end %>
-          </div>
-          <div class="checkbox">
-            <%= f.label :institution do %>
-              <%= f.check_box :institution, {}, org.institution?.to_s, class: 'org_types' %>
-              <%= _('Institution') %>
-            <% end %>
-          </div>
-          <div class="checkbox">
-            <%= f.label :organisation do %>
-              <%= f.check_box :organisation, {}, org.organisation?.to_s, class: 'org_types' %>
-              <%= _('Organisation') %>
-            <% end %>
-          </div>
+        <div class="checkbox">
+          <%= f.label :funder do %>
+            <%= f.check_box :funder, {}, org.funder?.to_s, class: 'org_types' %>
+            <%= _('Funder') %>
+          <% end %>
+        </div>
+        <div class="checkbox">
+          <%= f.label :institution do %>
+            <%= f.check_box :institution, {}, org.institution?.to_s, class: 'org_types' %>
+            <%= _('Institution') %>
+          <% end %>
+        </div>
+        <div class="checkbox">
+          <%= f.label :organisation do %>
+            <%= f.check_box :organisation, {}, org.organisation?.to_s, class: 'org_types' %>
+            <%= _('Organisation') %>
+          <% end %>
+        </div>
       </fieldset>
     <% else %>
       <div class="col-xs-8">

--- a/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
@@ -31,7 +31,7 @@
                 <td><%= plan.owner.present? ? plan.owner.name : _('Unknown') %></td>
                 <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
                 <td class="text-center">
-                  <%= link_to plan_export_path(plan, format: :pdf),
+                  <%= link_to plan_export_path(plan, format: :pdf, export: { question_headings: true }),
                       class: 'has-new-window-popup-info',
                       target: '_blank' do %>
                     <i class="fas fa-file-pdf" aria-hidden="true"></i>

--- a/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
@@ -34,7 +34,7 @@
                   <%= link_to plan_export_path(plan, format: :pdf),
                       class: 'has-new-window-popup-info',
                       target: '_blank' do %>
-                    <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
+                    <i class="fas fa-file-pdf" aria-hidden="true"></i>
                     <em class="sr-only"><%= _('(new window)') %></em>
                     <span class="new-window-popup-info"><%= _('Opens in new window') %></span>
                   <% end %>

--- a/app/views/paginable/plans/_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_publicly_visible.html.erb
@@ -19,7 +19,7 @@
           <td class="text-center">
             <%= link_to plan_export_path(plan, format: :pdf),
                 class: "dmp_table_link has-new-window-popup-info", target: '_blank' do %>
-              <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
+              <i class="fas fa-file-pdf" aria-hidden="true"></i>
               <em class="sr-only"><%= _('(new window)') %></em>
               <span class="new-window-popup-info"><%= _('Opens in new window') %></span>
             <% end %>

--- a/app/views/paginable/plans/_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_publicly_visible.html.erb
@@ -17,7 +17,7 @@
           <td><%= (plan.owner.nil? || plan.owner.org.nil? ? _('Not Applicable') : plan.owner.org.name) %></td>
           <td><%= (plan.owner.nil? ? _('Unknown') : plan.owner.name(false)) %></td>
           <td class="text-center">
-            <%= link_to plan_export_path(plan, format: :pdf),
+            <%= link_to plan_export_path(plan, format: :pdf, export: { question_headings: true }),
                 class: "dmp_table_link has-new-window-popup-info", target: '_blank' do %>
               <i class="fas fa-file-pdf" aria-hidden="true"></i>
               <em class="sr-only"><%= _('(new window)') %></em>

--- a/app/views/paginable/templates/_customisable.html.erb
+++ b/app/views/paginable/templates/_customisable.html.erb
@@ -25,14 +25,14 @@
             <% if customization.upgrade_customization? %>
               <% tooltip = _("Select 'Transfer customisation' in the Actions menu to review your customisation(s) and make any necessary changes. When you are done, you must return to the Actions menu and publish your customisation(s).") %>
               <%= _('Original funder template has changed!') %><em class="sr-only"><%= tooltip %></em>
-              &nbsp;&nbsp;<i class="fa fa-files-o red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
+              &nbsp;&nbsp;<i class="fas fa-copy red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
             <% else %>
               <% if customization.published? %>
                 <%= _('Published') %>
               <% elsif customization.draft? %>
                 <% tooltip = _('You have unpublished changes! Select "Publish changes" in the Actions menu when you are ready to make them available to users.') %>
                 <%= _('Published') %> <em class="sr-only"><%= tooltip %></em>
-              &nbsp;&nbsp;<i class="fa fa-pencil-square-o red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
+              &nbsp;&nbsp;<i class="fas fa-edit red" aria-hidden="true" data-toggle="tooltip" title="<%= tooltip %>"></i>
               <% else %>
                 <%= _('Unpublished') %>
               <% end %>
@@ -51,7 +51,7 @@
               <%= _('Actions') %><span class="caret"></span>
             </button>
             <ul class="dropdown-menu">
-              <li><%= link_to_customizable_template customization, template %></li>
+              <li><%= link_to_customizable_template "", customization, template %></li>
               <% if customization.present? && customization.created_at >= template.created_at %>
                 <li><%= link_to _('History'), history_org_admin_template_path(customization.id) %></li>
                 <% if customization.draft? || customization.published? %>

--- a/app/views/paginable/templates/_history.html.erb
+++ b/app/views/paginable/templates/_history.html.erb
@@ -16,21 +16,21 @@
           <td>
             <%= template.title%>
             <% if template.draft? && template.latest? %>
-              &nbsp;&nbsp;<i class="fa fa-pencil-square-o" aria-hidden="true"></i>&nbsp;&nbsp;<em><%=_('Draft')%></em>
+              &nbsp;&nbsp;<i class="fas fa-pencil-square" aria-hidden="true"></i>&nbsp;&nbsp;<em><%=_('Draft')%></em>
             <% end %>
           </td>
           <td class="text-center">
             <%= link_to template_export_org_admin_template_url(template, format: :docx),
                         target: '_blank',
                         class: 'has-new-window-popup-info' do %>
-               <i class="fa fa-file-word-o" aria-hidden="true"></i>
+               <i class="fas fa-file-word" aria-hidden="true"></i>
                <em class="sr-only"><%= _('(new window)') %></em>
                <span class="new-window-popup-info"><%= _('Opens in new window') %></span>
             <% end %>
             <%= link_to template_export_org_admin_template_url(template, format: :pdf),
                         target: '_blank',
                         class: 'has-new-window-popup-info' do %>
-               <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
+               <i class="fas fa-file-pdf" aria-hidden="true"></i>
                <em class="sr-only"><%= _('(new window)') %></em>
                <span class="new-window-popup-info"><%= _('Opens in new window') %></span>
             <% end %>

--- a/app/views/paginable/templates/_publicly_visible.html.erb
+++ b/app/views/paginable/templates/_publicly_visible.html.erb
@@ -23,14 +23,14 @@
             <%= link_to template_export_path(template.family_id, format: :docx),
                         target: '_blank',
                         class: 'has-new-window-popup-info' do %>
-               <i class="fa fa-file-word-o" aria-hidden="true"></i>
+               <i class="fas fa-file-word" aria-hidden="true"></i>
                <em class="sr-only"><%= _('(new window)') %></em>
                <span class="new-window-popup-info"><%= _('Opens in new window') %></span>
             <% end %>
             <%= link_to template_export_path(template.family_id, format: :pdf),
                         target: '_blank',
                         class: 'has-new-window-popup-info' do %>
-               <i class="fa fa-file-pdf-o" aria-hidden="true"></i>
+               <i class="fas fa-file-pdf" aria-hidden="true"></i>
                <em class="sr-only"><%= _('(new window)') %></em>
                <span class="new-window-popup-info"><%= _('Opens in new window') %></span>
             <% end %>
@@ -42,7 +42,7 @@
           </td>
           <td class="text-center">
             <%= direct_link(template) %>
-            <a href="" class="copy-link" data-toggle="modal" data-target="#link-modal" title="<%= _('Copy link to create a new plan') %>"><span class="fa fa-clipboard"></span></a>
+            <a href="" class="copy-link" data-toggle="modal" data-target="#link-modal" title="<%= _('Copy link to create a new plan') %>"><span class="fas fa-clipboard"></span></a>
           </td>
           <td>
             <%= sanitize links_to_a_elements(template.links['sample_plan'], '<br>') %>

--- a/app/views/phases/_edit_plan_answers.html.erb
+++ b/app/views/phases/_edit_plan_answers.html.erb
@@ -46,7 +46,7 @@
                   </span>
               <% end %>
             </div>
-            <i class="fa fa-plus pull-right" aria-hidden="true"></i>
+            <i class="fas fa-plus pull-right" aria-hidden="true"></i>
             <div class="clearfix"></div>
           </div>
         </div>
@@ -98,7 +98,7 @@
                   </div>
                   <% if i != section.questions.length - 1 %>
                     <hr>
-                  <% end %> 
+                  <% end %>
                 </div>
                 <% if i != section.questions.length - 1 %>
                   <hr />

--- a/app/views/plans/_guidance_selection.html.erb
+++ b/app/views/plans/_guidance_selection.html.erb
@@ -33,7 +33,7 @@
         <div class="sign-in">
           <div class="modal-body">
             <button type="button" class="close pull-right" data-dismiss="modal" aria-label="<%= _('Cancel') %>">
-              <span class="fa fa-times" aria-hidden="true">&nbsp;</span>
+              <span class="fas fa-times" aria-hidden="true">&nbsp;</span>
             </button>
             <h2><%= _('Select Guidance') %></h2>
             <p>

--- a/app/views/plans/_overview_details.html.erb
+++ b/app/views/plans/_overview_details.html.erb
@@ -45,7 +45,7 @@
                       :questions => n_('question', 'questions', questions_size) } %>
                   </div>
                   <div class="pull-right">
-                    <i class="fa fa-plus pull-right" aria-hidden="true"></i>
+                    <i class="fas fa-plus pull-right" aria-hidden="true"></i>
                   </div>
                   <div class="clearfix"></div>
                 </div>

--- a/app/views/shared/_links.html.erb
+++ b/app/views/shared/_links.html.erb
@@ -12,7 +12,7 @@
         </small>&nbsp;
         <a href="#" aria-label="<%= _('Text') %>" data-toggle="tooltip"
            data-placement="right" title="<%= tooltip %>">
-          <i class="fa fa-question-circle fa-reverse" aria-hidden="true"></i>
+          <i class="fas fa-question-circle fa-reverse" aria-hidden="true"></i>
           <em class="sr-only"><%= tooltip %></em>
         </a>
       </h3>
@@ -40,7 +40,7 @@
           <div class="col-xs-2">
             <div class="form-group">
               <a href="#" class="delete" aria-label="<%= _('Remove this link') %>">
-                <i class="fa fa-times-circle fa-reverse" aria-hidden="true"></i>
+                <i class="fas fa-times-circle fa-reverse" aria-hidden="true"></i>
               </a>
             </div>
           </div>

--- a/app/views/shared/_popover.html.erb
+++ b/app/views/shared/_popover.html.erb
@@ -2,7 +2,7 @@
 <% if message.present? %>
   <a href="#" class="btn btn-default" data-toggle="tooltip"
      title="<%= message %>" placement="<%= placement %>">
-    <i class="fa fa-question-circle"></i>
+    <i class="fas fa-question-circle"></i>
     <em class="sr-only"><%= message %>></em>
   </a>
 <% end %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -4,7 +4,7 @@
   <div class="form-group">
     <div class="input-group">
       <span class="input-group-addon" id="search-addon">
-        <span class="fa fa-search" aria-hidden="true"></span>
+        <span class="fas fa-search" aria-hidden="true"></span>
       </span>
       <%= text_field_tag(:search, search_term, class: 'form-control', 'aria-labelledby': 'search',
                         spellcheck: true, 'aria-describedby': 'search-addon', 'aria-required': true) %>

--- a/app/views/shared/_table_filter.html.erb
+++ b/app/views/shared/_table_filter.html.erb
@@ -12,7 +12,7 @@
             data-toggle="tooltip"
             title="<%= remove_filter_tooltip %>"
             aria-label="<%= remove_filter_tooltip %>">
-              <i class="fa fa-times" aria-hidden="true"></i>
+              <i class="fas fa-times" aria-hidden="true"></i>
               <em class="sr-only"><%= remove_filter_tooltip %></em>
           </a>
       </li>

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -45,9 +45,10 @@
                   <br>
                 <% end %>
                 <% answer = @plan.answer(question[:id], false) %>
+                <% blank = answer.present? ? answer.blank? : true %>
                 <% options = answer.present? ? answer.question_options : [] %>
                 <%# case where question has not been answered sufficiently to display%>
-                <% if @show_unanswered && !answer.answered? %>
+                <% if @show_unanswered && !blank %>
                   <br>
                   <p><%= _('Question not answered.') -%></p>
                   <br><br>

--- a/app/views/super_admin/users/_confirm_merge.html.erb
+++ b/app/views/super_admin/users/_confirm_merge.html.erb
@@ -6,7 +6,7 @@
   <div class="form-group">
     <div class="input-group">
       <span class="input-group-addon" id="search-addon">
-        <span class="fa fa-search" aria-hidden="true"></span>
+        <span class="fas fa-search" aria-hidden="true"></span>
       </span>
     <%= select_tag(:merge_id, options_from_collection_for_select(@users, "id", "email"), class: "form-control") %>
     </div>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -79,7 +79,7 @@
           <div class="form-group">
             <div class="input-group">
               <span class="input-group-addon" id="search-addon">
-                <span class="fa fa-search" aria-hidden="true"></span>
+                <span class="fas fa-search" aria-hidden="true"></span>
               </span>
             <%= text_field_tag(:email, nil, class: "form-control", placeholder: _("Email")) %>
             </div>

--- a/app/views/usage/_template_statistics_accordion.html.erb
+++ b/app/views/usage/_template_statistics_accordion.html.erb
@@ -11,7 +11,7 @@
         <%= _('Statistics on your Templates') %>
       </div>
       <div class="pull-right">
-        <i class="fa fa-<%= expanded ? 'minus' : 'plus' %> pull-right" aria-hidden="true"></i>
+        <i class="fas fa-<%= expanded ? 'minus' : 'plus' %> pull-right" aria-hidden="true"></i>
       </div>
       <div class="clearfix"></div>
     </div>

--- a/app/views/usage/_total_usage.html.erb
+++ b/app/views/usage/_total_usage.html.erb
@@ -3,11 +3,11 @@
 <div class="row mt-15 mb-15">
   <div class="col-md-3">
     <div class="col-xs-6">
-      <i class="fa fa-users f-large"></i>
+      <i class="fas fa-users f-large"></i>
       <p class="fontsize-h4"><%= user_count.to_i %> Total users</p>
     </div>
     <div class="col-xs-6">
-      <i class="fa fa-files-o f-large"></i>
+      <i class="fas fa-files f-large"></i>
       <p  class="fontsize-h4"><%= plan_count.to_i %> Total plans</p>
       <%= form_tag('/usage', method: :get, id: :filter_plans_form) do |f| %>
         <%= label_tag :filtered do %>
@@ -34,14 +34,14 @@
   <% if current_user.can_super_admin? %>
     <div class="col-md-3">
       <%= link_to usage_global_statistics_path(sep: ",", filtered: @filtered), class: "stat btn btn-default #{'pull-right' if @funder.present?}", role: 'button', target: '_blank' do %>
-        <%= _('Download global usage') %> <i class="fa fa-download" aria-hidden="true"></i>
+        <%= _('Download global usage') %> <i class="fas fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
   <% end %>
   <% unless @funder.present? %>
     <div class="col-md-3">
       <%= link_to usage_org_statistics_path(sep: ",", filtered: @filtered), class: 'stat btn btn-default pull-right', role: 'button', target: '_blank' do %>
-        <%= _('Download Monthly Usage') %> <i class="fa fa-download" aria-hidden="true"></i>
+        <%= _('Download Monthly Usage') %> <i class="fas fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
   <% end %>

--- a/app/views/usage/_user_statistics.html.erb
+++ b/app/views/usage/_user_statistics.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class="pull-right">
       <%= link_to usage_yearly_users_path(sep: ","), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
-        <%= _('Download') %> <i class="fa fa-download" aria-hidden="true"></i>
+        <%= _('Download') %> <i class="fas fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
     <div class="clearfix"></div>
@@ -35,7 +35,7 @@
     </div>
     <div class="pull-right">
       <%= link_to usage_yearly_plans_path(sep: ",", filtered: @filtered), class: 'stat btn btn-default', role: 'button', target: '_blank' do %>
-        <%= _('Download') %> <i class="fa fa-download" aria-hidden="true"></i>
+        <%= _('Download') %> <i class="fas fa-download" aria-hidden="true"></i>
       <% end %>
     </div>
     <div class="clearfix"></div>
@@ -82,7 +82,7 @@
             <li>
               <div class="form-group">
                 <%= link_to usage_all_plans_by_template_path(sep: ",", filtered: @filtered), class: 'btn btn-default stat', role: 'button', target: '_blank' do %>
-                  <%= _('Download all') %> <i class="fa fa-download" aria-hidden="true"></i>
+                  <%= _('Download all') %> <i class="fas fa-download" aria-hidden="true"></i>
                 <% end %>
              </div>
             </li>

--- a/app/views/usage/_user_statistics_accordion.html.erb
+++ b/app/views/usage/_user_statistics_accordion.html.erb
@@ -11,7 +11,7 @@
         <%= _('Statistics on your Users') %>
       </div>
       <div class="pull-right">
-        <i class="fa fa-<%= expanded ? 'minus' : 'plus' %> pull-right" aria-hidden="true"></i>
+        <i class="fas fa-<%= expanded ? 'minus' : 'plus' %> pull-right" aria-hidden="true"></i>
       </div>
       <div class="clearfix"></div>
     </div>

--- a/spec/controllers/contributors_controller_spec.rb
+++ b/spec/controllers/contributors_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ContributorsController, type: :controller do
       }
     }
     @roles = Contributor.new.all_roles
-    @params_hash[:contributor][@roles.sample.to_sym] = true
+    @params_hash[:contributor][@roles.sample.to_sym] = "1"
     @controller = described_class.new
   end
 

--- a/spec/factories/orgs.rb
+++ b/spec/factories/orgs.rb
@@ -40,9 +40,7 @@ FactoryBot.define do
     abbreviation { SecureRandom.hex(4) }
     feedback_enabled { false }
     region { Region.first || create(:region) }
-    language do
-      Language.first_or_create(name: "English", abbreviation: "en-GB")
-    end
+    language { Language.default }
     is_other { false }
     contact_email { Faker::Internet.safe_email }
     contact_name { Faker::Name.name }

--- a/spec/factories/templates.rb
+++ b/spec/factories/templates.rb
@@ -42,7 +42,6 @@ FactoryBot.define do
     published { false }
     archived { false }
     sequence(:version)
-    family_id { Template.unique_random(field_name: "family_id") }
 
     trait :publicly_visible do
       after(:create) do |template|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -56,7 +56,7 @@
 FactoryBot.define do
   factory :user do
     org
-    language
+    language     { Language.default }
     firstname    { Faker::Name.unique.first_name }
     surname      { Faker::Name.unique.last_name }
     email        { Faker::Internet.unique.safe_email }

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Registrations", type: :feature do
 
   let!(:org) { create(:org) }
+  let!(:language) { Language.default || create(:language, default_language: true) }
 
   let(:user_attributes) { attributes_for(:user) }
 

--- a/spec/features/templates/templates_editings_spec.rb
+++ b/spec/features/templates/templates_editings_spec.rb
@@ -38,8 +38,10 @@ RSpec.feature "Templates::Editing", type: :feature do
     end
     click_link template.sections.first.title
     within("#edit_question_#{template.question_ids.first}") do
-      id = "question_annotations_attributes_annotation_#{Regexp.last_match(1)}_text"
-      tinymce_fill_in(:"#{id}", with: "Foo bar")
+      # rubocop:disable Lint/UselessAssignment, Style/PerlBackrefs
+      textarea_id = page.body.match(/question\_annotations\_attributes\_annotation\_(\d+)\_text/)
+      tinymce_fill_in(:"question_annotations_attributes_annotation_#{$1}_text", with: "Foo bar")
+      # rubocop:enable Lint/UselessAssignment, Style/PerlBackrefs
       click_button "Save"
     end
     # Make sure annotation has been updated

--- a/spec/features/templates/templates_upgrade_customisations_spec.rb
+++ b/spec/features/templates/templates_upgrade_customisations_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature "Templates::UpgradeCustomisations", type: :feature do
     # Publish our customisation
     click_button "Actions"
     click_link "Publish"
+    expect(customized_template.reload.published?).to eql(true)
 
     # Move to the other funder Org's Templates
     fill_in(:superadmin_user_org_name, with: funder.name)
@@ -88,8 +89,8 @@ RSpec.feature "Templates::UpgradeCustomisations", type: :feature do
     visit organisational_org_admin_templates_path
 
     click_button "Actions"
-    target = Template.last.published?
-    expect { click_link "Publish changes" }.to change { target }.from(false).to(true)
+    click_link "Publish changes"
+    expect(new_funder_template.reload.published?).to eql(true)
 
     # Go back to the original Org...
 
@@ -98,6 +99,7 @@ RSpec.feature "Templates::UpgradeCustomisations", type: :feature do
     click_button("Change affiliation")
 
     click_link "Customisable Templates"
+
     expect(page).to have_text("Original funder template has changed")
 
     click_button "Actions"

--- a/spec/features/templates_spec.rb
+++ b/spec/features/templates_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Templates", type: :feature do
     end
 
     # Expectations
-    last_section = Section.last
+    last_section = @template.phases.first.sections.order(:created_at).last
     expect(@template.sections.count).to eql(5)
     expect(last_section.title).to eql("My new section")
     expect(last_section.description).to match("This is the description of my new section")

--- a/spec/javascripts/fixtures/accordion.html
+++ b/spec/javascripts/fixtures/accordion.html
@@ -14,7 +14,7 @@
         <h2 class="panel-title">
           <a role="button" data-toggle="collapse" data-parent="accordion" href="#collapseA" aria-controls="collapseA" aria-expanded="false">
             Section A
-            <span class="fa fa-plus" aria-hidden="true"></span>
+            <span class="fas fa-plus" aria-hidden="true"></span>
           </a>
         </h2>
       </div>
@@ -30,7 +30,7 @@
         <h2 class="panel-title">
           <a role="button" data-toggle="collapse" data-parent="accordion" href="#collapseB" aria-controls="collapseB" aria-expanded="false">
             Section B
-            <span class="fa fa-plus" aria-hidden="true"></span>
+            <span class="fas fa-plus" aria-hidden="true"></span>
           </a>
         </h2>
       </div>
@@ -46,7 +46,7 @@
         <h2 class="panel-title">
           <a role="button" data-toggle="collapse" data-parent="accordion" href="#collapseC" aria-controls="collapseC" aria-expanded="false">
             Section C
-            <span class="fa fa-plus" aria-hidden="true"></span>
+            <span class="fas fa-plus" aria-hidden="true"></span>
           </a>
         </h2>
       </div>

--- a/spec/requests/api/v1/plans_controller.rb
+++ b/spec/requests/api/v1/plans_controller.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
       mock_authorization_for_api_client
 
       # Org model requires a language so make sure the default is set
-      create(:language, default_language: true)
+      create(:language, default_language: true) unless Language.default.present?
     end
 
     describe "GET /api/v1/plan/:id - show" do

--- a/spec/services/locale_service_spec.rb
+++ b/spec/services/locale_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe LocaleService do
 
   before(:each) do
     Language.destroy_all
-    @default = create(:language, default_language: true)
+    @default = Language.default || create(:language, default_language: true)
     Rails.configuration.x.locales.default = @default.abbreviation
     Rails.configuration.x.locales.gettext_join_character = "_"
     Rails.configuration.x.locales.i18n_join_character = "-"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,6 +127,9 @@ RSpec.configure do |config|
         allow: %w[chromedriver.storage.googleapis.com]
       )
     end
+
+    # Ensure that there is always a default Language
+    create(:language, default_language: true) unless Language.default.present?
   end
 
   config.after(:suite) do


### PR DESCRIPTION
Fixes #2572 and #2610

Upgrade to Fontawesome 5. The old `fa` class has been replaced by `fas` (aka solid) and `far` (aka regular). The icons are now SVG and there are no `-o` suffixed classes (use `fas` instead).

Minor adjustments to various models, controllers, and specs to fix all of the remaining broken tests.

@raycarrick-ed I updated the JS for the template pages. I did not verify the conditional questions though since I know you had been doing some work on that.
