### PR TITLE
fixed typo with name of guidance text area selector

### DIFF
--- a/app/javascript/src/guidances/newEdit.js
+++ b/app/javascript/src/guidances/newEdit.js
@@ -1,5 +1,5 @@
 import { Tinymce } from '../utils/tinymce.js.erb';
 
 $(() => {
-  Tinymce.init({ selector: '#guidance-text' });
+  Tinymce.init({ selector: '#guidance_text' });
 });


### PR DESCRIPTION
Fixes #2640 .

Changes proposed in this PR:
- Updated name of selector for the guidance text area so that Tinymce could init
