### PR TITLE
fixes issue with sorts for tables with multiple words in their name

### DIFF
--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -134,7 +134,7 @@ module Paginable
       # exist, ambiguity on column, etc)
       # how we contruct scope depends on whether sort field is in the
       # main table or in a related table
-      scope_table = scope.klass.name.downcase
+      scope_table = scope.klass.name.underscore
       parts = @args[:sort_field].partition(".")
       table_part = parts.first
       column_part = parts.last


### PR DESCRIPTION
Adjustment to PR #2786.

The change to the paginable sort concern will not work for model names that consist of multiple words. Discovered this while testing the fix against a new model called ResearchOutput. The `class.name.downcase` was turning this into `researchoutput` and trying to us it in the query. It should be `research_output` instead. 