### PR TITLE
Bug fix - issue with api v0 plans' index endpoint having an undefined method

### DIFF
--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -2,6 +2,8 @@
 
 class Api::V0::PlansController < Api::V0::BaseController
 
+  include Paginable
+
   before_action :authenticate
 
   ##
@@ -92,7 +94,8 @@ class Api::V0::PlansController < Api::V0::BaseController
     plan_ids = extract_param_list(params, "plan")
     @plans = @plans.where(id: plan_ids) if plan_ids.present?
     # apply pagination after filtering
-    @plans = paginate @plans
+    @args = { per_page: params[:per_page], page: params[:page] }
+    @plans = refine_query(@plans)
     respond_with @plans
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/views/api/v0/plans/index.json.jbuilder
+++ b/app/views/api/v0/plans/index.json.jbuilder
@@ -31,7 +31,7 @@ json.array! @plans.each do |plan|
     data_contact = plan.contributors.data_curation.first
     json.name         data_contact.name
     json.email        data_contact.email
-    json.phone        data_contact.phones
+    json.phone        data_contact.phone
   end
   json.users plan.roles.each do |role|
     json.email role.user.email


### PR DESCRIPTION
Fixes #2776.

Changes proposed in this PR:
- `api/v0/plans` was returning a 500 error due to an undefined `paginate` method. Updated controller to use the Paginable concern's `refine_query` method.
