### PR TITLE
Tinymce label fix

### DIFF
--- a/app/javascript/src/utils/tinymce.js.erb
+++ b/app/javascript/src/utils/tinymce.js.erb
@@ -69,8 +69,11 @@ const resizeEditors = (editors) => {
  */
 const attachLabelToIframe = (tinymceContext) => {
   const iframe = $(tinymceContext).siblings('.mce-container').find('iframe');
-  if (isObject(iframe)) {
-    const lbl = iframe.closest('form').find('label');
+  const hiddenField = $(hiddenFieldSelector);
+
+  if (isObject(iframe) && isObject(hiddenField)) {
+    const id = hiddenField.attr('id');
+    const lbl = iframe.closest('form').find(`label[for="${id}"]`);
     if (isObject(lbl)) {
       // Connect the label to the iframe
       lbl.attr('for', iframe.attr('id'));
@@ -93,7 +96,7 @@ export const Tinymce = {
 
     // Connect the label to the Tinymce iframe
     $(options.selector).each((idx, el) => {
-      attachLabelToIframe(el);
+      attachLabelToIframe(el, options.selector);
     });
   },
   /*

--- a/app/javascript/src/utils/tinymce.js.erb
+++ b/app/javascript/src/utils/tinymce.js.erb
@@ -67,7 +67,7 @@ const resizeEditors = (editors) => {
   behind the scenes) to the Tinymce iframe so that screen readers read the correct
   label when the tinymce iframe receives focus.
  */
-const attachLabelToIframe = (tinymceContext) => {
+const attachLabelToIframe = (tinymceContext, hiddenFieldSelector) => {
   const iframe = $(tinymceContext).siblings('.mce-container').find('iframe');
   const hiddenField = $(hiddenFieldSelector);
 


### PR DESCRIPTION
While working on something else, I noticed that the existing Tinymce JS was connecting the editor to the incorrect labels. This can cause problems for screen reader accessibility.

The old code was changing the `for` attribute of ALL labels on the form. This change ensures that it updates only the related label.


