### PR TITLE
Issue2989

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -192,7 +192,7 @@ class PlansController < ApplicationController
       @important_ggs << [current_user.org, @all_ggs_grouped_by_org[current_user.org]]
     end
     @all_ggs_grouped_by_org.each do |org, ggs|
-      @important_ggs << [org, ggs] if org.organisation?
+      @important_ggs << [org, ggs] if Org.default_orgs.include?(org)
 
       # If this is one of the already selected guidance groups its important!
       unless (ggs & @selected_guidance_groups).empty?


### PR DESCRIPTION
Fixes #2989.

Changes proposed in this PR:
- Prevent the project details page from displaying all guidance groups associated with an Org whose org_type is 'organization'.

It Iooks like I added this line over a year ago and don't recall why. Updated it to only use the default org's guidance.
