### PR TITLE
redirect to edit page of notification after successfull creation/update

### DIFF
--- a/app/controllers/super_admin/notifications_controller.rb
+++ b/app/controllers/super_admin/notifications_controller.rb
@@ -36,7 +36,7 @@ module SuperAdmin
       @notification.notification_type = "global"
       if @notification.save
         flash.now[:notice] = success_message(@notification, _("created"))
-        render :edit
+        redirect_to edit_super_admin_notification_path(@notification)
       else
         flash.now[:alert] = failure_message(@notification, _("create"))
         render :new
@@ -49,6 +49,7 @@ module SuperAdmin
       authorize(Notification)
       if @notification.update(notification_params)
         flash.now[:notice] = success_message(@notification, _("updated"))
+        return redirect_to edit_super_admin_notification_path(@notification)
       else
         flash.now[:alert] = failure_message(@notification, _("update"))
       end


### PR DESCRIPTION
Changes proposed in this PR:
- redirect to edit page of notifications controller after create
- redirect to edit page of notifications controller after update

Just trying to prevent a user from trying to reload the page by
hitting the url as presented in the url bar.