### PR TITLE
Mark some strings for translation.

### DIFF
--- a/app/presenters/contributor_presenter.rb
+++ b/app/presenters/contributor_presenter.rb
@@ -40,13 +40,13 @@ class ContributorPresenter
     def role_symbol_to_string(symbol:)
       case symbol
       when :data_curation
-        "Data Manager"
+        _("Data Manager")
       when :project_administration
-        "Project Administrator"
+        _("Project Administrator")
       when :investigation
-        "Principal Investigator"
+        _("Principal Investigator")
       else
-        "Other"
+        _("Other")
       end
     end
 

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -192,7 +192,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
                                       autocomplete: "off",
                                       aria: { required: false } %>
           <%= grant_fields.hidden_field :value %>
-          <span class="text-muted" id="grant_number_info">Grant number: <%= plan.grant&.value %></span>
+          <span class="text-muted" id="grant_number_info"><%=_("Grant number:") plan.grant&.value %></span>
         <% else %>
           <%= grant_fields.text_field(:value, class: "form-control",
                                             data: { toggle: "tooltip" },


### PR DESCRIPTION
This PR marks some unmarked strings for translation. Specifically, this PR fixes #3057 and #3058.

Changes proposed in this PR:
- Mark roles presented in "Add a Contributor" pane, defined in `app/presenters/contributor_presenter.rb`.
- Mark "Grant Number" label under "Project Details" tab, defined in `app/views/plans/_project_details.html.erb`.