### PR TITLE
Fix error thrown by PG when lowercasing an int

### DIFF
--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -46,8 +46,9 @@ class Identifier < ActiveRecord::Base
   # = Scopes =
   # ===============
 
-  def self.by_scheme_name(value, identifiable_type)
-    where(identifier_scheme: IdentifierScheme.by_name(value),
+  def self.by_scheme_name(scheme, identifiable_type)
+    scheme_id = scheme.instance_of?(IdentifierScheme) ? scheme.id : IdentifierScheme.by_name(scheme).first&.id
+    where(identifier_scheme_id: scheme_id,
           identifiable_type: identifiable_type)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,7 +234,6 @@ class User < ActiveRecord::Base
   #
   # Returns UserIdentifier
   def identifier_for(scheme)
-    scheme = scheme.instance_of?(IdentifierScheme) ? scheme.name : scheme
     identifiers.by_scheme_name(scheme, "User").first
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,6 +234,7 @@ class User < ActiveRecord::Base
   #
   # Returns UserIdentifier
   def identifier_for(scheme)
+    scheme = scheme.instance_of?(IdentifierScheme) ? scheme.name : scheme
     identifiers.by_scheme_name(scheme, "User").first
   end
 


### PR DESCRIPTION
Fixes #2653 

`Identifier.by_scheme_name` expects the first argument to be a string, not an object.