### PR TITLE
Adds an additional "other" role to the contributors page

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -67,6 +67,7 @@ class Contributor < ApplicationRecord
   has_flags 1 => :data_curation,
             2 => :investigation,
             3 => :project_administration,
+            4 => :other,
             column: "roles"
 
   # ==========
@@ -91,7 +92,7 @@ class Contributor < ApplicationRecord
 
     # returns the default role
     def default_role
-      "investigation"
+      "other"
     end
 
   end

--- a/app/presenters/api/v1/contributor_presenter.rb
+++ b/app/presenters/api/v1/contributor_presenter.rb
@@ -11,6 +11,7 @@ module Api
         # Convert the specified role into a CRediT Taxonomy URL
         def role_as_uri(role:)
           return nil unless role.present?
+          return "other" if role.to_s.downcase == "other"
 
           "#{Contributor::ONTOLOGY_BASE_URL}/#{role.to_s.downcase.gsub('_', '-')}"
         end

--- a/app/presenters/contributor_presenter.rb
+++ b/app/presenters/contributor_presenter.rb
@@ -43,8 +43,10 @@ class ContributorPresenter
         "Data Manager"
       when :project_administration
         "Project Administrator"
-      else
+      when :investigation
         "Principal Investigator"
+      else
+        "Other"
       end
     end
 

--- a/app/views/contributors/_form.html.erb
+++ b/app/views/contributors/_form.html.erb
@@ -73,7 +73,7 @@ roles_tooltip = _("Select each role that applies to the contributor.")
 
       <% roles = ContributorPresenter.roles_for_radio(contributor: contributor) %>
       <% roles.each do |hash| %>
-        <div class="col-md-4">
+        <div class="col-md-3">
           <div class="checkbox">
             <%= form.check_box hash.keys.first.to_sym,
                                value: hash.values.first,

--- a/app/views/contributors/_form.html.erb
+++ b/app/views/contributors/_form.html.erb
@@ -42,7 +42,7 @@ roles_tooltip = _("Select each role that applies to the contributor.")
   <div class="col-md-12">
     <%= form.label(:phone, _("Phone number"), class: "control-label") %>
   </div>
-  <div class="col-md-4">
+  <div class="col-md-3">
     <em class="sr-only"><%= phone_tooltip %></em>
     <%= form.phone_field :phone, class: "form-control",
                                  title: phone_tooltip,


### PR DESCRIPTION
We received feedback that the current list of roles was too limited. So adding an "other" category since the user is required to select one but the contributor may not be a Project Admin, Investigator or Data Curator.

This role is carried through into the JSON output as `"role": "other"` without any Credit taxonomy URL since Credit does not have an equivalent