### PR TITLE
Patch for v3 - Fix bug preventing some identifiers from updating & fix bad fundref prefix

### DIFF
--- a/app/controllers/concerns/org_selectable.rb
+++ b/app/controllers/concerns/org_selectable.rb
@@ -28,7 +28,7 @@
 #      \"name\":\"Portland State University (PDX)\",
 #      \"sort_name\":\"Portland State University\",
 #      \"ror\":\"https://ror.org/00yn2fy02\",
-#      \"fundref\":\"https://api.crossref.org/funders/100007083\"
+#      \"fundref\":\"https://doi.org/10.13039/100007083\"
 #    }
 #  }
 #

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -133,8 +133,8 @@ class Identifier < ApplicationRecord
 
   # Ensure that the identifiable only has one identifier for the scheme
   def value_uniqueness_with_scheme
-    if Identifier.where(identifier_scheme: identifier_scheme,
-                        identifiable: identifiable).any?
+    if new_record? && Identifier.where(identifier_scheme: identifier_scheme,
+                                       identifiable: identifiable).any?
       errors.add(:identifier_scheme, _("already assigned a value"))
     end
   end

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -832,7 +832,7 @@ namespace :upgrade do
 
       fundref = IdentifierScheme.find_or_initialize_by(name: "fundref")
       fundref.for_orgs = true
-      fundref.identifier_prefix = "https://api.crossref.org/funders/"
+      fundref.identifier_prefix = "https://doi.org/10.13039/"
       fundref.save
     end
 
@@ -1217,7 +1217,7 @@ namespace :upgrade do
     p "               'University of Somewhere' may match to 'Univerity of Somewhere - Medical Center'"
     p "            To correct any issues, please delete/insert/update the corresponding Identifier:"
     p "               delete from identifiers where identifiable_type = 'Org' and identifiable_id = [orgs.id];"
-    p "               insert into identifiers (identifiable_type, identifier_scheme_id, attrs, identifiable_id, value) values ('Org', [identifier_scheme_id], '{}', [orgs.id], 'https://api.crossref.org/funders/0000000000');"
+    p "               insert into identifiers (identifiable_type, identifier_scheme_id, attrs, identifiable_id, value) values ('Org', [identifier_scheme_id], '{}', [orgs.id], 'https://doi.org/10.13039/0000000000');"
     p "               update identifiers set `value` = 'https://ror.org/123456789' where identifiable_id = [orgs.id] and identifier_scheme_id = [identifier_scheme_id] and identifiable_type= 'Org';"
     p "---------------------------------------------------------------"
   end

--- a/spec/services/api/v1/deserialization/identifier_spec.rb
+++ b/spec/services/api/v1/deserialization/identifier_spec.rb
@@ -96,14 +96,15 @@ RSpec.describe Api::V1::Deserialization::Identifier do
                                       identifiable: @identifiable, json: json)
         expect(result).to eql(nil)
       end
-      it "returns the existing Identifier for the IdentifierScheme" do
+      it "returns the updated Identifier for the IdentifierScheme" do
         identifier = create(:identifier, identifier_scheme: @scheme,
                                          identifiable: @identifiable,
                                          value: Faker::Number.number)
         result = described_class.send(:identifier_for_scheme,
                                       scheme: @scheme,
                                       identifiable: @identifiable, json: @json)
-        validate_identifier(result: result, scheme: @scheme, value: identifier.value)
+        expected = "#{@scheme.identifier_prefix}#{@json[:identifier]}"
+        validate_identifier(result: result, scheme: @scheme, value: expected)
         expect(result.id).to eql(identifier.id)
       end
     end


### PR DESCRIPTION
- Bug fix that was preventing ORCIDs, RORs and Fundrefs from being updated
- Update code to use/reference the correct Crossref funder id prefix: from 'https://api.crossref.org/funders/' to 'https://doi.org/10.13039/'
- Added v3 migration script that will update the identifier_scheme and fix any existing identifiers in the DB