### PR TITLE
Patch for project details page

### DIFF
--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<% partial = @plan.editable_by?(current_user) ? "edit_details" : "show_details" %>
+<% partial = @plan.editable_by?(current_user.id) ? "edit_details" : "show_details" %>
 
 <div class="row">
   <div class="col-md-12">


### PR DESCRIPTION
The changes made to pass `current_user.id` instead of `current_user` to the `administerable_by` and `editable_by` methods did not include the project details page. 