### PR TITLE
get org creation to follow restrict_orgs

### DIFF
--- a/app/controllers/concerns/org_selectable.rb
+++ b/app/controllers/concerns/org_selectable.rb
@@ -65,7 +65,9 @@ module OrgSelectable
 
     # Converts the incoming params_into an Org by either locating it
     # via its id, identifier and/or name, or initializing a new one
-    def org_from_params(params_in:, allow_create: true)
+    # the default allow_create is based off restrict_orgs
+    def org_from_params(params_in:, 
+                        allow_create: !Rails.configuration.x.application.restrict_orgs)
       # params_in = params_in.with_indifferent_access
       return nil unless params_in[:org_id].present? &&
                         params_in[:org_id].is_a?(String)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -267,7 +267,7 @@ class PlansController < ApplicationController
       #       appropriate namespace, so org_id represents our funder
       funder_attrs = plan_params[:funder]
       funder_attrs[:org_id] = plan_params[:funder][:id]
-      funder = org_from_params(params_in: funder_attrs, allow_create: true)
+      funder = org_from_params(params_in: funder_attrs)
       @plan.funder_id = funder&.id
       attrs.delete(:funder)
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -304,7 +304,7 @@ class RegistrationsController < Devise::RegistrationsController
   def handle_org(attrs:)
     return attrs unless attrs.present? && attrs[:org_id].present?
 
-    org = org_from_params(params_in: attrs, allow_create: true)
+    org = org_from_params(params_in: attrs)
 
     # Remove the extraneous Org Selector hidden fields
     attrs = remove_org_selection_params(params_in: attrs)


### PR DESCRIPTION
Fixes [#3064](https://github.com/DMPRoadmap/roadmap/issues/3064) and [#650](https://github.com/DigitalCurationCentre/DMPonline-Service/issues/650) .

Changes proposed in this PR:
- change default allow creation to trigger off the config setting restrict_orgs
- remove various explicit allow_creates so that they just go to the default
