### PR TITLE
change policy to allow more than just default template download

### DIFF
--- a/app/policies/public_page_policy.rb
+++ b/app/policies/public_page_policy.rb
@@ -16,7 +16,7 @@ class PublicPagePolicy < ApplicationPolicy
   end
 
   def template_export?
-    @object.present? && (@object.is_default? || @object.org.funder?) && @object.published?
+    @object.present? && @object.published?
   end
 
   def plan_export?


### PR DESCRIPTION
Fixes https://github.com/DigitalCurationCentre/DMPonline-Service/issues/493 .

Changes proposed in this PR:
- previously could only download default template of not a funder. This removes that restriction.
