### PR TITLE
Update google analytics config

### DIFF
--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -192,7 +192,7 @@ module DMPRoadmap
     # Google Analytics #
     # ---------------- #
     # this is the abbreviation for the installation's root org as set in the org table
-    config.x.tracker_root = ""
+    config.x.google_analytics.tracker_root = ""
 
     # ------------------------------------------------------------------------ #
     # reCAPTCHA - recaptcha appears on the create account and contact us forms #


### PR DESCRIPTION
Forgot to mention this one in our meeting today. The `config/initializers/_dmproadmap.rb` file has the Google Analytics tracker variable as: `config.x.tracker_root = ""` but it is referenced as `Rails.configuration.x.google_analytics.tracker_root` in the code.

Just updating the example in this PR to add the missing `google_analytics` namespace. Be sure to check your deployments to make sure they are using the correct name.
