### PR TITLE
issue#2647: display of identifiers in user tables

### DIFF
--- a/app/presenters/identifier_presenter.rb
+++ b/app/presenters/identifier_presenter.rb
@@ -27,10 +27,11 @@ class IdentifierPresenter
     return _("None defined") if id.new_record? || id.value.blank?
 
     without = id.value_without_scheme_prefix
-    return id.value unless without != id.value && !without.starts_with?("http")
+    prefix = with_scheme_name ? id.identifier_scheme.description + ": " : ''
+    return prefix + id.value unless without != id.value && !without.starts_with?("http")
 
     "<a href=\"#{id.value}\" class=\"has-new-window-popup-info\"> " \
-      "#{with_scheme_name ? id.identifier_scheme.description : ''}: #{without}</a>"
+      "#{prefix} #{without}</a>"
   end
 
   private

--- a/app/views/org_admin/users/edit.html.erb
+++ b/app/views/org_admin/users/edit.html.erb
@@ -55,6 +55,15 @@
         <% end %>
       </div>
     <% end %>
+
+    <% if @user.identifiers.present? %>
+      <h2>Identifiers</h2>
+      <% presenter = IdentifierPresenter.new(identifiable: @user) %>
+      <% presenter.identifiers.each do |identifier| %>
+        <p><%= presenter.id_for_display(id: identifier, with_scheme_name: true).html_safe %></p>
+      <% end %>
+    <% end %>
+
   </div>
 </div>
 

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -95,7 +95,7 @@
                   <td class="text-center">
                     <% presenter = IdentifierPresenter.new(identifiable: user) %>
                     <% presenter.identifiers.each do |identifier| %>
-                      <p><%= presenter.id_for_display(id: identifier, with_scheme_name: true).html_safe %></p>
+                      <p><%= identifier.identifier_scheme.name %></p>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -65,6 +65,15 @@
             class: 'btn btn-default', role: 'button' %>
       </div>
     <% end %>
+
+    <% if @user.identifiers.present? %>
+      <h2>Identifiers</h2>
+      <% presenter = IdentifierPresenter.new(identifiable: @user) %>
+      <% presenter.identifiers.each do |identifier| %>
+        <p><%= presenter.id_for_display(id: identifier, with_scheme_name: true).html_safe %></p>
+      <% end %>
+    <% end %>
+
   </div>
   <div class="col-xs-5">
     <div class="row">


### PR DESCRIPTION
Fixes #2647  .

Changes proposed in this PR:
- user table shows scheme name but not value
- value is then displayed on user page if you click through
