### PR TITLE
fix for plan deletion

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -103,6 +103,10 @@ class Role < ApplicationRecord
   def deactivate!
     self.active = false
     if save!
+      # Set the org_id on the Plan before calling deactivate. The org_id should
+      # not be blank. This catches the scenario where the `upgrade:v2_2_0_part1`
+      # upgrade task has not been run or it missed a record for some reason
+      plan.org_id = user.org_id unless plan.org_id.present?
       plan.deactivate! if plan.authors.empty?
       true
     else


### PR DESCRIPTION
Fixes #2643 .

Changes proposed in this PR:
- set the Plan's org_id to that of the Role record's user if it is not set

Ideally the `upgrade:v2_2_0_part1` upgrade task would have been run and none of the Plan records would have a nil org_id. This addresses the issue though for scenarios where the plans.org_id is nil for some reason.
