### PR TITLE
only include active roles in plan share tab; don't take inactive role…

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -302,7 +302,7 @@ class PlansController < ApplicationController
     @plan = Plan.find(params[:id])
     if @plan.present?
       authorize @plan
-      @plan_roles = @plan.roles
+      @plan_roles = @plan.roles.where(active: true)
     else
       redirect_to(plans_path)
     end
@@ -315,7 +315,7 @@ class PlansController < ApplicationController
     @plan = Plan.find(params[:id])
     if @plan.present?
       authorize @plan
-      @plan_roles = @plan.roles
+      @plan_roles = @plan.roles.where(active: true)
     else
       redirect_to(plans_path)
     end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -29,7 +29,11 @@ class RolesController < ApplicationController
         # rubocop:enable Layout/LineLength
       else
         user = User.where_case_insensitive("email", role_params[:user][:email]).first
-        if Role.find_by(plan: @role.plan, user: user) # role already exists
+        if user.present? &&
+           Role.where(plan: @role.plan, user: user, active: true)
+               .count
+               .positive? # role already exists
+
           flash[:notice] = _("Plan is already shared with %{email}.") % {
             email: role_params[:user][:email]
           }

--- a/app/views/plans/_share_form.html.erb
+++ b/app/views/plans/_share_form.html.erb
@@ -41,7 +41,7 @@
 
 <h2><%= _('Manage collaborators')%></h2>
 <p><%= _('Invite specific people to read, edit, or administer your plan. Invitees will receive an email notification that they have access to this plan.') %></p>
-<% if @plan.roles.any? then %>
+<% if @plan_roles.any? then %>
   <table class="table table-hover table-bordered" id="collaborator-table">
     <thead>
       <tr>


### PR DESCRIPTION
Fixes #2951 

Comments:

* I also updated the query for `@plan_roles` in `PlansController#request_feedback`, but that variables isn't used anywhere?