### PR TITLE
Issue #2958 - Fix for Download option "unanswered questions" does

### DIFF
--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -36,17 +36,19 @@
               <% end %>
               <div class="question">
                 <% if @show_sections_questions%>
-                  <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
-                  <% if local_assigns[:export_format] && export_format == 'docx' %>
-                    <strong><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></strong>
-                  <% else %>
-                    <div class="bold"><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>
+                  <% answer = @plan.answer(question[:id], false) %>
+                  <% blank = answer.present? ? answer.blank? : true %>
+                  <% options = answer.present? ? answer.question_options : [] %>
+                  <% if @show_unanswered %>
+                    <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
+                    <% if local_assigns[:export_format] && export_format == 'docx' %>
+                      <strong><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></strong>
+                    <% else %>
+                     <div class="bold"><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>
+                    <% end %>
+                    <br>
                   <% end %>
-                  <br>
                 <% end %>
-                <% answer = @plan.answer(question[:id], false) %>
-                <% blank = answer.present? ? answer.blank? : true %>
-                <% options = answer.present? ? answer.question_options : [] %>
                 <%# case where question has not been answered sufficiently to display%>
                 <% if @show_unanswered && blank %>
                   <br>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -37,7 +37,6 @@
         <%# text in this case is an array to accomodate for option_based %>
         <% if @show_sections_questions %>
           <% answer = @plan.answer(question[:id], false) %>
-          <% blank = not(answer.present? && answer.answered?) %>
           <% if @show_unanswered %>
             <% if question[:text].respond_to?(:each) %>
               <% question[:text].each do |txt| %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -36,15 +36,18 @@
         <% end %>
         <%# text in this case is an array to accomodate for option_based %>
         <% if @show_sections_questions %>
-          <% if question[:text].respond_to?(:each) %>
-            <% question[:text].each do |txt| %>
-              <%= "#{strip_tags(txt.gsub(/<br\/?>/, '\n'))}\n" %>
+          <% answer = @plan.answer(question[:id], false) %>
+          <% blank = not(answer.present? && answer.answered?) %>
+          <% if @show_unanswered %>
+            <% if question[:text].respond_to?(:each) %>
+              <% question[:text].each do |txt| %>
+                <%= "#{strip_tags(txt.gsub(/<br\/?>/, '\n'))}\n" %>
+              <% end %>
+            <% else %>
+              <%= "#{strip_tags(question[:text].gsub(/<tr>(\s|<td>|<\/td>|&nbsp;)*(<\/tr>|<tr>)/,""))}\n" if question[:text].present? && question[:text][0].present? %>
             <% end %>
-          <% else %>
-            <%= "#{strip_tags(question[:text].gsub(/<tr>(\s|<td>|<\/td>|&nbsp;)*(<\/tr>|<tr>)/,""))}\n" if question[:text].present? && question[:text][0].present? %>
           <% end %>
         <% end %>
-        <% answer = @plan.answer(question[:id], false) %>
         <% blank = not(answer.present? && answer.answered?) %>
         <% if blank && @show_unanswered %>
           <%= "    #{_("Question not answered.")}\n\n" %>


### PR DESCRIPTION
opposite.

Fixes #2958 .

Changes to following views in shared/export:
- _plan.erb &  _plan_txt.erb: In the questions code block
added a missing check for whether the question should be displayed. This
required moving some of the variables evaluated from lower down in the code, as we need them for our check here.

Here are screenshots of results for options: **question text and section headings** & **unanswered question**

**PDF**
![Selection_046](https://user-images.githubusercontent.com/8876215/135251126-53114c42-8644-4f3a-80df-9a8b80d9dc73.png)

**TXT**
![Selection_047](https://user-images.githubusercontent.com/8876215/135251254-5dca283c-f690-4c2c-9257-29402e33ba11.png)

**DOCX**
![Selection_051](https://user-images.githubusercontent.com/8876215/135251356-23261652-b5b6-4eb9-a55c-649f8d2c7cf8.png)


Here are screenshots of results for options: **question text and section headings**

**PDF**
![Selection_049](https://user-images.githubusercontent.com/8876215/135251603-d72e19ec-119a-417f-95f3-4c1fccfa3337.png)

**TXT**
![Selection_048](https://user-images.githubusercontent.com/8876215/135251647-9891103e-3c4f-4152-acba-7fd7bff4d83a.png)


**DOCX**
![Selection_050](https://user-images.githubusercontent.com/8876215/135251714-57150af5-8be0-4e7e-b0d6-d491e2be0130.png)
