### PR TITLE
added handler for Pundit errors on ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,8 @@ class ApplicationController < ActionController::Base
 
   rescue_from StandardError, with: :handle_server_error
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
   private
 
   def current_org

--- a/spec/controllers/super_admin/orgs_controller_spec.rb
+++ b/spec/controllers/super_admin/orgs_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SuperAdmin::OrgsController, type: :controller do
       sign_in(create(:user))
       post :merge_analyze, params: @params
       expect(response.code).to eql("302")
-      expect(response).to redirect_to(root_path)
+      expect(response).to redirect_to(plans_path)
       expect(flash[:alert].present?).to eql(true)
     end
     it "succeeds in analyzing the Orgs" do
@@ -64,7 +64,7 @@ RSpec.describe SuperAdmin::OrgsController, type: :controller do
         sign_in(create(:user))
         post :merge_commit, params: @params
         expect(response.code).to eql("302")
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(plans_path)
         expect(flash[:alert].present?).to eql(true)
       end
       it "fails if :target_org is not found" do


### PR DESCRIPTION
Just building off of the pattern @johnpinto1 established for us for handling errors.

This ensures that any Pundit authorization errors result in an Unauthorized error message and brings the user back to their Dashboard or the homepage if they're not logged in
