### PR TITLE
disable recaptcha on contact-us page when disabled in configuration

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -5,7 +5,7 @@ class ContactUs::ContactsController < ApplicationController
   def create
     @contact = ContactUs::Contact.new(params[:contact_us_contact])
 
-    unless user_signed_in?
+    if !user_signed_in? && Rails.configuration.x.recaptcha.enabled
       unless verify_recaptcha(model: @contact) && @contact.save
         flash[:alert] = _("Captcha verification failed, please retry.")
         render_new_page and return

--- a/app/views/contact_us/contacts/_new_left.html.erb
+++ b/app/views/contact_us/contacts/_new_left.html.erb
@@ -33,8 +33,8 @@
             rows: 10,
             "aria-required": true) %>
     </div>
-<% if !user_signed_in? then %>
-    <div class="form-group"><!-- FIX first https://github.com/DMPRoadmap/roadmap/issues/501 !-->
+<% if !user_signed_in? && Rails.configuration.x.recaptcha.enabled then %>
+    <div class="form-group">
         <%= label_tag(nil, _('Security check')) %>
         <%= recaptcha_tags %>
     </div>


### PR DESCRIPTION
Changes proposed in this PR:
- disable recaptcha in contact-us page when `Rails.configuration.x.recaptcha.enabled` is set to `false`

See also #501