### PR TITLE
Translation.io tags missing

### DIFF
--- a/app/presenters/contributor_presenter.rb
+++ b/app/presenters/contributor_presenter.rb
@@ -40,13 +40,13 @@ class ContributorPresenter
     def role_symbol_to_string(symbol:)
       case symbol
       when :data_curation
-        "Data Manager"
+        _("Data Manager")
       when :project_administration
-        "Project Administrator"
+        _("Project Administrator")
       when :investigation
-        "Principal Investigator"
+        _("Principal Investigator")
       else
-        "Other"
+        _("Other")
       end
     end
 

--- a/app/views/plans/request_feedback.html.erb
+++ b/app/views/plans/request_feedback.html.erb
@@ -1,4 +1,4 @@
-<% title "#{@plan.title} - Request feedback" %>
+<% title _("#{@plan.title} - Request feedback") %>
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->


### PR DESCRIPTION
Fixes Translation.io missing tags on roadmap/app/views/plans/request_feedback.html.erb and roadmap/app/presenters/contributor_presenter.rb


