### PR TITLE
Issue#dcc2983 - Fix for preventing adding a Contributor via Contributor

### DIFF
--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -55,7 +55,7 @@ class Contributor < ApplicationRecord
   validates :roles, numericality: { greater_than: 0,
                                     message: _("You must specify at least one role.") }
 
-  validate :name_or_email_presence
+  validate :name_and_email_presence
 
   ONTOLOGY_NAME = "CRediT - Contributor Roles Taxonomy"
   ONTOLOGY_LANDING_PAGE = "https://credit.niso.org/"
@@ -130,11 +130,11 @@ class Contributor < ApplicationRecord
 
   private
 
-  def name_or_email_presence
-    return true unless name.blank? && email.blank?
+  def name_and_email_presence
+    return true unless name.blank? || email.blank?
 
-    errors.add(:name, _("can't be blank if no email is provided"))
-    errors.add(:email, _("can't be blank if no name is provided"))
+    errors.add(:name, _("can't be blank.")) if name.blank?
+    errors.add(:email, _("can't be blank.")) if email.blank?
   end
 
 end

--- a/spec/models/contributor_spec.rb
+++ b/spec/models/contributor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Contributor, type: :model do
         .with_message("You must specify at least one role.")
     end
 
-    describe "#name_or_email_presence" do
+    describe "#name_and_email_presence" do
       before(:each) do
         @contributor = build(:contributor, plan: create(:plan), investigation: true)
       end
@@ -27,13 +27,13 @@ RSpec.describe Contributor, type: :model do
         expect(@contributor.errors[:name].present?).to eql(true)
         expect(@contributor.errors[:email].present?).to eql(true)
       end
-      it "is valid if a name is present" do
+      it "is valid if a name is present and email is blank" do
         @contributor.email = nil
-        expect(@contributor.valid?).to eql(true)
+        expect(@contributor.valid?).to eql(false)
       end
-      it "is valid if an email is present" do
+      it "is valid if an email is present and name is blank" do
         @contributor.name = nil
-        expect(@contributor.valid?).to eql(true)
+        expect(@contributor.valid?).to eql(false)
       end
     end
 

--- a/spec/services/api/v1/contextual_error_service_spec.rb
+++ b/spec/services/api/v1/contextual_error_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Api::V1::ContextualErrorService do
       result = described_class.contextualize(errors: @plan.errors)
       expect(result.length).to eql(2)
       expect(result.first.start_with?("Contact/Contributor ")).to eql(true)
-      expect(result.first.include?(" can't be blank if no ")).to eql(true)
+      expect(result.first.include?(" can't be blank")).to eql(true)
     end
     it "returns errors if a Contributor Org is invalid" do
       @plan.contributors.first.org.name = nil


### PR DESCRIPTION
page if both Name and Email are not present.

Fixes DCC bug https://github.com/DMPRoadmap/roadmap/issues/2983
spec/services/api/v1/contextual_error_service_spec.rb
Changes:
  - Changes in Contributor model:
       - Renamed validation method name_or_email_presence() -> name_and_email_presence()
       - Updated conditions in name_and_email_presence() method to return errors if Name or Email missing.
  - Updated tests in spec/models/contributor_spec.rb and spec/services/api/v1/contextual_error_service_spec.r to reflect change in Contributor model.

@briri Not sure if this conditionality is different for UC3.
(Away for a week so won't pick up until Nov 15th.)

Scrrenshots of different error scenarios:
![Selection_031](https://user-images.githubusercontent.com/8876215/140308893-d1f24451-5223-4460-b639-9309c70be057.png)
![Selection_030](https://user-images.githubusercontent.com/8876215/140308897-bfbc0bc5-d7ec-4d41-a51d-5a9a11ba8f29.png)
![Selection_029](https://user-images.githubusercontent.com/8876215/140308899-6b7624aa-39f1-4d08-a109-69fb1f69b916.png)
