### PR TITLE
Issue #496 - Plan search issues.

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -169,13 +169,13 @@ class Plan < ApplicationRecord
   scope :search, lambda { |term|
     if date_range?(term: term)
       joins(:template, roles: [user: :org])
-        .where(Role.creator_condition)
+        .where(roles: { active: true })
         .by_date_range(:created_at, term)
     else
       search_pattern = "%#{term}%"
       joins(:template, roles: [user: :org])
         .left_outer_joins(:identifiers, :contributors)
-        .where(Role.creator_condition)
+        .where(roles: { active: true })
         .where("lower(plans.title) LIKE lower(:search_pattern)
                 OR lower(orgs.name) LIKE lower (:search_pattern)
                 OR lower(orgs.abbreviation) LIKE lower (:search_pattern)


### PR DESCRIPTION
Fixes #496 .
The specification for Plans search and display was cited by @mariapraetzellis  in comment
https://github.com/DMPRoadmap/roadmap/pull/3000#issuecomment-901207072
```
We discussed this in our team meeting. @johnpinto1

My Dashboard - shows Plans the current user's currently has an 'active' role on (creator, co-owner, editor, commenter)

    agreed this is the correct behavior

My Dashboard - shows the organisationally visible plans for the current user
-- agreed this is the correct behavior

Admin -> Plans - shows all of the plans owned/co-owned by one of the Org's users

    agreed this is the correct behavior
    -there is an exception to this in the code that are two configurable settings that allows an instance to set this so private plans do not display for admins or super admins

Admin -> Users - shows the Plans for the user being edited (not sure if these are creator or would show if the user is just an editor or commenter)

    This is the correct behavior but we do have an additional feature to add as described below. We will make a new issue for this additional feature.
    We should add a new column that shows the user's role in each plan. This would also need to adhere to the configuration settings that allows an instance to set this so private plans do not display for admins or super admins.

Public Plans - shows any Plan marked as publicly_visible

    This is the correct behavior

We'd have to look at the API v0 and v1 to see if they use that search method (I think v0 might)

    Please check API v0 & V1 to make sure they're following the configuration settings
```

Further comments by @raycarrick-ed and @briri  are linked here:
https://github.com/DMPRoadmap/roadmap/pull/3000#issuecomment-901706504
https://github.com/DMPRoadmap/roadmap/pull/3000#issuecomment-901975844

Changes proposed in this PR:

     - Replaced .where(Role.creator_condition) with .where(roles: { active: true })
     in model Plan search scope.
     - Added .where(roles: { active: true }) to Plan retrieval in
    org_admin_plans() method of the Org model.  (@briri does this address comment https://github.com/DMPRoadmap/roadmap/pull/3000#issuecomment-901975844, as aPI only available to Org Admins.)


