### PR TITLE
needs require csvable in prod but not dev

### DIFF
--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -2,6 +2,8 @@
 
 class UsageController < ApplicationController
 
+  require "csvable"
+
   after_action :verify_authorized
   # GET /usage
   def index


### PR DESCRIPTION

In production hitting "Download Monthly Usage" on the org admin usage page caused a NameError not finding Csvable. Works in dev fine but in production needs the require.
