### PR TITLE
Bug fix for updating identifiers, update fundref DOI base URL and Credit taxonomy base URL

### DIFF
--- a/app/controllers/concerns/org_selectable.rb
+++ b/app/controllers/concerns/org_selectable.rb
@@ -28,7 +28,7 @@
 #      \"name\":\"Portland State University (PDX)\",
 #      \"sort_name\":\"Portland State University\",
 #      \"ror\":\"https://ror.org/00yn2fy02\",
-#      \"fundref\":\"https://api.crossref.org/funders/100007083\"
+#      \"fundref\":\"https://doi.org/10.13039/100007083\"
 #    }
 #  }
 #

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -58,12 +58,12 @@ class Contributor < ApplicationRecord
   validate :name_or_email_presence
 
   ONTOLOGY_NAME = "CRediT - Contributor Roles Taxonomy"
-  ONTOLOGY_LANDING_PAGE = "https://casrai.org/credit/"
-  ONTOLOGY_BASE_URL = "https://dictionary.casrai.org/Contributor_Roles"
+  ONTOLOGY_LANDING_PAGE = "https://credit.niso.org/"
+  ONTOLOGY_BASE_URL = "http://credit.niso.org/contributor-roles/"
 
   ##
   # Define Bit Field values for roles
-  # Derived from the CASRAI CRediT Taxonomy: https://casrai.org/credit/
+  # Derived from the CASRAI CRediT Taxonomy: http://credit.niso.org/contributor-roles/
   has_flags 1 => :data_curation,
             2 => :investigation,
             3 => :project_administration,

--- a/app/models/identifier.rb
+++ b/app/models/identifier.rb
@@ -133,8 +133,8 @@ class Identifier < ApplicationRecord
 
   # Ensure that the identifiable only has one identifier for the scheme
   def value_uniqueness_with_scheme
-    if Identifier.where(identifier_scheme: identifier_scheme,
-                        identifiable: identifiable).any?
+    if new_record? && Identifier.where(identifier_scheme: identifier_scheme,
+                                       identifiable: identifiable).any?
       errors.add(:identifier_scheme, _("already assigned a value"))
     end
   end

--- a/app/presenters/api/v1/contributor_presenter.rb
+++ b/app/presenters/api/v1/contributor_presenter.rb
@@ -12,7 +12,7 @@ module Api
         def role_as_uri(role:)
           return nil unless role.present?
 
-          "#{Contributor::ONTOLOGY_BASE_URL}/#{role.to_s.capitalize}"
+          "#{Contributor::ONTOLOGY_BASE_URL}/#{role.to_s.downcase.gsub('_', '-')}"
         end
 
         def contributor_id(identifiers:)

--- a/app/services/api/v1/deserialization/contributor.rb
+++ b/app/services/api/v1/deserialization/contributor.rb
@@ -13,7 +13,7 @@ module Api
           # Convert the incoming JSON into a Contributor
           #   {
           #     "role": [
-          #       "https://dictionary.casrai.org/Contributor_Roles/Project_administration"
+          #       "http://credit.niso.org/contributor-roles/project-administration"
           #     ],
           #     "name": "Jane Doe",
           #     "mbox": "jane.doe@university.edu",

--- a/app/views/paginable/contributors/_index.html.erb
+++ b/app/views/paginable/contributors/_index.html.erb
@@ -36,11 +36,6 @@
         <td>
           <% if contributor.org.present? %>
             <%= contributor.org&.name %>
-            <% ror = contributor.org.identifier_for_scheme(scheme: ror_scheme) %>
-            <% if ror.present? %>
-              <br/>
-              <%= id_for_display(id: ror) %>
-            <% end %>
           <% end %>
         </td>
         <td><%= ContributorPresenter.display_roles(roles: contributor.selected_roles) %></td>

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -832,7 +832,7 @@ namespace :upgrade do
 
       fundref = IdentifierScheme.find_or_initialize_by(name: "fundref")
       fundref.for_orgs = true
-      fundref.identifier_prefix = "https://api.crossref.org/funders/"
+      fundref.identifier_prefix = "https://doi.org/10.13039/"
       fundref.save
     end
 
@@ -1217,7 +1217,7 @@ namespace :upgrade do
     p "               'University of Somewhere' may match to 'Univerity of Somewhere - Medical Center'"
     p "            To correct any issues, please delete/insert/update the corresponding Identifier:"
     p "               delete from identifiers where identifiable_type = 'Org' and identifiable_id = [orgs.id];"
-    p "               insert into identifiers (identifiable_type, identifier_scheme_id, attrs, identifiable_id, value) values ('Org', [identifier_scheme_id], '{}', [orgs.id], 'https://api.crossref.org/funders/0000000000');"
+    p "               insert into identifiers (identifiable_type, identifier_scheme_id, attrs, identifiable_id, value) values ('Org', [identifier_scheme_id], '{}', [orgs.id], 'https://doi.org/10.13039/0000000000');"
     p "               update identifiers set `value` = 'https://ror.org/123456789' where identifiable_id = [orgs.id] and identifier_scheme_id = [identifier_scheme_id] and identifiable_type= 'Org';"
     p "---------------------------------------------------------------"
   end

--- a/spec/presenters/api/v1/contributor_presenter_spec.rb
+++ b/spec/presenters/api/v1/contributor_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::ContributorPresenter do
     it "returns the correct URI" do
       uri = described_class.role_as_uri(role: "data_curation")
       expect(uri.start_with?("http")).to eql(true)
-      expect(uri.end_with?("Data_curation")).to eql(true)
+      expect(uri.end_with?("data-curation")).to eql(true)
     end
   end
 

--- a/spec/services/api/v1/deserialization/identifier_spec.rb
+++ b/spec/services/api/v1/deserialization/identifier_spec.rb
@@ -96,14 +96,15 @@ RSpec.describe Api::V1::Deserialization::Identifier do
                                       identifiable: @identifiable, json: json)
         expect(result).to eql(nil)
       end
-      it "returns the existing Identifier for the IdentifierScheme" do
+      it "returns the updated Identifier for the IdentifierScheme" do
         identifier = create(:identifier, identifier_scheme: @scheme,
                                          identifiable: @identifiable,
                                          value: Faker::Number.number)
         result = described_class.send(:identifier_for_scheme,
                                       scheme: @scheme,
                                       identifiable: @identifiable, json: @json)
-        validate_identifier(result: result, scheme: @scheme, value: identifier.value)
+        expected = "#{@scheme.identifier_prefix}#{@json[:identifier]}"
+        validate_identifier(result: result, scheme: @scheme, value: expected)
         expect(result.id).to eql(identifier.id)
       end
     end

--- a/spec/support/mocks/api_json_samples.rb
+++ b/spec/support/mocks/api_json_samples.rb
@@ -111,8 +111,8 @@ module Mocks
               },
               "contributor": [{
                 "role": [
-                  "https://dictionary.casrai.org/Contributor_Roles/Project_administration",
-                  "https://dictionary.casrai.org/Contributor_Roles/Investigation"
+                  "http://credit.niso.org/contributor-roles/project-administration",
+                  "http://credit.niso.org/contributor-roles/investigation"
                 ],
                 "name": Faker::Movies::StarWars.character,
                 "mbox": Faker::Internet.email,
@@ -130,7 +130,7 @@ module Mocks
                 }
               }, {
                 "role": [
-                  "https://dictionary.casrai.org/Contributor_Roles/Investigation"
+                  "http://credit.niso.org/contributor-roles/investigation"
                 ],
                 "name": contact[:name],
                 "mbox": contact[:email],

--- a/spec/views/api/v1/contributors/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/contributors/_show.json.jbuilder_spec.rb
@@ -28,7 +28,7 @@ describe "api/v1/contributors/_show.json.jbuilder" do
     end
 
     it "includes the :role" do
-      expect(@json[:role].first.ends_with?("Data_curation")).to eql(true)
+      expect(@json[:role].first.ends_with?("data-curation")).to eql(true)
     end
 
     it "includes :affiliation" do


### PR DESCRIPTION
- Bug fix that was preventing ORCIDs, RORs and Fundrefs from being updated
- Update code to use/reference the correct Crossref funder id prefix: from 'https://api.crossref.org/funders/' to 'https://doi.org/10.13039/'
- Added v3 migration script that will update the identifier_scheme and fix any existing identifiers in the DB
- Discovered today that the Credit URLs we were using are no longer valid. This updates the code to work with the new URL structure.
- Remove ROR link from the affiliation column on the contributors table
