### PR TITLE
Update to JS spinner

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -31,13 +31,13 @@ import '../src/utils/paginable';
 import '../src/utils/panelHeading';
 import '../src/utils/popoverHelper';
 import '../src/utils/requiredField';
-import '../src/utils/spinner';
 import '../src/utils/tabHelper';
 import '../src/utils/tooltipHelper';
 
 // Specific functions from the Utilities files that will be made available to
 // the js.erb templates in the `window.x` statements below
 import { renderAlert, renderNotice } from '../src/utils/notificationHelper';
+import toggleSpinner from '../src/utils/spinner';
 
 // View specific JS
 import '../src/answers/conditions';
@@ -102,3 +102,4 @@ window.jQuery = jQuery;
 // Allow js.erb files to access the notificationHelper functions
 window.renderAlert = renderAlert;
 window.renderNotice = renderNotice;
+window.toggleSpinner = toggleSpinner;

--- a/app/javascript/src/utils/spinner.js
+++ b/app/javascript/src/utils/spinner.js
@@ -1,19 +1,39 @@
 // Will display a spinner at the start of any UJS/Ajax call and then hide it after the
 // controller responds.
-$(() => {
-  const toggleSpinner = () => {
-    const spinnerBlock = $('.spinner-border');
+const toggleSpinner = (visible) => {
+  const spinnerBlock = $('.spinner-border');
 
-    if (spinnerBlock.length > 0) {
-      if (spinnerBlock.hasClass('hidden')) {
-        spinnerBlock.removeClass('hidden');
-      } else {
-        spinnerBlock.addClass('hidden');
-      }
+  if (spinnerBlock.length > 0) {
+    if (visible) {
+      spinnerBlock.removeClass('hidden');
+    } else {
+      spinnerBlock.addClass('hidden');
     }
-  };
+  }
+};
 
-  $('body').on('ajax:send', toggleSpinner);
-  $('body').on('ajax:success', toggleSpinner);
-  $('body').on('ajax:error', toggleSpinner);
+$(() => {
+  $('body').on('ajax:beforeSend', () => {
+    toggleSpinner(true);
+  });
+
+  $('body').on('ajax:complete', () => {
+    toggleSpinner(false);
+  });
+
+  $('body').on('ajax:error', () => {
+    toggleSpinner(false);
+  });
+
+  $('body').on('ajax:stopped', () => {
+    toggleSpinner(false);
+  });
+
+  $('body').on('ajax:success', () => {
+    toggleSpinner(false);
+  });
+
+  toggleSpinner(false);
 });
+
+export default (visible) => toggleSpinner(visible);

--- a/app/views/super_admin/api_clients/email_credentials.js.erb
+++ b/app/views/super_admin/api_clients/email_credentials.js.erb
@@ -1,2 +1,3 @@
 var msg = '<%= _("The credentials have been sent to %{email}.") % { email: @api_client.contact_email } %>';
 renderNotice(msg);
+toggleSpinner(false);

--- a/app/views/super_admin/api_clients/refresh_credentials.js.erb
+++ b/app/views/super_admin/api_clients/refresh_credentials.js.erb
@@ -3,3 +3,4 @@ var msg = '<%= @success ? _("Successfully regenerated the client credentials.") 
 var context = $('#edit_api_client_<%= @api_client.id %>');
 context.html('<%= escape_javascript(render partial: "/super_admin/api_clients/form") %>');
 renderNotice(msg);
+toggleSpinner(false);

--- a/app/views/usage/plans_by_template.js.erb
+++ b/app/views/usage/plans_by_template.js.erb
@@ -8,3 +8,4 @@ window.templatePlansChart.dispatchEvent(
     detail: JSON.parse('<%= prep_data_for_template_plans_chart(data: @plans_per_month).html_safe %>')
   })
 );
+toggleSpinner(false);

--- a/app/views/users/refresh_token.js.erb
+++ b/app/views/users/refresh_token.js.erb
@@ -3,3 +3,4 @@ var msg = '<%= @success ? _("Successfully regenerate your API token.") : _("Unab
 var context = $('#api-token');
 context.html('<%= escape_javascript(render partial: "/devise/registrations/api_token", locals: { user: current_user }) %>');
 renderNotice(msg);
+toggleSpinner(false);


### PR DESCRIPTION
Updating the toggleSpinner JS function so that it is now callable from js.erb templates

Note: 
- if PR #2763 is merged before this one then this PR should be updated to include the new js.erb template added by PR #2763  
- if this PR is merged first then we should update PR #2763 to call `toggleSpinner(false);` on its js.erb template.