### PR TITLE
Removed duplicate call to .first in upgrade task for migrating users …

### DIFF
--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -1076,7 +1076,7 @@ namespace :upgrade do
 
       elsif owner.present?
         contact, contact_id = to_contributor(plan, owner.name(false),
-          owner.email, nil, owner.identifier_for(orcid)&.first&.value, owner.org_id)
+          owner.email, nil, owner.identifier_for(orcid)&.value, owner.org_id)
       end
       # Add the DMP Data Contact
       if contact.present?


### PR DESCRIPTION
An issue with the v2_2 upgrade scripts was reporting that caused the migration of Users to Contributors to fail.

The User model's `identifier_for` method returns an instance of Identifier not a collection. This PR removes a call to `&.first` on the result from `owner.identifier_for`.

This PR's Brakeman checks will fail. It should probably be merged before the Rails 5 changes though