### PR TITLE
Issue #584 - Fix for "Not possible to add funder once the creation pl…

### DIFF
--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -141,16 +141,16 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
 <conditional>
   <div id="funder-org-controls" class="form-group">
     <div class="col-md-8">
-      <%= fields_for :funder, plan.funder do |funder_fields| %>
-        <%= render partial: org_partial,
-           locals: {
-             form: form,
-             orgs: orgs,
-             funder_only: true,
-             label: _("Funder"),
-             default_org: plan.funder,
-             required: false
-           } %>
+      <%= form.fields_for :funder, Org.new do |funder_fields| %>
+        <%= render partial: "shared/org_selectors/local_only",
+                    locals: {
+                      form: funder_fields,
+                      id_field: :id,
+                      label: _("Funder"),
+                      default_org: plan.funder,
+                      orgs: @funders,
+                      required: false
+                    } %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
…an wizard page is completed"

Fixes # 586.
Changes:
- In plans_controller.rb: save funder selected in
  - added funders to show() method for the use by the partial
    "shared/org_selectors/local_only" in _project_details.html.erb
  - update() method changed to receive params for funder
- In _project_details.html.erb added "shared/org_selectors/local_only"
for funders.

