### PR TITLE
Fix for minor bugs with Rails5

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -47,8 +47,9 @@ class OrgsController < ApplicationController
       if Rails.configuration.x.shibboleth.use_filtered_discovery_service
         shib = IdentifierScheme.by_name("shibboleth").first
 
-        if shib.present? && attrs.fetch(:identifiers_attributes, []).any?
-          entity_id = attrs[:identifiers_attributes].first[:value]
+        if shib.present? && attrs[:identifiers_attributes].present?
+          key = attrs[:identifiers_attributes].keys.first
+          entity_id = attrs[:identifiers_attributes][:"#{key}"][:value]
           identifier = Identifier.find_or_initialize_by(
             identifiable: @org, identifier_scheme: shib, value: entity_id
           )

--- a/app/javascript/src/shared/createAccountForm.js
+++ b/app/javascript/src/shared/createAccountForm.js
@@ -2,10 +2,9 @@ import { initAutocomplete, scrubOrgSelectionParamsOnSubmit } from '../utils/auto
 import { togglisePasswords } from '../utils/passwordHelper';
 
 $(() => {
-  const options = { selector: '#create-account-form' };
   initAutocomplete('#create-account-org-controls .autocomplete');
   // Scrub out the large arrays of data used for the Org Selector JS so that they
   // are not a part of the form submissiomn
   scrubOrgSelectionParamsOnSubmit('#create_account_form');
-  togglisePasswords(options);
+  togglisePasswords({ selector: '#create_account_form' });
 });

--- a/app/views/users/_current_privileges.html.erb
+++ b/app/views/users/_current_privileges.html.erb
@@ -3,6 +3,4 @@
   <%= _("Super Admin") %>
 <% elsif  user.can_org_admin? %>
   <%= _("Organisational Admin") %>
-<% else %>
-  <%= _("") %>
 <% end %>

--- a/spec/controllers/orgs_controller_spec.rb
+++ b/spec/controllers/orgs_controller_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe OrgsController, type: :controller do
       @args.delete(:feedback_enabled)
       Rails.configuration.x.shibboleth.use_filtered_discovery_service = true
       scheme = create(:identifier_scheme, name: "shibboleth")
-      @args[:identifiers_attributes] = { identifier_scheme_id: scheme.id,
-                                         value: SecureRandom.uuid }
+      @args[:identifiers_attributes] = { "0": { identifier_scheme_id: scheme.id,
+                                                value: SecureRandom.uuid } }
       put :admin_update, params: { id: @org.id, org: @args }
       expect(response).to redirect_to("#{admin_edit_org_path(@org)}#profile")
       expect(flash[:notice].present?).to eql(true)

--- a/spec/controllers/orgs_controller_spec.rb
+++ b/spec/controllers/orgs_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe OrgsController, type: :controller do
       identifier = @org.reload.identifiers.last
       expect(identifier.present?).to eql(true)
       expect(identifier.identifier_scheme).to eql(scheme)
-      expected = @args[:identifiers_attributes].first[:value]
+      expected = @args[:identifiers_attributes][:"0"][:value]
       expect(identifier.value.end_with?(expected)).to eql(true)
     end
     it "fails" do

--- a/spec/controllers/orgs_controller_spec.rb
+++ b/spec/controllers/orgs_controller_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe OrgsController, type: :controller do
       @args.delete(:feedback_enabled)
       Rails.configuration.x.shibboleth.use_filtered_discovery_service = true
       scheme = create(:identifier_scheme, name: "shibboleth")
-      @args[:identifiers_attributes] = [{ identifier_scheme_id: scheme.id,
-                                          value: SecureRandom.uuid }]
+      @args[:identifiers_attributes] = { identifier_scheme_id: scheme.id,
+                                         value: SecureRandom.uuid }
       put :admin_update, params: { id: @org.id, org: @args }
       expect(response).to redirect_to("#{admin_edit_org_path(@org)}#profile")
       expect(flash[:notice].present?).to eql(true)


### PR DESCRIPTION
- Found a bug saving an Org when  the shibboleth entityId field is enabled and visible on the form 
- Fixed issue with form id for the `togglizePasswords` call on the create account form's JS
- Fixes issue when translation file does not have a translation defined for an empty string. The admin - users page was displaying a nasty error if the user was not an admin. Removed the `_("")` entirely.

See https://github.com/CDLUC3/dmptool/issues/214 for details and screenshots