### PR TITLE
convert api_clients:last_access from date to datetime

### DIFF
--- a/db/migrate/20201216140226_change_last_access_api_clients.rb
+++ b/db/migrate/20201216140226_change_last_access_api_clients.rb
@@ -1,0 +1,5 @@
+class ChangeLastAccessApiClients < ActiveRecord::Migration[5.2]
+  def change
+    change_column :api_clients, :last_access, :datetime
+  end
+end


### PR DESCRIPTION
Fixes #2742 

I did not include the resulting `db/schema.rb` in this PR,
as it accidentally includes other tables as well that I happen
to have in my database. Not sure if that file is even necessary.

Previous entries in `last_access` now have zero time appended to the date.
