### PR TITLE
change migration classname

### DIFF
--- a/db/migrate/20210729204238_create_research_domains.rb
+++ b/db/migrate/20210729204238_create_research_domains.rb
@@ -1,4 +1,4 @@
-class CreateFos < ActiveRecord::Migration[5.2]
+class CreateResearchDomains < ActiveRecord::Migration[5.2]
   def change
     create_table :research_domains do |t|
       t.string :identifier, null: false


### PR DESCRIPTION
Fixes bug in db:migrate caused by classname/filename mismatch.

Changes proposed in this PR:
- change classname to match filename
