### PR TITLE
Minor fixes for Rails 5

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -223,9 +223,9 @@ class UserMailer < ActionMailer::Base
   end
 
   def api_credentials(api_client)
+    @api_client = api_client
     return unless @api_client.contact_email.present?
 
-    @api_client = api_client
     @api_docs = Rails.configuration.x.application.api_documentation_url
 
     @name = @api_client.contact_name.present? ? @api_client.contact_name : @api_client.contact_email

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -92,7 +92,7 @@
     </div>
     <div class="form-group col-xs-8">
       <%= label_tag(:api_information, _('API Information'), class: 'control-label') %>
-      <a href="https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation"><%= _('How to use the API') %></a>
+      <a href="https://github.com/DMPRoadmap/roadmap/wiki/API-V0-Documentation"><%= _('How to use the API') %></a>
     </div>
   <% end %>
 

--- a/app/views/plans/_request_feedback_form.html.erb
+++ b/app/views/plans/_request_feedback_form.html.erb
@@ -6,7 +6,7 @@
       <h2><%= _('Request expert feedback') %></h2>
       <p><%= _("Click below to give data management staff at #{plan.owner.org.name}, the Plan Owner's org, access to read and comment on your plan.") %></p>
       <div class="well well-sm">
-        <%= sanitize plan.owner.org.feedback_email_msg.to_s % { user_name: current_user.name(false), plan_name: plan.title } %>
+        <%= sanitize plan.owner.org.feedback_email_msg.to_s % { user_name: current_user.name(false), plan_name: plan.title, organisation_email: current_user.org.contact_email } %>
       </div>
       <p><%= _('You can continue to edit and download the plan in the interim.') %></p>
       <div class="form-group col-xs-8">

--- a/config/credentials.yml.example
+++ b/config/credentials.yml.example
@@ -4,14 +4,20 @@
 # EDITOR=my_ave_editor rails credentials:edit
 # and paste the rest of this file in, filling in the correct values
 #
+# If you need to generate a new secret you can run the `rails secret` utility
+
+database:
+  host: [my_host_name]
+  username: [my_db_user]
+  password: [my_db_password]
+
+devise_pepper: [my_pepper]
+
+dragonfly_secret: [my_secret]
+
+recaptcha:
+  site_key:[mykey]
+  secret_key: [my_secret]
 
 # Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
-secret_key_base: "replace_with_your_secret_key"
-# used in config/initializers/devise.rb
-devise_pepper: "replace_with_your_pepper"
-#used in config/initializers/dragonfly.rb
-dragonfly_secret: "replace_with_your_dregaonfly_secret"
-# used in recaptcha.rb
-recaptcha:
-  site_key: 'replace_this_with_your_public_key'
-  secret_key: 'replace_this_with_your_private_key'
+secret_key_base: [my_secret]


### PR DESCRIPTION
- Fixed an issue with the request feedback screen that was happening if the the feedback message contained the `%{organisation_email}` placeholder. That variable is in the default message from the feedbacks_helper.rb.
- Updated the example credentials file
- Updated the URL to the API documentation on the Edit Profile page
- Fixed issue with api client emailer