### PR TITLE
Fix for Org selection dropdowns

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -143,7 +143,7 @@ class OrgsController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   # POST /orgs  (via AJAX from Org Typeaheads ... see below for specific pages)
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def search
     args = search_params
     # If the search term is greater than 2 characters
@@ -204,8 +204,7 @@ class OrgsController < ApplicationController
       render json: []
     end
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   private
 

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -148,7 +148,7 @@ class OrgsController < ApplicationController
     args = search_params
     # If the search term is greater than 2 characters
     if args.present? && args.fetch(:name, "").length > 2
-      type = args.fetch(:type, "local")
+      type = params.fetch(:type, "local")
 
       # If we are including external API results
       orgs = case type
@@ -192,7 +192,7 @@ class OrgsController < ApplicationController
 
       # If we need to restrict the results to funding orgs then
       # only return the ones with a valid fundref
-      if orgs.present? && args.fetch(:funder_only, "false") == true
+      if orgs.present? && params.fetch(:funder_only, "false") == true
         orgs = orgs.select do |org|
           org[:fundref].present? && !org[:fundref].blank?
         end

--- a/spec/controllers/orgs_controller_spec.rb
+++ b/spec/controllers/orgs_controller_spec.rb
@@ -174,13 +174,13 @@ RSpec.describe OrgsController, type: :controller do
 
     it "calls search_externally when query string contains type=external" do
       OrgSelection::SearchService.expects(:search_externally).at_least(1)
-      post :search, params: { org: { name: Faker::Lorem.sentence, type: "external" } },
+      post :search, params: { org: { name: Faker::Lorem.sentence }, type: "external" },
                     format: :js
     end
 
     it "calls search_combined when query string contains type=combined" do
       OrgSelection::SearchService.expects(:search_combined).at_least(1)
-      post :search, params: { org: { name: Faker::Lorem.sentence, type: "combined" } },
+      post :search, params: { org: { name: Faker::Lorem.sentence }, type: "combined" },
                     format: :js
     end
   end


### PR DESCRIPTION
Fixes #2746.

Changes proposed in this PR:
- Update controller to fetch the `funder_only` and `type` parameters from `params` instead of the Strong params that are encapsulating the search term/org name
- Update tests to mimic reality
