### PR TITLE
plan/edit: produce less queries

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -228,7 +228,16 @@ class PlansController < ApplicationController
   #       doing this when we refactor the Plan editing UI
   # GET /plans/:plan_id/phases/:id/edit
   def edit
-    plan = Plan.includes({ template: { phases: { sections: :questions } } }, { answers: :notes })
+    plan = Plan.includes(
+      { template: {
+        phases: {
+          sections: {
+            questions: %i[question_format question_options annotations themes]
+          }
+        }
+      } },
+      { answers: :notes }
+    )
                .find(params[:id])
     authorize plan
     phase_id = params[:phase_id].to_i

--- a/app/helpers/conditions_helper.rb
+++ b/app/helpers/conditions_helper.rb
@@ -71,9 +71,9 @@ module ConditionsHelper
     count = 0
     plan_remove_list = remove_list(plan)
     plan.answers.each do |answer|
-      next unless answer.question.section.id == section.id &&
-                  !plan_remove_list.include?(answer.question.id) &&
-                  section.answered_questions(plan).include?(answer) &&
+      next unless answer.question.section_id == section.id &&
+                  !plan_remove_list.include?(answer.question_id) &&
+                  section.question_ids.include?(answer.question_id) &&
                   answer.answered?
 
       count += 1
@@ -82,28 +82,27 @@ module ConditionsHelper
   end
 
   # number of questions in a section after update with conditions
-  # rubocop:disable Metrics/AbcSize
   def num_section_questions(plan, section, phase = nil)
     # when section and phase are a hash in exports
     if section.is_a?(Hash) &&
        !phase.nil? &&
        plan.is_a?(Plan)
-      phase_id = plan.phases.select { |ph| ph.number == phase[:number] }.first.id
-      section = plan.sections
-                    .select { |s| s.phase_id == phase_id && s.title == section[:title] }
-                    .first
+
+      phase = plan.template
+                  .phases
+                  .select { |ph| ph.number == phase[:number] }
+                  .first
+      section = phase.sections
+                     .select { |s| s.phase_id == phase.id && s.title == section[:title] }
+                     .first
     end
     count = 0
     plan_remove_list = remove_list(plan)
-    plan.questions.each do |question|
-      if question.section.id == section.id &&
-         !plan_remove_list.include?(question.id)
-        count += 1
-      end
+    section.questions.each do |question|
+      count += 1 unless plan_remove_list.include?(question.id)
     end
     count
   end
-  # rubocop:enable Metrics/AbcSize
 
   # returns an array of hashes of section_id, number of section questions, and
   # number of section answers

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -168,8 +168,8 @@ class Question < ApplicationRecord
   def example_answers(org_ids)
     org_ids = Array(org_ids)
     annotations.select { |a| org_ids.include?(a.org_id) }
-               .select { |a| a.example_answer? }
-               .sort   { |a, b| a.created_at <=> b.created_at }
+               .select(&:example_answer?)
+               .sort { |a, b| a.created_at <=> b.created_at }
   end
 
   alias get_example_answers example_answers
@@ -185,7 +185,7 @@ class Question < ApplicationRecord
   # Returns Annotation
   def guidance_annotation(org_id)
     annotations.select { |a| a.org_id == org_id }
-               .select { |a| a.guidance? }
+               .select(&:guidance?)
                .first
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -168,7 +168,7 @@ class Question < ApplicationRecord
   def example_answers(org_ids)
     org_ids = Array(org_ids)
     annotations.select { |a| org_ids.include?(a.org_id) }
-               .select { |a| a.type == Annotation.types[:example_answer] }
+               .select { |a| a.example_answer? }
                .sort   { |a, b| a.created_at <=> b.created_at }
   end
 
@@ -185,7 +185,7 @@ class Question < ApplicationRecord
   # Returns Annotation
   def guidance_annotation(org_id)
     annotations.select { |a| a.org_id == org_id }
-               .select { |a| a.type == Annotation.types[:guidance] }
+               .select { |a| a.guidance? }
                .first
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -166,9 +166,10 @@ class Question < ApplicationRecord
   #
   # Returns ActiveRecord::Relation
   def example_answers(org_ids)
-    annotations.where(org_id: Array(org_ids),
-                      type: Annotation.types[:example_answer])
-               .order(:created_at)
+    org_ids = Array(org_ids)
+    annotations.select { |a| org_ids.include?(a.org_id) }
+               .select { |a| a.type == Annotation.types[:example_answer] }
+               .sort   { |a, b| a.created_at <=> b.created_at }
   end
 
   alias get_example_answers example_answers
@@ -183,7 +184,9 @@ class Question < ApplicationRecord
   #
   # Returns Annotation
   def guidance_annotation(org_id)
-    annotations.where(org_id: org_id, type: Annotation.types[:guidance]).first
+    annotations.select { |a| a.org_id == org_id }
+               .select { |a| a.type == Annotation.types[:guidance] }
+               .first
   end
 
   alias get_guidance_annotation guidance_annotation

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -113,8 +113,8 @@ class Section < ApplicationRecord
   def answered_questions(plan)
     return [] if plan.nil?
 
-    plan.answers.includes({ question: :question_format }, :question_options)
-        .where(question_id: question_ids)
+    plan.answers
+        .select { |answer| question_ids.include?(answer.question_id) }
         .to_a
   end
 

--- a/app/presenters/guidance_presenter.rb
+++ b/app/presenters/guidance_presenter.rb
@@ -113,9 +113,9 @@ class GuidancePresenter
   # structure:
   # { guidance_group: { theme: [guidance, ...], ... }, ... }
   def guidance_groups_by_theme(org: nil, question: nil)
-    raise ArgumentError unless question.respond_to?(:themes)
+    raise ArgumentError unless question.is_a?(Question)
+    raise ArgumentError unless org.is_a?(Org)
 
-    question = Question.includes(:themes).find(question.id)
     return {} unless hashified_guidance_groups.key?(org)
 
     hashified_guidance_groups[org].each_key.each_with_object({}) do |gg, acc|


### PR DESCRIPTION
Changes proposed in this PR:
- add relations `question_format question_options annotations themes` to list of `include` in `PlansController`
- remove `include` in `Section#answered_questions`, because already done by `PlansController` and because it breaks the chain of relations
- replace `where` and `order` by `select` and `sort` in model `Question` because it reexecutes the queries instead of using the relations
- Optimize `GuidancePresenter#guidance_groups_by_theme`
- Optimize `ConditionsHelper`

You should see less queries in the log when opening the tab "Write plan"

P.S. Is `ConditionsHelper#num_section_questions` still expected to receive `section` and `phase` as hashes, or is this kept for backward compatibility for those who are branding their views?
