### PR TITLE
remove double-assignment of mananged flag

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -51,8 +51,6 @@ class OrgsController < ApplicationController
         attrs.delete(:identifiers_attributes)
       end
 
-      attrs[:managed] = attrs[:managed] == "1"
-
       # See if the user selected a new Org via the Org Lookup and
       # convert it into an Org
       lookup = org_from_params(params_in: attrs)


### PR DESCRIPTION
Fixes #2682 
Removes 2nd parse of `managed` flag to boolean.

@briri There's quite a few places where we convert these checkbox flags from "1/0" -> true/false.
Would it be worthwhile opening a ticket to pull this logic out and make it more homogenous across the app?