### PR TITLE
Remove the the hardcoded word - DMPRoadmap

### DIFF
--- a/app/views/static_pages/termsuse.html.erb
+++ b/app/views/static_pages/termsuse.html.erb
@@ -11,13 +11,13 @@
       <p>The <%= link_to 'Digital Curation Centre', 'https://dmponline.dcc.ac.uk/' %> (DCC) and <%= link_to 'California Digital Library', 'http://www.cdlib.org/' %>
       <%= _("(CDL) are consortia supported by the University of Edinburgh and the University of California, respectively. Our primary constituency is the research community. We provide services to the UK, US and international higher education sector. ") %></p>
 
-      <h2 class="fontsize-h3"><%= _('DMPRoadmap') %></h2>
+      <h2 class="fontsize-h3"><%= _('%{application_name}') % { application_name: ApplicationService.application_name } %></h2>
 
-      <p><%= _("DMPRoadmap ('the tool', 'the system') is a tool developed by the DCC and CDL as a shared resource for the research community. It is hosted at CDL by the University of California Curation Center.") %></p>
+      <p><%= _("%{application_name} ('the tool', 'the system') is a tool developed by the DCC and CDL as a shared resource for the research community. It is hosted at CDL by the University of California Curation Center.") % { application_name: ApplicationService.application_name } %></p>
 
       <%= sanitize(_("<h3>Your personal details and consent notice</h3>
 
-      <p>In order to help identify and administer your account with DMPRoadmap, we need to store your name and email address. We may also use it to contact you to obtain feedback on your use of the tool, or to inform you of the latest developments or releases. The information may be transferred between the DCC and CDL but only for the following legitimate DCC and CDL purposes: marketing, improving our services and informing you of relevant content and events. We will not sell, rent, or trade any personal information you provide to us.
+      <p>In order to help identify and administer your account with %{application_name}, we need to store your name and email address. We may also use it to contact you to obtain feedback on your use of the tool, or to inform you of the latest developments or releases. The information may be transferred between the DCC and CDL but only for the following legitimate DCC and CDL purposes: marketing, improving our services and informing you of relevant content and events. We will not sell, rent, or trade any personal information you provide to us.
 
 
         By using this system, you consent to the collection, retention, and use of your personal information in accordance with the above. You have the right to ask us not to process your personal details for marketing purposes.</p>
@@ -35,7 +35,7 @@
 
       <h3>Cookies</h3>
 
-      <p>Please note that DMPRoadmap uses Cookies. Further information about Cookies and how we use them is available on the <a target='_blank' href='http://www.dcc.ac.uk/about-us/about-site/website-terms-use/cookies' class=\"has-new-window-popup-info\">main DCC website<em class=\"sr-only\"> (new window)</em><span class=\"new-window-popup-info\">%{open_in_new_window_text}</span></a>.</p>
+      <p>Please note that %{application_name} uses Cookies. Further information about Cookies and how we use them is available on the <a target='_blank' href='http://www.dcc.ac.uk/about-us/about-site/website-terms-use/cookies' class=\"has-new-window-popup-info\">main DCC website<em class=\"sr-only\"> (new window)</em><span class=\"new-window-popup-info\">%{open_in_new_window_text}</span></a>.</p>
 
       <h3>Third party APIs</h3>
 
@@ -43,7 +43,7 @@
 
       <h3>Revisions</h3>
 
-      <p>This statement was last revised on October 5, 2017 and may be revised at any time. Use of the tool indicates that you understand and agree to these terms and conditions.</p>" ) % { open_in_new_window_text: _('Opens in new window') },
+      <p>This statement was last revised on October 5, 2017 and may be revised at any time. Use of the tool indicates that you understand and agree to these terms and conditions.</p>" ) % { open_in_new_window_text: _('Opens in new window'), application_name: ApplicationService.application_name },
       tags: %w( a h3 p span em )) %>
     </div>
   </div>


### PR DESCRIPTION
Fixes # .

Remove the the hardcoded word - DMPRoadmap from the "terms of use" page


