### PR TITLE
Bugfix for issue with setting plan visibility

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -142,9 +142,11 @@ class Answer < ApplicationRecord
     # Remove guard? this is an after-save so unreachable if there is no plan
     return unless plan_id?
 
-    complete = plan.no_questions_matches_no_answers?
-    if plan.complete != complete
-      plan.update!(complete: complete)
+    # Retrieve the percentage of answered questions that determines if a plan can
+    # be considered complete. If this answer completes the plan then update the Plan
+    target_percentage = Rails.configuration.x.plans.default_percentage_answered || 50.0
+    if plan.percent_answered > target_percentage && !plan.complete
+      plan.update!(complete: true)
     else
       # Force updated_at changes if nothing changed since save only saves if changes
       # were made to the record

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -536,12 +536,12 @@ class Plan < ApplicationRecord
     Plan.joins(:questions).exists?(id: id, "questions.id": question_id)
   end
 
-  # Checks whether or not the number of questions matches the number of valid
-  # answers
+  # Determines what percentage of the Plan's questions have been num_answered_questions
   #
-  # Returns Boolean
-  def no_questions_matches_no_answers?
+  def percent_answered
     num_questions = question_ids.length
+    return false unless num_questions.positive?
+
     pre_fetched_answers = Answer.includes(:question_options,
                                           question: :question_format)
                                 .where(id: answer_ids)
@@ -549,7 +549,9 @@ class Plan < ApplicationRecord
       m += 1 if a.answered?
       m
     end
-    num_questions == num_answers
+    return 0 unless num_answers.positive?
+
+    (num_answers / num_questions.to_f) * 100
   end
 
   # Deactivates the plan (sets all roles to inactive and visibility to :private)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -540,7 +540,7 @@ class Plan < ApplicationRecord
   #
   def percent_answered
     num_questions = question_ids.length
-    return false unless num_questions.positive?
+    return 0 unless num_questions.positive?
 
     pre_fetched_answers = Answer.includes(:question_options,
                                           question: :question_format)

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1356,7 +1356,7 @@ describe Plan do
     end
 
     it "returns the percentage of questions with valid answers" do
-      expect(subject).to eql(50.0)
+      expect(subject.to_i).to eql(33)
     end
 
   end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1333,13 +1333,13 @@ describe Plan do
     end
   end
 
-  describe "#num_answered_questions" do
+  describe "#percent_answered" do
 
     let!(:template) { create(:template) }
 
     let!(:plan) { create(:plan, :creator, template: template) }
 
-    subject { plan.num_answered_questions }
+    subject { plan.percent_answered }
 
     before do
       @phase     = create(:phase, template: template)
@@ -1355,7 +1355,7 @@ describe Plan do
       end
     end
 
-    it "returns the number of questions with valid answers" do
+    it "returns the percentage of questions with valid answers" do
       expect(subject).to eql(2)
     end
 
@@ -1449,39 +1449,45 @@ describe Plan do
 
   end
 
-  describe "#no_questions_matches_no_answers?" do
+  describe "#percent_answered" do
 
-    let!(:plan) { create(:plan, :creator) }
+    let!(:template) { create(:template, phases: 1, sections: 1, questions: 1) }
+    
+    let!(:plan) { create(:plan, :creator, template: template) }
 
-    subject { plan.no_questions_matches_no_answers? }
+    subject { plan.percent_answered }
 
     context "when has no answers" do
 
-      it { is_expected.to eql(true) }
+      it { is_expected.to eql(0) }
 
     end
 
     context "when has answers that are not valid" do
 
-      let!(:question) { create(:question, :textarea) }
+      let!(:question) do
+        create(:question, :textarea, section: template.phases.first.sections.first)
+      end
 
       before do
         create_list(:answer, 1, text: "", plan: plan, question: question)
       end
 
-      it { is_expected.to eql(true) }
+      it { is_expected.to eql(0) }
 
     end
 
     context "when has answers that are valid" do
 
-      let!(:question) { create(:question, :textarea) }
-
-      before do
-        create_list(:answer, 1, plan: plan, question: question)
+      let!(:question) do
+        create(:question, :textarea, section: template.phases.first.sections.first)
       end
 
-      it { is_expected.to eql(false) }
+      before do
+        create_list(:answer, 1, plan: plan, question: question, text: Faker::Lorem.paragraph)
+      end
+
+      it { is_expected.to eql(50.0) }
 
     end
   end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1452,7 +1452,7 @@ describe Plan do
   describe "#percent_answered" do
 
     let!(:template) { create(:template, phases: 1, sections: 1, questions: 1) }
-    
+
     let!(:plan) { create(:plan, :creator, template: template) }
 
     subject { plan.percent_answered }

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -1345,8 +1345,8 @@ describe Plan do
       @phase     = create(:phase, template: template)
       @section   = create(:section, phase: @phase)
       @questions = create_list(:question, 3, :textarea, section: @section)
-      # 2 valid answers
-      @questions.first(2).each do |question|
+      # 1 valid answers
+      @questions.first(1).each do |question|
         create(:answer, question: question, plan: plan)
       end
       # 1 valid answers
@@ -1356,7 +1356,7 @@ describe Plan do
     end
 
     it "returns the percentage of questions with valid answers" do
-      expect(subject).to eql(2)
+      expect(subject).to eql(50.0)
     end
 
   end


### PR DESCRIPTION
Fixes #2745.

Changes proposed in this PR:
- Replaced old `no_questions_matches_no_answers?` with `percent_answered` on the Plan model which returns the percentage of answered questions rather than a boolean which was doing an equality check between questions and answers
- Updated the Answer model to use the new `percent_answered` method and then compare the returned percentage to the one defined in `config/initializers/_dmproadmap.rb`
- Updated tests
