### PR TITLE
Convert api_clients:last_access from date to datetime

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_19_210343) do
+ActiveRecord::Schema.define(version: 2020_12_16_140226) do
 
   create_table "annotations", id: :integer, force: :cascade do |t|
     t.integer "question_id"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2020_11_19_210343) do
     t.string "contact_email", null: false
     t.string "client_id", null: false
     t.string "client_secret", null: false
-    t.date "last_access"
+    t.datetime "last_access"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "org_id"


### PR DESCRIPTION
New PR replacing #2764 that includes updates to schema.rb file.

Changes proposed in this PR:
- Convert the `api_clients.last_access` from a Data to DateTime
