### PR TITLE
Prevent the 'remove' link on Orgs page if it has contributors or plans

### DIFF
--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -12,7 +12,7 @@ module SuperAdmin
     def index
       authorize Org
       render "index", locals: {
-        orgs: Org.with_template_and_user_counts.page(1)
+        orgs: Org.includes(:contributors, :plans).with_template_and_user_counts.page(1)
       }
     end
 

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -81,6 +81,8 @@ class Org < ApplicationRecord
 
   has_many :users
 
+  has_many :contributors
+
   has_many :annotations
 
   has_and_belongs_to_many :token_permission_types,

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -31,7 +31,7 @@
               </button>
               <ul class="dropdown-menu" aria-labelledby="org-<%= org.id %>-actions">
                 <li><%= link_to _('Edit'), admin_edit_org_path(org) %></li>
-                <% unless org.user_count > 0 || org.template_count > 0 %>
+                <% unless org.user_count > 0 || org.template_count > 0 || org.contributors.length > 0 || org.plans.length > 0 %>
                   <li><%= link_to _('Remove'), super_admin_org_path(org), data: {confirm: _("You are about to delete '%{org_name}'. Are you sure?") % { org_name: org.name}}, method: :delete %></li>
                 <% end %>
               </ul>


### PR DESCRIPTION
Fixes https://github.com/DigitalCurationCentre/DMPonline-Service/issues/498

@raycarrick-ed I think this will address the issue you were seeing with this one. I think its worth considering though if that is the behavior we want. If its actually ok to delete an Org despite it having those associated records, we could add a callback that nils the association first (on the plan and contributor records) before deleting the Org record.

Also note that it doesn't check for guidance which is also a relation but I think the cascading delete logic handles those.
