### PR TITLE
Fixed issue with enabling/disabling notifications from table

### DIFF
--- a/app/controllers/super_admin/notifications_controller.rb
+++ b/app/controllers/super_admin/notifications_controller.rb
@@ -59,7 +59,7 @@ module SuperAdmin
     def enable
       notification = Notification.find(params[:id])
       authorize(Notification)
-      notification.enabled = (notification_params[:enabled] == "1")
+      notification.enabled = (params[:enabled] == "1")
 
       # rubocop:disable Layout/LineLength
       if notification.save

--- a/app/views/paginable/notifications/_index.html.erb
+++ b/app/views/paginable/notifications/_index.html.erb
@@ -15,13 +15,9 @@
         <td><%= notification.level %></td>
         <td><%= notification.starts_at %></td>
         <td><%= notification.expires_at %></td>
-        <td>
-          <%= form_for notification,
-                url: enable_super_admin_notification_path(notification),
-                html: { method: :post, remote: true, class: 'enable_notification'  } do |f| %>
-            <%= check_box_tag(:enabled, "1", notification.enabled, "aria-label": "active" ) %>
-            <%= f.submit(_('Update'), style: 'display: none;') %>
-          <% end %>
+        <td class="enable_notification">
+          <%= check_box_tag(:enabled, "1", notification.enabled, "aria-label": "active",
+                            data: { remote: true, method: :post, url: enable_super_admin_notification_path(notification) } ) %>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
Fixes https://github.com/DigitalCurationCentre/DMPonline-Service/issues/480

Updated code to use Rails 5+ new data remote logic for input elements. Also needed to update controller to grab the enabled flag value from `params`