### PR TITLE
Fix share required params

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -17,7 +17,10 @@ class RolesController < ApplicationController
     authorize @role
 
     message = ""
-    if role_params[:user].present? && plan.present?
+    if role_params[:user].present? &&
+       role_params[:user].key?(:email) &&
+       role_params[:user][:email].present? && plan.present?
+
       if @role.plan.owner.present? && @role.plan.owner.email == role_params[:user][:email]
         # rubocop:disable Layout/LineLength
         flash[:notice] = _("Cannot share plan with %{email} since that email matches with the owner of the plan.") % {

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -108,6 +108,7 @@
          <em class="sr-only"><%= email_tooltip %></em>
         <%= user.email_field :email, class: "form-control", title: email_tooltip,
                                      aria: { required: true },
+                                     required: true,
                                      date: { toggle: "tooltip", html: true } %>
       <% end %>
     </div>
@@ -122,7 +123,7 @@
       <div class="form-group">
         <div class="radio">
           <%= f.label :administrator_access do %>
-            <%= f.radio_button :access, administrator.access, id: "role_administrator_access", "aria-required": true %>
+            <%= f.radio_button :access, administrator.access, id: "role_administrator_access", "aria-required": true, required: true %>
             <%= _('Co-owner') %>
           <% end %>
         </div>


### PR DESCRIPTION
Changes proposed in this PR:
- check on existance of `:email` in hash `:user`. If you do not supply an email address now, the controller crashes
- make fields email and access required in html
