### PR TITLE
fix up strong params etc for plan creation

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -191,7 +191,7 @@ class OrgsController < ApplicationController
   end
 
   def search_params
-    params.require(:org).permit(:name, :type)
+    params.require(:plan).permit(org_attributes: [ :name, :type ])
   end
 
   def shib_login_url

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -191,7 +191,7 @@ class OrgsController < ApplicationController
   end
 
   def search_params
-    params.require(:plan).permit(org_attributes: [ :name, :type ])
+    params.require(:plan).permit(org_attributes: %i[name type ])
   end
 
   def shib_login_url

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -92,11 +92,13 @@ class PlansController < ApplicationController
       # plan.funder which forces the hidden id hash to be :id
       # so we need to convert it to :org_id so it works with the
       # OrgSelectable and OrgSelection services
-      if plan_params[:org_attributes].present? && plan_params[:org_attributes][:org_id].present?
+      if plan_params[:org_attributes].present? &&
+          plan_params[:org_attributes][:org_id].present?
         attrs = plan_params[:org_attributes]
         @plan.org = org_from_params(params_in: attrs, allow_create: false)
       end
-      if plan_params[:funder_attributes].present? && plan_params[:funder_attributes][:org_id].present?
+      if plan_params[:funder_attributes].present? &&
+          plan_params[:funder_attributes][:org_id].present?
         attrs = plan_params[:funder_attributes]
         @plan.funder = org_from_params(params_in: attrs, allow_create: false)
       end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -92,14 +92,12 @@ class PlansController < ApplicationController
       # plan.funder which forces the hidden id hash to be :id
       # so we need to convert it to :org_id so it works with the
       # OrgSelectable and OrgSelection services
-      if plan_params[:org][:id].present?
-        attrs = plan_params[:org]
-        attrs[:org_id] = attrs[:id]
+      if plan_params[:org_attributes].present? && plan_params[:org_attributes][:org_id].present?
+        attrs = plan_params[:org_attributes]
         @plan.org = org_from_params(params_in: attrs, allow_create: false)
       end
-      if plan_params[:funder][:id].present?
-        attrs = plan_params[:funder]
-        attrs[:org_id] = attrs[:id]
+      if plan_params[:funder_attributes].present? && plan_params[:funder_attributes][:org_id].present?
+        attrs = plan_params[:funder_attributes]
         @plan.funder = org_from_params(params_in: attrs, allow_create: false)
       end
 
@@ -450,7 +448,7 @@ class PlansController < ApplicationController
           .permit(:template_id, :title, :visibility, :description, :identifier,
                   :start_date, :end_date, :org_id, :org_name, :org_crosswalk,
                   grant: %i[name value],
-                  org: %i[org_id org_name org_sources org_crosswalk],
+                  org_attributes: %i[org_id org_name org_sources org_crosswalk],
                   funder: %i[org_id org_name org_sources org_crosswalk])
   end
 

--- a/app/javascript/src/plans/new.js
+++ b/app/javascript/src/plans/new.js
@@ -101,10 +101,10 @@ $(() => {
 
       // For some reason Rails freaks out it everything is empty so send
       // the word "none" instead and handle on the controller side
-      if (orgId.length <= 0) {
+      if (orgId == undefined || orgId.length <= 0) {
         orgId = '"none"';
       }
-      if (funderId.length <= 0) {
+      if (funderId == undefined || funderId.length <= 0) {
         funderId = '"none"';
       }
       const data = `{"plan": {"research_org_id":${orgId},"funder_id":${funderId}}}`;

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -127,6 +127,8 @@ class Plan < ApplicationRecord
 
   accepts_nested_attributes_for :template
 
+  accepts_nested_attributes_for :org
+
   accepts_nested_attributes_for :roles
 
   accepts_nested_attributes_for :contributors

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -50,11 +50,11 @@
         <div class="form-group col-md-6">
            <em class="sr-only"><%= research_org_tooltip %></em>
            <% dflt = @orgs.include?(current_user.org) ? current_user.org : nil %>
-           <%= fields_for :org, @plan.org do |org_fields| %>
+           <%= f.fields_for :org, @plan.org do |org_fields| %>
              <%= render partial: "shared/org_selectors/local_only",
                         locals: {
                           form: org_fields,
-                          id_field: :id,
+                          id_field: :org_id,
                           default_org: dflt,
                           orgs: @orgs,
                           required: false


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

Create plan wasn't working. Not sure I haven't gone down a rabbit hole with this, so needs checking.

The strong params seemed to be a problem. The org params where at the same level as the plan attributes and so the plan_params stripped them out. As far as I can tell:
```
params.require(X).permit(Y,Z)
```
means that params need to be of the form
```
{X => {Y => foo, Z => bar}}
```
rather than
```
{
X => {Y => foo}
Z => bar
}
```
which is what was there.

So I changed the `plan` model to accept attributes for `org` and altered the org form to use `f.fields_for` rather than plain `fields_for` to embed the org attributes within the plan which gave params that looked like
```
{
plan => {
    ....
    org_attributes => {...}
}
```
which can then pass strong params.
I then reworked the other bits as needed to get it to work.
There was also an issue with the JS for plan creation where it was looking for `orgId.length` but `orgId` was undefined so I put in a check for that too.

