### PR TITLE
Fix Plan grant_number bug

### DIFF
--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -138,8 +138,8 @@ module ExportablePlan
            else
              [_("Template: "), _("%{template}") % { template: hash[:template] + hash[:customizer] }]
            end
-    if grant_number.present?
-      csv << [_("Grant number: "), _("%{grant_number}") % { grant_number: grant_number }]
+    if grant&.value.present?
+      csv << [_("Grant number: "), _("%{grant_number}") % { grant_number: grant&.value }]
     end
     if description.present?
       csv << [_("Project abstract: "), _("%{description}") %

--- a/app/models/exported_plan.rb
+++ b/app/models/exported_plan.rb
@@ -46,7 +46,7 @@ class ExportedPlan < ApplicationRecord
   end
 
   def grant_title
-    plan.grant_number
+    plan.grant&.value
   end
 
   def principal_investigator

--- a/app/views/api/v0/plans/index.json.jbuilder
+++ b/app/views/api/v0/plans/index.json.jbuilder
@@ -8,7 +8,7 @@ json.prettify!
 json.array! @plans.each do |plan|
   json.id             plan.id
   json.title          plan.title
-  json.grant_number   plan.grant_number
+  json.grant_number   plan.grant&.value
   json.last_updated   plan.updated_at
   json.creation_date  plan.created_at
   json.test_plan      plan.is_test?

--- a/app/views/api/v0/statistics/plans.json.jbuilder
+++ b/app/views/api/v0/statistics/plans.json.jbuilder
@@ -4,7 +4,7 @@ json.prettify!
 
 json.plans @org_plans.each do |plan|
   json.id             plan.id
-  json.grant_number   plan.grant_number
+  json.grant_number   plan.grant&.value
   json.title          plan.title
   json.test_plan      plan.is_test?
 

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -8,8 +8,8 @@
   <% else %>
 <%= _("Template: ") + @hash[:template] + @hash[:customizer] %>
   <% end %>
-  <% if @plan.grant_number.present? %>
-<%= _("Grant number: ") + @plan.grant_number %>
+  <% if @plan.grant&.value.present? %>
+<%= _("Grant number: ") + @plan.grant&.value %>
   <% end %>
   <% if @plan.description.present? %>
 <%= _("Project abstract: ") %>
@@ -31,7 +31,7 @@
         <%= "#{section[:title]}\n" %>
       <% end %>
       <% section[:questions].each do |question| %>
-        <% if remove_list(@plan).include?(question[:id]) %> 
+        <% if remove_list(@plan).include?(question[:id]) %>
           <% next %>
         <% end %>
         <%# text in this case is an array to accomodate for option_based %>


### PR DESCRIPTION
**"undefined method `grant_number' for #<Plan:0x00007fd5384ec108>\nDid you mean?  grant_id"**

Change:
- replacing Plan grant_number by **grant&.value** in files.

This is a fix based on comment by @briri in a closed PR https://github.com/DMPRoadmap/roadmap/pull/3028#issuecomment-924147278
```
Anyway, it looks like maybe its trying to reference grant_number in a few places. Can you update these as part of this PR when you have a chance?

Here's the output of a quick grep on the app directory:

briley@CDL-BRILEY-9M roadmap % grep -r 'grant_number' app 
app/models/exported_plan.rb:    plan.grant_number
app/models/concerns/exportable_plan.rb:    if grant_number.present?
app/models/concerns/exportable_plan.rb:      csv << [_("Grant number: "), _("%{grant_number}") % { grant_number: grant_number }]
app/javascript/src/plans/editDetails.js:              $('#grant_number_info').html(grantNumberInfo(grantId));
app/javascript/src/plans/editDetails.js:            $('#grant_number_info').html(grantNumberInfo(''));
app/views/plans/_project_details.html.erb:          <span class="text-muted" id="grant_number_info">Grant number: <%= plan.grant&.value %></span>
app/views/shared/export/_plan_txt.erb:  <% if @plan.grant_number.present? %>
app/views/shared/export/_plan_txt.erb:<%= _("Grant number: ") + @plan.grant_number %>
app/views/api/v0/statistics/plans.json.jbuilder:  json.grant_number   plan.grant_number
app/views/api/v0/plans/index.json.jbuilder:  json.grant_number   plan.grant_number
```

