### PR TITLE
use current user rather than form user id which can be spoofed

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -11,7 +11,8 @@ class NotesController < ApplicationController
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def create
     @note = Note.new
-    @note.user_id = note_params[:user_id]
+    # take user id from current user rather than form as form can be spoofed
+    @note.user_id = current_user.id
     # ensure user has access to plan BEFORE creating/finding answer
     unless Plan.find_by(id: note_params[:plan_id]).readable_by?(@note.user_id)
       raise Pundit::NotAuthorizedError


### PR DESCRIPTION
Fixes #[603](https://github.com/DigitalCurationCentre/DMPonline-Service/issues/603) .

Changes proposed in this PR:
- use current user id for comments rather than the user id on the form
- the above ticket listed a couple of "security issues" which came from Erasmus. This is the second.
- if someone edits the html and replaces the userid with one for someone who has permissions to comment they can spoof the user. Only works with people who have permission to comment so not a big deal but, still, might as well plug it.
