### PR TITLE
Issue#dcc2983 - Fix for preventing adding a Contributor via Contributor

### DIFF
--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -58,16 +58,17 @@ module Paginable
     end
     # rubocop:enable Metrics/AbcSize
 
-    # GET /paginable/plans/org_admin/:page
-    def org_admin_other_user
+    # GET /paginable/users/:id/plans
+    def index
       @user = User.find(params[:id])
       authorize @user
       raise Pundit::NotAuthorizedError unless current_user.present? && current_user.can_org_admin? && @user.present?
 
       paginable_renderise(
-        partial: 'org_admin_other_user',
+        partial: 'index',
         scope: Plan.active(@user),
-        query_params: { sort_field: 'plans.updated_at', sort_direction: :desc }
+        query_params: { sort_field: 'plans.updated_at', sort_direction: :desc },
+        format: :json
       )
     end
   end

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -153,7 +153,8 @@ module SuperAdmin
       params.require(:org).permit(:name, :abbreviation, :logo, :managed,
                                   :contact_email, :contact_name,
                                   :remove_logo, :feedback_enabled, :feedback_msg,
-                                  :org_id, :org_name, :org_crosswalk)
+                                  :org_id, :org_name, :org_crosswalk,
+                                  :funder, :institution, :organisation)
     end
 
     def merge_params

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -174,7 +174,7 @@ module ExportablePlan
       answer_text = ''
       if answer.present?
         answer_text += answer.question_options.pluck(:text).join(', ') if answer.question_options.any?
-        answer_text += answer.text if answer.answered?
+        answer_text += answer.text if answer.answered? && answer.text.present?
       elsif unanswered
         answer_text += _('Not Answered')
       end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -145,5 +145,5 @@ class Contributor < ApplicationRecord
     end
 
     return errors.length == 0
-end
+  end
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -130,35 +130,20 @@ class Contributor < ApplicationRecord
 
   private
 
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def name_or_email_presence
-    return true unless (name.blank? && email.blank?) ||
-                        (!!Rails.configuration.x.application.require_contributor_name &&
-                        name.blank?) ||
-                        (!!Rails.configuration.x.application.require_contributor_email &&
-                        email.blank?)
-
-    # Error messages for case where name.blank? and email.blank? and
-    # properties Rails.configuration.x.application.require_contributor_name and
-    # Rails.configuration.x.application.require_contributor_email both not set (i.e, nil) or false.
-    if (name.blank? && email.blank?) &&
-       !Rails.configuration.x.application.require_contributor_name &&
-       !Rails.configuration.x.application.require_contributor_email
+    if name.blank? && Rails.configuration.x.application.require_contributor_name
+      errors.add(:name, _("can't be blank."))
+    end
+    
+    if email.blank? && Rails.configuration.x.application.require_contributor_email
+      errors.add(:email, _("can't be blank."))
+    end
+    
+    if name.blank? && email.blank? && errors.length == 0
       errors.add(:name, _("can't be blank if no email is provided."))
       errors.add(:email, _("can't be blank if no name is provided."))
-    else
-
-      # Error messages cases where enither ame.blank? or email.blank?
-      if name.blank? && !!Rails.configuration.x.application.require_contributor_name
-        errors.add(:name, _("can't be blank."))
-      end
-
-      if email.blank? && !!Rails.configuration.x.application.require_contributor_email
-        errors.add(:email, _("can't be blank."))
-      end
     end
-  end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
+
+    return errors.length == 0
+end
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -130,20 +130,17 @@ class Contributor < ApplicationRecord
 
   private
 
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
   def name_or_email_presence
-    if name.blank? && Rails.configuration.x.application.require_contributor_name
-      errors.add(:name, _("can't be blank."))
-    end
-    
-    if email.blank? && Rails.configuration.x.application.require_contributor_email
-      errors.add(:email, _("can't be blank."))
-    end
-    
-    if name.blank? && email.blank? && errors.length == 0
+    errors.add(:name, _("can't be blank.")) if name.blank? && Rails.configuration.x.application.require_contributor_name
+    errors.add(:email, _("can't be blank.")) if email.blank? && Rails.configuration.x.application.require_contributor_email
+  
+    if name.blank? && email.blank? && errors.length.zero?
       errors.add(:name, _("can't be blank if no email is provided."))
       errors.add(:email, _("can't be blank if no name is provided."))
     end
 
-    return errors.length == 0
+    return errors.length.zero?
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -130,10 +130,35 @@ class Contributor < ApplicationRecord
 
   private
 
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   def name_or_email_presence
-    return true unless name.blank? && email.blank?
+    return true unless (name.blank? && email.blank?) ||
+                        (!!Rails.configuration.x.application.require_contributor_name &&
+                        name.blank?) ||
+                        (!!Rails.configuration.x.application.require_contributor_email &&
+                        email.blank?)
 
-    errors.add(:name, _("can't be blank if no email is provided"))
-    errors.add(:email, _("can't be blank if no name is provided"))
+    # Error messages for case where name.blank? and email.blank? and
+    # properties Rails.configuration.x.application.require_contributor_name and
+    # Rails.configuration.x.application.require_contributor_email both not set (i.e, nil) or false.
+    if (name.blank? && email.blank?) &&
+       !Rails.configuration.x.application.require_contributor_name &&
+       !Rails.configuration.x.application.require_contributor_email
+      errors.add(:name, _("can't be blank if no email is provided."))
+      errors.add(:email, _("can't be blank if no name is provided."))
+    else
+
+      # Error messages cases where enither ame.blank? or email.blank?
+      if name.blank? && !!Rails.configuration.x.application.require_contributor_name
+        errors.add(:name, _("can't be blank."))
+      end
+
+      if email.blank? && !!Rails.configuration.x.application.require_contributor_email
+        errors.add(:email, _("can't be blank."))
+      end
+    end
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -133,14 +133,17 @@ class Contributor < ApplicationRecord
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
   def name_or_email_presence
     errors.add(:name, _("can't be blank.")) if name.blank? && Rails.configuration.x.application.require_contributor_name
-    errors.add(:email, _("can't be blank.")) if email.blank? && Rails.configuration.x.application.require_contributor_email
-  
+    if email.blank? && Rails.configuration.x.application.require_contributor_email
+      errors.add(:email,
+                 _("can't be blank."))
+    end
+
     if name.blank? && email.blank? && errors.length.zero?
       errors.add(:name, _("can't be blank if no email is provided."))
       errors.add(:email, _("can't be blank if no name is provided."))
     end
 
-    return errors.length.zero?
+    errors.length.zero?
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -138,12 +138,12 @@ class Contributor < ApplicationRecord
                  _("can't be blank."))
     end
 
-    if name.blank? && email.blank? && errors.length.zero?
+    if name.blank? && email.blank? && errors.size.zero?
       errors.add(:name, _("can't be blank if no email is provided."))
       errors.add(:email, _("can't be blank if no name is provided."))
     end
 
-    errors.length.zero?
+    errors.size.zero?
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -288,10 +288,12 @@ class Org < ApplicationRecord
 
     if Rails.configuration.x.plans.org_admins_read_all
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
+          .where(roles: { active: true })
     else
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
           .where.not(visibility: Plan.visibilities[:privately_visible])
           .where.not(visibility: Plan.visibilities[:is_test])
+          .where(roles: { active: true })
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -94,8 +94,6 @@ class Org < ApplicationRecord
   validates :name, presence: { message: PRESENCE_MESSAGE },
                    uniqueness: { message: UNIQUENESS_MESSAGE }
 
-  validates :abbreviation, presence: { message: PRESENCE_MESSAGE }
-
   validates :is_other, inclusion: { in: BOOLEAN_VALUES,
                                     message: PRESENCE_MESSAGE }
 

--- a/app/views/org_admin/users/edit.html.erb
+++ b/app/views/org_admin/users/edit.html.erb
@@ -75,9 +75,9 @@
 <div class="row">
   <div class="col-md-12">
     <%= paginable_renderise(
-      partial: '/paginable/plans/org_admin_other_user',
+      partial: '/paginable/plans/index',
       controller: 'paginable/plans',
-      action: 'org_admin_other_user',
+      action: 'index',
       scope: @plans,
       query_params: { sort_field: 'plans.updated_at', sort_direction: 'desc' }) %>
   </div>

--- a/app/views/org_admin/users/plans.html.erb
+++ b/app/views/org_admin/users/plans.html.erb
@@ -7,9 +7,9 @@
 <div class="row">
   <div class="col-md-12">
     <%= paginable_renderise(
-      partial: '/paginable/plans/org_admin_other_user',
+      partial: '/paginable/plans/index',
       controller: 'paginable/plans',
-      action: 'org_admin_other_user',
+      action: 'index',
       remote: true,
       scope: @plans,
       query_params: { sort_field: 'plans.updated_at', sort_direction: 'desc' }) %>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -25,7 +25,7 @@
     <div class="row">
       <div class="form-group col-xs-8">
         <%= f.label :abbreviation, _('Organisation abbreviated name'), class: "control-label" %>
-        <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control", "aria-required": true %>
+        <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control" %>
       </div>
     </div>
   <% end %>

--- a/app/views/paginable/plans/_index.html.erb
+++ b/app/views/paginable/plans/_index.html.erb
@@ -21,8 +21,8 @@
             <% end %>
           </td>
           <td><%= plan.template.title %></td>
-          <td><%= plan.owner&.org&.name %></td>
-          <td><%= plan.owner&.name(false) %></td>
+          <td><%= plan.owner.org.name if plan.owner.present? %></td>
+          <td><%= plan.owner.name(false) if plan.owner.present? %></td>
           <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
           <td class="plan-visibility">
             <%= plan.visibility === 'is_test' ? _('Test') : sanitize(display_visibility(plan.visibility)) %>

--- a/app/views/shared/org_selectors/_external_only.html.erb
+++ b/app/views/shared/org_selectors/_external_only.html.erb
@@ -13,8 +13,8 @@ presenter = OrgSelectionPresenter.new(orgs: [default_org],
 placeholder = _("Begin typing to see a list of suggestions.")
 %>
 
-<%= form.label :org_name, label %>
-<%= form.text_field :org_name, class: "form-control autocomplete",
+<%= form.label :name, label %>
+<%= form.text_field :name, class: "form-control autocomplete",
                             placeholder: placeholder,
                             value: presenter.name,
                             spellcheck: true,

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -109,9 +109,9 @@
 <div class="row">
   <div class="col-md-12">
     <%= paginable_renderise(
-      partial: '/paginable/plans/org_admin_other_user',
+      partial: '/paginable/plans/index',
       controller: 'paginable/plans',
-      action: 'org_admin_other_user',
+      action: 'index',
       scope: @plans,
       query_params: { sort_field: 'plans.updated_at', sort_direction: 'desc' }) %>
   </div>

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -118,6 +118,10 @@ module DMPRoadmap
     # Setting to display phone number in contributor form
     config.x.application.display_contributor_phone_number = false
 
+    # Setting require contributor requirement of contributor name and email
+    config.x.application.require_contributor_name = false
+    config.x.application.require_contributor_email = false
+
     # ------------------- #
     # SHIBBOLETH SETTINGS #
     # ------------------- #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,17 +210,17 @@ Rails.application.routes.draw do
 
       get 'org_admin/:page', action: :org_admin, on: :collection, as: :org_admin
 
-      get 'org_admin_other_user/:page', action: :org_admin_other_user,
-                                        on: :collection, as: :org_admin_other_user
-
       # Paginable actions for contributors
       resources :contributors, only: %i[index] do
         get 'index/:page', action: :index, on: :collection, as: :index
       end
     end
+
     # Paginable actions for users
-    resources :users, only: [] do
-      get 'index/:page', action: :index, on: :collection, as: :index
+    resources :users, only: %i[index] do
+      member do
+        resources :plans, only: %(index)
+      end
     end
     # Paginable actions for themes
     resources :themes, only: [] do

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -399,6 +399,7 @@ RSpec.describe Org, type: :model do
         @perm = build(:perm)
         @perm.name = 'grant_permissions'
         user.perms << @perm
+        plan.add_user!(user.id, :reviewer)
         plan.privately_visible!
       end
 
@@ -411,6 +412,7 @@ RSpec.describe Org, type: :model do
         @perm = build(:perm)
         @perm.name = 'grant_permissions'
         user.perms << @perm
+        plan.add_user!(user.id, :reviewer)
         plan.publicly_visible!
       end
 

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Org, type: :model do
         .with_message('must be unique')
     }
 
-    it { is_expected.to validate_presence_of(:abbreviation) }
-
     it { is_expected.to allow_values(true, false).for(:is_other) }
 
     it { is_expected.not_to allow_value(nil).for(:is_other) }


### PR DESCRIPTION
form for Plan based on whether email and/or name are required.

Fix for DCC bug https://github.com/DMPRoadmap/roadmap/issues/2983

Changes:
 - Added two new properties to config/initializers/_dmproadmap.rb
   (both devault to false):
   config.x.application.require_contributor_name = false
   config.x.application.require_contributor_email = false
 -In Contributor model the private method name_or_email_presence()
  has been updated to take account of the above mentioned property
settings.

Fixes # .

Changes proposed in this PR:
-
