### PR TITLE
addressed a few minor bugs found while working on the dmptool

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -211,7 +211,7 @@ class UserMailer < ActionMailer::Base
 
     @user      = user
     @username  = @user.name
-    @ul_list   = sanitize(privileges_list(@user))
+    @ul_list   = privileges_list(@user)
 
     I18n.with_locale I18n.default_locale do
       mail(to: user.email,

--- a/app/views/org_admin/users/edit.html.erb
+++ b/app/views/org_admin/users/edit.html.erb
@@ -58,7 +58,7 @@
 
     <% if @user.identifiers.present? %>
       <h2>Identifiers</h2>
-      <% presenter.identifiers.each do |identifier| %>
+      <% @user.identifiers.each do |identifier| %>
         <p><%= id_for_display(id: identifier, with_scheme_name: true) %></p>
       <% end %>
     <% end %>

--- a/app/views/user_mailer/admin_privileges.html.erb
+++ b/app/views/user_mailer/admin_privileges.html.erb
@@ -6,7 +6,7 @@
     <%= _('You have been granted administrator privileges in %{tool_name}:') %{ tool_name: tool_name } %>
   </p>
   <p>
-    <%= @ul_list %>
+    <%= sanitize(@ul_list) %>
   </p>
 <% else %>
   <p>
@@ -16,7 +16,7 @@
 <p>
   <%= sanitize _('More information about administering the %{tool_name} for users at your organisation is available at the %{help_url}.') % {
     tool_name: tool_name,
-    help_url: link_to('help for administrators page', @help_url) }
+    help_url: link_to('help for administrators page', help_url) }
   %>
 </p>
 <%= render partial: 'email_signature' %>


### PR DESCRIPTION
Discovered a few bugs reported in our logs

- Move the call to the Rails `sanitize` method from the Mailer to the View. That method is not available on a Mailer
- Removed the `@` from the `@help_url` in the admin_privileges email so that it uses the Rails route instead
- The Org Admin Edit User page had a typo (probably from a copy/paste). Swapped `presenter.identifiers` out with `@user.identifiers`