### PR TITLE
exclude private and test plans if read_all not set

### DIFF
--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -292,7 +292,14 @@ class Org < ApplicationRecord
   # This replaces the old plans method. We now use the native plans method and this.
   def org_admin_plans
     combined_plan_ids = (native_plan_ids + affiliated_plan_ids).flatten.uniq
-    Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
+    
+    if Rails.configuration.x.plans.org_admins_read_all
+      Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
+    else
+      Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
+        .where.not(visibility: Plan.visibilities[:privately_visible])
+        .where.not(visibility: Plan.visibilities[:is_test])
+    end
   end
 
   def grant_api!(token_permission_type)

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -292,13 +292,13 @@ class Org < ApplicationRecord
   # This replaces the old plans method. We now use the native plans method and this.
   def org_admin_plans
     combined_plan_ids = (native_plan_ids + affiliated_plan_ids).flatten.uniq
-    
+
     if Rails.configuration.x.plans.org_admins_read_all
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
     else
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
-        .where.not(visibility: Plan.visibilities[:privately_visible])
-        .where.not(visibility: Plan.visibilities[:is_test])
+          .where.not(visibility: Plan.visibilities[:privately_visible])
+          .where.not(visibility: Plan.visibilities[:is_test])
     end
   end
 

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -420,8 +420,9 @@ RSpec.describe Org, type: :model do
 
   describe "#org_admin_plans" do
 
+    Rails.configuration.x.plans.org_admins_read_all = true
     let!(:org) { create(:org) }
-    let!(:plan) { create(:plan, org: org) }
+    let!(:plan) { create(:plan, org: org, visibility: "publicly_visible") }
     let!(:user) { create(:user, org: org) }
 
     subject { org.org_admin_plans }
@@ -473,6 +474,34 @@ RSpec.describe Org, type: :model do
 
       before do
         plan.add_user!(user.id, :reviewer)
+      end
+
+      it { is_expected.to include(plan) }
+
+    end
+ 
+    context "read_all is false, visibility private and user org_admin" do
+
+      before do
+        Rails.configuration.x.plans.org_admins_read_all = false
+        @perm = build(:perm)
+        @perm.name = "grant_permissions"
+        user.perms << @perm
+        plan.privately_visible!
+      end
+
+      it { is_expected.not_to include(plan) }
+
+    end
+
+    context "read_all is false, visibility public and user org_admin" do
+
+      before do
+        Rails.configuration.x.plans.org_admins_read_all = false
+        @perm = build(:perm)
+        @perm.name = "grant_permissions"
+        user.perms << @perm
+        plan.publicly_visible!
       end
 
       it { is_expected.to include(plan) }


### PR DESCRIPTION
Fixes https://github.com/DigitalCurationCentre/DMPonline-Service/issues/594

Changes proposed in this PR:
- there was already a config setting org_admins_read_all but it wasn't being used in the org_admin plans page
- this PR fixes that by removing private and test plans from the orgadmin view if org_admin_read_all is false.

We use this in our DMPTuuli instance.