### PR TITLE
Share plan org

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -7,8 +7,16 @@ class Users::InvitationsController < Devise::InvitationsController
   # Creates the selected Org if necessary and then attaches the invited user
   # to the Org after Devise does its thing
   prepend_after_action :handle_org, only: [:update]
+  prepend_before_action :fix_org_params, only: [:update]
 
   protected
+
+  def fix_org_params
+    hash = org_hash_from_params(params_in: params[:user])
+    org = OrgSelection::HashToOrgService.to_org(hash: hash,
+                                                  allow_create: false)
+    params[:user][:org_id]  = org.id
+  end
 
   # Override require_no_authentication method defined at DeviseController
   # (parent of Devise::InvitationsController) The following filter gets

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,8 +14,8 @@ class Users::InvitationsController < Devise::InvitationsController
   def fix_org_params
     hash = org_hash_from_params(params_in: params[:user])
     org = OrgSelection::HashToOrgService.to_org(hash: hash,
-                                                  allow_create: false)
-    params[:user][:org_id]  = org.id
+                                                allow_create: false)
+    params[:user][:org_id] = org.id
   end
 
   # Override require_no_authentication method defined at DeviseController


### PR DESCRIPTION
When sharing a plan with a new user, when the new user followed the link in the invitation email and filled in the new user form, they got an "org needs set" error because the org params coming back to devise where not as needed.

This adds a before-action to fix up the params for devise.

