### PR TITLE
Remove p tag from help page text changes

### DIFF
--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -47,7 +47,7 @@
 
 
           <h2 class="fontsize-h3"><%= _("Download plans") %></h2>
-          <p><%= _("From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to download. You can also adjust the formatting (font type, size and margins) for PDF files, which may be helpful if working to page limits.</p>") %>
+          <p><%= _("From here you can download your plan in various formats. This may be useful if you need to submit your plan as part of a grant application. Choose what format you would like to view/download your plan in and click to download. You can also adjust the formatting (font type, size and margins) for PDF files, which may be helpful if working to page limits.") %></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes # .
The 'p' tag was being closed inside the rails. This was causing problems on the html display
Changes proposed in this PR:

Remove the p tag from inside rails and add it to the out side as it should be.