### PR TITLE
Org selector refactor

### DIFF
--- a/app/controllers/concerns/org_selectable.rb
+++ b/app/controllers/concerns/org_selectable.rb
@@ -59,7 +59,6 @@ module OrgSelectable
 
   # rubocop:disable Metrics/BlockLength
   included do
-
     before_action :prep_org_partial
 
     private

--- a/app/controllers/concerns/org_selectable.rb
+++ b/app/controllers/concerns/org_selectable.rb
@@ -59,6 +59,9 @@ module OrgSelectable
 
   # rubocop:disable Metrics/BlockLength
   included do
+
+    before_action :prep_org_partial
+
     private
 
     # Converts the incoming params_into an Org by either locating it
@@ -120,6 +123,12 @@ module OrgSelectable
         identifier.save
       end
       org.reload
+    end
+
+    def prep_org_partial
+      name = Rails.configuration.x.application.restrict_orgs ? "local_only" : "combined"
+      @org_partial = "shared/org_selectors/#{name}"
+      @all_orgs = Org.includes(identifiers: [:identifier_scheme]).all
     end
   end
   # rubocop:enable Metrics/BlockLength

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -25,14 +25,6 @@ class ContributorsController < ApplicationController
   # GET /plans/:plan_id/contributors/:id/edit
   def edit
     authorize @plan
-    @all_orgs = Org.all
-
-    # choose which org partial to use for choosing org
-    @org_partial = if Rails.configuration.x.application.restrict_orgs
-                     "shared/org_selectors/local_only"
-                   else
-                     "shared/org_selectors/combined"
-                   end
   end
 
   # POST /plans/:plan_id/contributors

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,8 @@
 
 class HomeController < ApplicationController
 
+  include OrgSelectable
+
   respond_to :html
 
   ##
@@ -12,15 +14,6 @@ class HomeController < ApplicationController
   # User's contact name is not filled in
   # Is this the desired behavior?
   def index
-    @all_orgs = Org.all
-
-    # choose which org patial to use for choosing org
-    @org_partial = if Rails.configuration.x.application.restrict_orgs
-                     "shared/org_selectors/local_only"
-                   else
-                     "shared/org_selectors/combined"
-                   end
-
     if user_signed_in?
       name = current_user.name(false)
       # The RolesController defaults the firstname and surname (both required fields)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -209,15 +209,6 @@ class PlansController < ApplicationController
                   Template.where(family_id: @plan.template.customization_of).first
                 end
 
-    @all_orgs = Org.all
-
-    # choose which org patial to use for choosing org
-    @org_partial = if Rails.configuration.x.application.restrict_orgs
-                     "shared/org_selectors/local_only"
-                   else
-                     "shared/org_selectors/combined"
-                   end
-
     respond_to :html
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -13,13 +13,6 @@ class RegistrationsController < Devise::RegistrationsController
     @identifier_schemes = IdentifierScheme.for_users.order(:name)
     @default_org = current_user.org
 
-    # choose which org patial to use for choosing org
-    @org_partial = if Rails.configuration.x.application.restrict_orgs
-                     "shared/org_selectors/local_only"
-                   else
-                     "shared/org_selectors/combined"
-                   end
-
     msg = "No default preferences found (should be in dmproadmap.rb initializer)."
     flash[:alert] = msg unless @prefs
   end
@@ -248,11 +241,6 @@ class RegistrationsController < Devise::RegistrationsController
     else
       flash[:alert] = message.blank? ? failure_message(current_user, _("save")) : message
       @orgs = Org.order("name")
-      @org_partial = if Rails.configuration.x.application.restrict_orgs
-                       "shared/org_selectors/local_only"
-                     else
-                       "shared/org_selectors/combined"
-                     end
       render "edit"
     end
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -8,28 +8,6 @@ class Users::InvitationsController < Devise::InvitationsController
   # to the Org after Devise does its thing
   prepend_after_action :handle_org, only: [:update]
 
-  def edit
-    @all_orgs = Org.all
-    # choose which org patial to use for choosing org
-    @org_partial = if Rails.configuration.x.application.restrict_orgs
-                     "shared/org_selectors/local_only"
-                   else
-                     "shared/org_selectors/combined"
-                   end
-    super
-  end
-
-  def update
-    @all_orgs = Org.all
-    # choose which org patial to use for choosing org
-    @org_partial = if Rails.configuration.x.application.restrict_orgs
-                     "shared/org_selectors/local_only"
-                   else
-                     "shared/org_selectors/combined"
-                   end
-    super
-  end
-
   protected
 
   # Override require_no_authentication method defined at DeviseController

--- a/app/services/external_apis/base_service.rb
+++ b/app/services/external_apis/base_service.rb
@@ -87,7 +87,7 @@ module ExternalApis
 
       # Retrieves the helpdesk email from dmproadmap.rb initializer or uses the contact page url
       def app_email
-        dflt = Rails.application.routes.url_helpers.contact_us_url || ''
+        dflt = Rails.application.routes.url_helpers.contact_us_url || ""
         Rails.configuration.x.organisation.fetch(:helpdesk_email, dflt)
       end
 

--- a/app/services/external_apis/base_service.rb
+++ b/app/services/external_apis/base_service.rb
@@ -87,7 +87,7 @@ module ExternalApis
 
       # Retrieves the helpdesk email from dmproadmap.rb initializer or uses the contact page url
       def app_email
-        dflt = Rails.application.routes.url_helpers.contact_us_url
+        dflt = Rails.application.routes.url_helpers.contact_us_url || ''
         Rails.configuration.x.organisation.fetch(:helpdesk_email, dflt)
       end
 

--- a/app/views/contributors/new.html.erb
+++ b/app/views/contributors/new.html.erb
@@ -17,7 +17,7 @@
     <div class="col-md-12">
       <%= form_for @contributor, url: plan_contributors_path do |f| %>
         <%= render partial: "contributors/form",
-                   locals: { form: f, plan: @plan, contributor: @contributor } %>
+                   locals: { form: f, plan: @plan, contributor: @contributor, orgs: @orgs, org_partial: @org_partial } %>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/_signin_signout.html.erb
+++ b/app/views/layouts/_signin_signout.html.erb
@@ -36,7 +36,7 @@
 <% else %>
   <% if !active_page?(root_path, true) %>
     <li>
-      <a href="#header-signin" data-toggle="modal" data-target="#header-signin">
+      <a href="<%= root_path %>">
         <i class="fas fa-sign-in" aria-hidden="true">&nbsp;</i>
         <%= _('Sign in') %>
       </a>


### PR DESCRIPTION
@raycarrick-ed I noticed that the 'Add contributor' page was failing because it was not setting the `org_partial`. I also noticed that the 'Sign in' menu was still trying to open the modal sign in/create account form that you removed.

This PR refactors those recent changes a bit.
- Move setting of `@all_orgs` and `@org_partial` to the OrgSelectable concern which sets them in a `before_action` hook
- Update 'Sign in' link in nav menu to send user to the `root_path` instead of trying to open the modal popup that was removed