### PR TITLE
Provide admins with a way to regenerate their API token

### DIFF
--- a/app/controllers/super_admin/api_clients_controller.rb
+++ b/app/controllers/super_admin/api_clients_controller.rb
@@ -75,8 +75,10 @@ module SuperAdmin
       @api_client = ApiClient.find(params[:id])
       return unless @api_client.present?
 
+      original = @api_client.client_secret
       @api_client.generate_credentials
       @api_client.save
+      @success = original != @api_client.client_secret
     end
 
     # GET /api_clients/:id/email_credentials/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -162,6 +162,14 @@ class UsersController < ApplicationController
     render body: nil
   end
 
+  # GET /users/:id/refresh_token (accessed via JSON call from profile page)
+  def refresh_token
+    authorize current_user
+    original = current_user.api_token
+    current_user.generate_token!
+    @success = current_user.api_token != original
+  end
+
   private
 
   def permission_params

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -88,3 +88,11 @@ require('@rails/ujs').start();
 // require('turbolinks').start();
 // require("@rails/activestorage").start()
 // require("@rails/actioncable").start()
+
+// Setup JS functions/libraries so that they're available within the js.erb templates
+window.$ = jQuery;
+window.jQuery = jQuery;
+
+import { renderAlert, renderNotice } from '../src/utils/notificationHelper';
+window.renderAlert = renderAlert;
+window.renderNotice = renderNotice;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -94,5 +94,6 @@ window.$ = jQuery;
 window.jQuery = jQuery;
 
 import { renderAlert, renderNotice } from '../src/utils/notificationHelper';
+
 window.renderAlert = renderAlert;
 window.renderNotice = renderNotice;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -34,6 +34,10 @@ import '../src/utils/requiredField';
 import '../src/utils/tabHelper';
 import '../src/utils/tooltipHelper';
 
+// Specific functions from the Utilities files that will be made available to
+// the js.erb templates in the `window.x` statements below
+import { renderAlert, renderNotice } from '../src/utils/notificationHelper';
+
 // View specific JS
 import '../src/answers/conditions';
 import '../src/answers/edit';
@@ -93,7 +97,6 @@ require('@rails/ujs').start();
 window.$ = jQuery;
 window.jQuery = jQuery;
 
-import { renderAlert, renderNotice } from '../src/utils/notificationHelper';
-
+// Allow js.erb files to access the notificationHelper functions
 window.renderAlert = renderAlert;
 window.renderNotice = renderNotice;

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -226,7 +226,7 @@ class UserMailer < ActionMailer::Base
     @api_client = api_client
     return unless @api_client.contact_email.present?
 
-    @api_docs = Rails.configuration.x.application.api_documentation_url
+    @api_docs = Rails.configuration.x.application.api_documentation_urls[:v1]
 
     @name = @api_client.contact_name.present? ? @api_client.contact_name : @api_client.contact_email
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -337,8 +337,13 @@ class User < ApplicationRecord
   def keep_or_generate_token!
     return unless api_token.nil? || api_token.empty?
 
+    generate_token! unless new_record?
+  end
+
+  # Generates a new token
+  def generate_token!
     new_token = User.unique_random(field_name: "api_token")
-    update_column(:api_token, new_token) unless new_record?
+    update_column(:api_token, new_token)
   end
 
   # The User's preferences for a given base key

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -59,6 +59,10 @@ class UserPolicy < ApplicationPolicy
     true
   end
 
+  def refresh_token?
+    true
+  end
+
   def merge?
     signed_in_user.can_super_admin?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -60,7 +60,8 @@ class UserPolicy < ApplicationPolicy
   end
 
   def refresh_token?
-    true
+    signed_in_user.can_super_admin? ||
+      (signed_in_user.can_org_admin? && signed_in_user.can_use_api?)
   end
 
   def merge?

--- a/app/views/devise/registrations/_api_token.html.erb
+++ b/app/views/devise/registrations/_api_token.html.erb
@@ -1,0 +1,25 @@
+<%# locals: user %>
+
+<% api_wikis = Rails.configuration.x.application.api_documentation_urls %>
+<div id="api-token" class="col-xs-12">
+  <div class="form-group col-xs-8">
+    <%= label_tag(:api_token, _('Access token'), class: 'control-label') %>
+    <% if user.api_token.present? %>
+      <%= user.api_token %>
+    <% else %>
+      <%= _("Click the button below to generate an API token") %>
+    <% end %>
+  </div>
+  <div class="form-group col-xs-12">
+    <%= label_tag(:api_information, _('Documentation'), class: 'control-label') %>
+    <br>
+    <%= _('See the <a href="%{api_v0_wiki}">documentation for v0</a> for more details on the original API which includes access to statistics, the full text of plans and the ability to connect users with departments.').html_safe % { api_v0_wiki: api_wikis[:v0] } %></a>
+    <br><br>
+    <%= _('See the <a href="%{api_v1_wiki}">documentation for v1</a> for more details on the API that supports the <a href="%{rda_standard_url}">RDA Common metadata standard for DMPs.</a>').html_safe % { api_v1_wiki: api_wikis[:v1], rda_standard_url: 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard' } %></a>
+  </div>
+  <div class="form-group col-xs-8">
+    <%= link_to _("Regenerate token"),
+                refresh_token_user_path(user),
+                class: "btn btn-default", remote: true %>
+  </div>
+</div>

--- a/app/views/devise/registrations/_personal_details.html.erb
+++ b/app/views/devise/registrations/_personal_details.html.erb
@@ -85,17 +85,6 @@
     </div>
   <% end %>
 
-  <% unless @user.api_token.blank? %>
-    <div class="form-group col-xs-8">
-      <%= f.label(:api_token, _('API token'), class: 'control-label') %>
-      <%= @user.api_token %>
-    </div>
-    <div class="form-group col-xs-8">
-      <%= label_tag(:api_information, _('API Information'), class: 'control-label') %>
-      <a href="https://github.com/DMPRoadmap/roadmap/wiki/API-V0-Documentation"><%= _('How to use the API') %></a>
-    </div>
-  <% end %>
-
   <div class="form-group col-xs-8">
     <%= f.button(_('Save'), class: 'btn btn-default', type: "submit", id: "personal_details_registration_form_submit") %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,6 +16,12 @@
           <a href="#password-details" role="tab" class="nav-link"
              aria-controls="password-details" data-toggle="tab"><%= _('Password') %></a>
         </li>
+        <% if @user.can_org_admin? %>
+          <li role="api-details" class="nav-item">
+            <a href="#api-details" role="tab" class="nav-link"
+               aria-controls="api-details" data-toggle="tab"><%= _('API Access') %></a>
+          </li>
+        <% end %>
         <li role="notification-preferences" class="nav-item">
           <a href="#notification-preferences" role="tab" class="nav-link"
              aria-controls="notification-preferences" data-toggle="tab"><%= _('Notification Preferences') %></a>
@@ -37,6 +43,15 @@
             </div>
           </div>
         </div>
+        <% if @user.can_org_admin? %>
+          <div id="api-details" role="tabpanel" class="tab-pane">
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <%= render partial: 'devise/registrations/api_token', locals: { user: @user } %>
+              </div>
+            </div>
+          </div>
+        <% end %>
         <div id="notification-preferences" role="tabpanel" class="tab-pane">
           <div class="panel panel-default">
             <div class="panel-body">

--- a/app/views/super_admin/api_clients/email_credentials.js.erb
+++ b/app/views/super_admin/api_clients/email_credentials.js.erb
@@ -1,6 +1,2 @@
 var msg = '<%= _("The credentials have been sent to %{email}.") % { email: @api_client.contact_email } %>';
-
-<%# TODO: replace this with the notificationHelper.js once we move to Rails 5 %>
-var notification = document.getElementById("notification-area");
-notification.append(msg);
-notification.classList.remove('hide');
+renderNotice(msg);

--- a/app/views/super_admin/api_clients/refresh_credentials.js.erb
+++ b/app/views/super_admin/api_clients/refresh_credentials.js.erb
@@ -1,9 +1,5 @@
-var msg = '<%= _("Successsfully refreshed the client credentials.") %>';
+var msg = '<%= @success ? _("Successfully regenerated the client credentials.") : _("Unable to regenerate the client credentials.") %>';
 
-var form = document.getElementById("edit_api_client_<%= @api_client.id %>");
-form.innerHTML = '<%= escape_javascript(render partial: "/super_admin/api_clients/form") %>';
-
-<%# TODO: replace this with the notificationHelper.js once we move to Rails 5 %>
-var notification = document.getElementById("notification-area");
-notification.append(msg);
-notification.classList.remove('hide');
+var context = $('#edit_api_client_<%= @api_client.id %>');
+context.html('<%= escape_javascript(render partial: "/super_admin/api_clients/form") %>');
+renderNotice(msg);

--- a/app/views/users/refresh_token.js.erb
+++ b/app/views/users/refresh_token.js.erb
@@ -1,4 +1,4 @@
-var msg = '<%= @success ? _("Successsfully regenerate your API token.") : _("Unable to regenerate your API token.") %>';
+var msg = '<%= @success ? _("Successfully regenerate your API token.") : _("Unable to regenerate your API token.") %>';
 
 var context = $('#api-token');
 context.html('<%= escape_javascript(render partial: "/devise/registrations/api_token", locals: { user: current_user }) %>');

--- a/app/views/users/refresh_token.js.erb
+++ b/app/views/users/refresh_token.js.erb
@@ -1,0 +1,5 @@
+var msg = '<%= @success ? _("Successsfully regenerate your API token.") : _("Unable to regenerate your API token.") %>';
+
+var context = $('#api-token');
+context.html('<%= escape_javascript(render partial: "/devise/registrations/api_token", locals: { user: current_user }) %>');
+renderNotice(msg);

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -75,7 +75,10 @@ module DMPRoadmap
     # The largest page size allowed in requests to the API (all versions)
     config.x.application.api_max_page_size = 100
     # The link to the API documentation - used in emails about the API
-    config.x.application.api_documentation_url = "https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation"
+    config.x.application.api_documentation_urls = {
+      v0: "https://github.com/DMPRoadmap/roadmap/wiki/API-V0-Documentation",
+      v1: "https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation-V1"
+    }
     # The links that appear on the home page. Add any number of links
     config.x.application.welcome_links = [
       {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
 
     member do
       put "update_email_preferences"
+      get "refresh_token"
     end
 
     post "/acknowledge_notification", to: "users#acknowledge_notification"


### PR DESCRIPTION
Fixes #2410 .

Added ability for user to regenerate their own API token (or create one if it was not initialized for some reason when they became an Org admin). Also updated the application.js to make jQuery and the notificationHelper functions available within the js.erb files.

Changes proposed in this PR:
- Move API token and link to wiki documentation to its own tab on Edit Profile page
- Update initializer to provide both v0 and v1 API urls
- Add a 'Regenerate token' button to new tab and brief explanation of v0 and v1 with links to their wiki pages
- Add route, controller and js.erb to regerate the user's token
- Update User model to separate out the create token functionality from the create_or_update method
- Update the application.js to make jQuery and the renderNotice and renderAlert helper functions available to the js.erb files
- Update api_client credentials mailer to use updated initializer values
- Update the refresh api client credentials js.erb
