### PR TITLE
removed check for @public_plan on plan export. It was preventing the …

### DIFF
--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -35,7 +35,7 @@
                 <% next %>
               <% end %>
               <div class="question">
-                <% if !@public_plan && @show_sections_questions%>
+                <% if @show_sections_questions%>
                   <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
                   <% if local_assigns[:export_format] && export_format == 'docx' %>
                     <strong><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></strong>


### PR DESCRIPTION
Fixes https://github.com/DigitalCurationCentre/DMPonline-Service/issues/491.

Hey @raycarrick-ed, I'm not sure why, but the logic was set so that it would not show the question text if the plan was publicly visible. I looked back through the git history and see that it was in place back in 2018. Perhaps `@public_plan` was not being properly set before and this was not an issue?

Anyway I removed that check so that all public plans now show the question text. 
