### PR TITLE
issue#2646: section sort arrows missing

### DIFF
--- a/app/javascript/src/orgAdmin/phases/show.js
+++ b/app/javascript/src/orgAdmin/phases/show.js
@@ -29,7 +29,7 @@ $(() => {
   // Initialize the draggable-sections element as a jQuery sortable.
   // Read the docs here for more info: http://api.jqueryui.com/sortable/
   $('.draggable-sections').sortable({
-    handle: 'i.fa-arrows',
+    handle: 'i.fa-arrows-alt',
     axis: 'y',
     cursor: 'move',
     // Remove the placeholder object from the DOM once the item has been placed

--- a/app/views/org_admin/sections/_section.html.erb
+++ b/app/views/org_admin/sections/_section.html.erb
@@ -15,9 +15,11 @@
         <%= section.title %>
       </div>
       <div class="pull-right">
-        <i class="fas fa-plus pull-right" aria-hidden="true" title="Click to expand"></i>
+        <% plussign = "fa-plus" %>
+        <% plussign = "fa-minus" if current_section.present? && section.id == current_section.id %>
+        <i class="fas <%= plussign %> pull-right" aria-hidden="true" title="Click to expand"></i>
         <% if local_assigns[:draggable] %>
-          <i class="fas fa-arrows pull-right" aria-hidden="true"
+          <i class="fas fa-arrows-alt pull-right" aria-hidden="true"
              title="Drag to reposition">
           </i>
         <% end %>


### PR DESCRIPTION
Fixes #2646 .

Changes proposed in this PR:
- change of arrows name in FA
- key +- section expansion/collapse off section being displayed.
