### PR TITLE
Org select fixes

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -154,6 +154,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Layout/LineLength, Metrics/BlockNesting
   def do_update(require_password = true, confirm = false)
+    restrict_orgs = Rails.configuration.x.application.restrict_orgs
     mandatory_params = true
     # added to by below, overwritten otherwise
     message = _("Save Unsuccessful. ")
@@ -171,7 +172,7 @@ class RegistrationsController < Devise::RegistrationsController
       message += _("Please enter a Last name. ")
       mandatory_params &&= false
     end
-    if update_params[:org_id].blank?
+    if restrict_orgs && update_params[:org_id]["id"].blank?
       message += _("Please select an organisation from the list, or enter your organisation's name.")
       mandatory_params &&= false
     end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -15,7 +15,7 @@ class Users::InvitationsController < Devise::InvitationsController
     hash = org_hash_from_params(params_in: params[:user])
     org = OrgSelection::HashToOrgService.to_org(hash: hash,
                                                 allow_create: false)
-    params[:user][:org_id] = org.id
+    params[:user][:org_id] = org&.id
   end
 
   # Override require_no_authentication method defined at DeviseController

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -47,7 +47,7 @@
           </p>
           <div id="create-account-form">
             <p >
-              <%= render partial: 'shared/create_account_form' %>
+            <%= render partial: 'shared/create_account_form', locals: {orgs: @all_orgs, org_partial: @org_partial} %>
               <br>
             </p>
           </div>
@@ -59,7 +59,7 @@
           <i class="fas fa-user-plus" aria-hidden="true">&nbsp;&nbsp;</i>
         </h2>
         <div id="create-account-form">
-          <%= render partial: 'shared/create_account_form' %>
+          <%= render partial: 'shared/create_account_form', locals: {orgs: @all_orgs, org_partial: @org_partial} %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Fixes a number of bugs with registrations.
Orgs were still being created freehand from the profile page.

Adds in orgs and org_partial needed for new registration partial
Refuses org update on profile if not in list and "restrict_orgs" set.