### PR TITLE
Allow logging level to be set by env variable

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,10 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = ENV["RAILS_LOG_LEVEL"]&.to_sym || :debug
+
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV["RAILS_LOG_LEVEL"]&.to_sym || :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Fixes #3004

Changes proposed in this PR:
- Allow the logging level to be defined by the RAILS_LOG_LEVEL env variable
- Set defaults to: `:debug` in `config/environments/development.rb` and `:info` in `config/environments/production.rb`
