### PR TITLE
pdf export filename qith quotes fails in chrome

### DIFF
--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -103,7 +103,7 @@ class PlanExportsController < ApplicationController
     ret = @plan.title
     Zaru.sanitize! ret
     ret = ret.strip.gsub(/\s+/, "_")
-    ret = ret.gsub(/"/,'')
+    ret = ret.gsub(/"/, "")
     # limit the filename length to 100 chars. Windows systems have a MAX_PATH allowance
     # of 255 characters, so this should provide enough of the title to allow the user
     # to understand which DMP it is and still allow for the file to be saved to a deeply

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -103,6 +103,7 @@ class PlanExportsController < ApplicationController
     ret = @plan.title
     Zaru.sanitize! ret
     ret = ret.strip.gsub(/\s+/, "_")
+    ret = ret.gsub(/"/,'')
     # limit the filename length to 100 chars. Windows systems have a MAX_PATH allowance
     # of 255 characters, so this should provide enough of the title to allow the user
     # to understand which DMP it is and still allow for the file to be saved to a deeply


### PR DESCRIPTION
Filename for pdf export is derived from plan title. If it has quotes in it, this fails in chrome. This removes the quotes.
