### PR TITLE
Bumped mimemagic dependency to deal with license compatibility issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,12 @@ ruby ">= 2.6.3"
 # Full-stack web application framework. (http://rubyonrails.org)
 gem "rails", "~> 5.2"
 
+# TODO: Remove this once Rails addresses the issue with its dependency on mimemagic. Mimemagic had
+#       an MIT license but was using some incompatible GPL license code.
+#       Versions of mimemagic that were yanked: https://rubygems.org/gems/mimemagic/versions
+#       Analysis of the issue: https://www.theregister.com/2021/03/25/ruby_rails_code/
+gem "mimemagic", "~> 0.3.7"
+
 # Use sqlite3 as the database for Active Record
 # gem 'sqlite3', '~> 1.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,7 +227,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -511,6 +513,7 @@ DEPENDENCIES
   kaminari
   ledermann-rails-settings
   listen
+  mimemagic (~> 0.3.7)
   mocha
   mysql2
   omniauth


### PR DESCRIPTION
Fixes #2842.

Mimemagic discovered a license compatibility issue with it's pre-3.7 releases and yanked them from the Rubygems repository: https://rubygems.org/gems/mimemagic/versions

The Rails team is working on a fix for this (possibly changing to a different dependency). It is used by ActiveStorage (through the Marcel gem) which is not in use in the DMPRoadmap codebase so there should be little impact. 

Changes proposed in this PR:
- Specify the version of mimemagic in the Gemfile to a compatible version. We should remove this from the Gemfile once Rails has addressed the issue
