### PR TITLE
fixed issue with create plan

### DIFF
--- a/app/controllers/concerns/org_selectable.rb
+++ b/app/controllers/concerns/org_selectable.rb
@@ -2,6 +2,57 @@
 
 # Provides methods to handle the org_id hash returned to the controller
 # for pages that use the Org selection autocomplete widget
+#
+# This Concern handles the incoming params from a page that has one of the
+# Org Typeahead boxes found in app/views/shared/org_selectors/.
+#
+# The incoming hash looks like this:
+#  {
+#    "org_name"=>"Portland State University (PDX)",
+#    "org_sources"=>"[
+#      \"3E (Belgium) (3e.eu)\",
+#      \"etc.\"
+#    ]",
+#    "org_crosswalk"=>"[
+#      {
+#        \"id\":1574,
+#        \"name\":\"3E (Belgium) (3e.eu)\",
+#        \"sort_name\":\"3E\",
+#        \"ror\":\"https://ror.org/03d33vh19\"
+#      },
+#     {
+#       "etc."
+#    }]",
+#    "id"=>"{
+#      \"id\":62,
+#      \"name\":\"Portland State University (PDX)\",
+#      \"sort_name\":\"Portland State University\",
+#      \"ror\":\"https://ror.org/00yn2fy02\",
+#      \"fundref\":\"https://api.crossref.org/funders/100007083\"
+#    }
+#  }
+#
+# The :org_name, :org_sources, :org_crosswalk are all relics of the JS involved in
+# handling the request/response from OrgsController#search AJAX action that is
+# used to search both the local DB and the ROR API as the user types.
+#   :org_name = the value the user has types in
+#   :org_sources = the pick list of Org names returned by the OrgsController#search action
+#   :org_crosswalk = all of the info about each Org returned by the OrgsController#search action
+#                    there is JS that takes the value in :org_name and then sets the :id param
+#                    to the matching Org in the :org_crosswalk on form submission
+#
+# They are typically removed from the incoming params hash prior to doing a :save or :update
+# by the :remove_org_selection_params below.
+# TODO: Consider adding a JS method that strips those 3 params out prior to form submission
+#       since we only need the contents of the :id param here
+#
+# The contents of :id are then used to either Create or Find the Org from the DB.
+# if id: { :id } is present then the Org was one pulled from the DB. If it is not
+# present then it is one of the following:
+#  if :ror or :fundref are present then it was one retrieved from the ROR API
+#  otherwise it is a free text value entered by the user
+#
+# See the comments on OrgsController#search for more info on how the typeaheads work
 module OrgSelectable
 
   extend ActiveSupport::Concern

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -186,13 +186,11 @@ module Paginable
     @args.except(*PAGINATION_QUERY_PARAMS).to_param
   end
 
-  # TODO: We would be better served here passing these arguments as a Ruby double splat
-  # rubocop:disable Lint/UnusedMethodArgument
   def stringify_query_params(page: 1, search: @args[:search],
                              sort_field: @args[:sort_field],
                              sort_direction: nil)
 
-    query_string = {}
+    query_string = { page: page }
     query_string["search"] = search if search.present?
     if sort_field.present?
       query_string["sort_field"] = sort_field
@@ -200,7 +198,6 @@ module Paginable
     end
     query_string.to_param
   end
-  # rubocop:enable Lint/UnusedMethodArgument
 
   def paginable_params
     params.permit(PAGINATION_QUERY_PARAMS)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -92,12 +92,12 @@ class PlansController < ApplicationController
       # plan.funder which forces the hidden id hash to be :id
       # so we need to convert it to :org_id so it works with the
       # OrgSelectable and OrgSelection services
-      if plan_params[:org][:id].present?
+      if plan_params[:org].present? && plan_params[:org][:id].present?
         attrs = plan_params[:org]
         attrs[:org_id] = attrs[:id]
         @plan.org = org_from_params(params_in: attrs, allow_create: false)
       end
-      if plan_params[:funder][:id].present?
+      if plan_params[:funder].present? && plan_params[:funder][:id].present?
         attrs = plan_params[:funder]
         attrs[:org_id] = attrs[:id]
         @plan.funder = org_from_params(params_in: attrs, allow_create: false)
@@ -450,8 +450,8 @@ class PlansController < ApplicationController
           .permit(:template_id, :title, :visibility, :description, :identifier,
                   :start_date, :end_date, :org_id, :org_name, :org_crosswalk,
                   grant: %i[name value],
-                  org: %i[org_id org_name org_sources org_crosswalk],
-                  funder: %i[org_id org_name org_sources org_crosswalk])
+                  org: %i[id org_id org_name org_sources org_crosswalk],
+                  funder: %i[id org_id org_name org_sources org_crosswalk])
   end
 
   # different versions of the same template have the same family_id

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -50,7 +50,7 @@
         <div class="form-group col-md-6">
            <em class="sr-only"><%= research_org_tooltip %></em>
            <% dflt = @orgs.include?(current_user.org) ? current_user.org : nil %>
-           <%= fields_for :org, @plan.org do |org_fields| %>
+           <%= f.fields_for :org, @plan.org do |org_fields| %>
              <%= render partial: "shared/org_selectors/local_only",
                         locals: {
                           form: org_fields,
@@ -78,7 +78,7 @@
       <div id="funder-org-controls" class="row">
         <div class="form-group col-xs-6">
           <em class="sr-only"><%= primary_funding_tooltip %></em>
-          <%= fields_for :funder, @plan.funder = Org.new do |funder_fields| %>
+          <%= f.fields_for :funder, @plan.funder = Org.new do |funder_fields| %>
             <%= render partial: "shared/org_selectors/local_only",
                         locals: {
                           form: funder_fields,


### PR DESCRIPTION
@raycarrick-ed this one fixes the issue with the Create Plan page. Thanks again for catching it. 

It wasn't actually an issue with the OrgsController#search action (which is used by the Typeahead AJAX logic). 

I also added a ton of comments to the OrgSelectable concern and the OrgsController#search action to hopefully help clarify what's going on. I have a feeling that it will be helpful in the future if we need to work on any of that code.