### PR TITLE
Bug DCC Issues 592, 645 - Fix for Org Admins seeing deleted Plans for…

### DIFF
--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -153,7 +153,8 @@ module SuperAdmin
       params.require(:org).permit(:name, :abbreviation, :logo, :managed,
                                   :contact_email, :contact_name,
                                   :remove_logo, :feedback_enabled, :feedback_msg,
-                                  :org_id, :org_name, :org_crosswalk)
+                                  :org_id, :org_name, :org_crosswalk,
+                                  :funder, :institution, :organisation)
     end
 
     def merge_params

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -288,10 +288,12 @@ class Org < ApplicationRecord
 
     if Rails.configuration.x.plans.org_admins_read_all
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
+          .where(roles: { active: true })
     else
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
           .where.not(visibility: Plan.visibilities[:privately_visible])
           .where.not(visibility: Plan.visibilities[:is_test])
+          .where(roles: { active: true })
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -94,8 +94,6 @@ class Org < ApplicationRecord
   validates :name, presence: { message: PRESENCE_MESSAGE },
                    uniqueness: { message: UNIQUENESS_MESSAGE }
 
-  validates :abbreviation, presence: { message: PRESENCE_MESSAGE }
-
   validates :is_other, inclusion: { in: BOOLEAN_VALUES,
                                     message: PRESENCE_MESSAGE }
 

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -25,7 +25,7 @@
     <div class="row">
       <div class="form-group col-xs-8">
         <%= f.label :abbreviation, _('Organisation abbreviated name'), class: "control-label" %>
-        <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control", "aria-required": true %>
+        <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control" %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/org_selectors/_external_only.html.erb
+++ b/app/views/shared/org_selectors/_external_only.html.erb
@@ -13,8 +13,8 @@ presenter = OrgSelectionPresenter.new(orgs: [default_org],
 placeholder = _("Begin typing to see a list of suggestions.")
 %>
 
-<%= form.label :org_name, label %>
-<%= form.text_field :org_name, class: "form-control autocomplete",
+<%= form.label :name, label %>
+<%= form.text_field :name, class: "form-control autocomplete",
                             placeholder: placeholder,
                             value: presenter.name,
                             spellcheck: true,

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -399,6 +399,7 @@ RSpec.describe Org, type: :model do
         @perm = build(:perm)
         @perm.name = 'grant_permissions'
         user.perms << @perm
+        plan.add_user!(user.id, :reviewer)
         plan.privately_visible!
       end
 
@@ -411,6 +412,7 @@ RSpec.describe Org, type: :model do
         @perm = build(:perm)
         @perm.name = 'grant_permissions'
         user.perms << @perm
+        plan.add_user!(user.id, :reviewer)
         plan.publicly_visible!
       end
 

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Org, type: :model do
         .with_message('must be unique')
     }
 
-    it { is_expected.to validate_presence_of(:abbreviation) }
-
     it { is_expected.to allow_values(true, false).for(:is_other) }
 
     it { is_expected.not_to allow_value(nil).for(:is_other) }


### PR DESCRIPTION
… Org.

Fixes issues:
https://github.com/DigitalCurationCentre/DMPonline-Service/issues/592
https://github.com/DigitalCurationCentre/DMPonline-Service/issues/645
https://github.com/DigitalCurationCentre/DMPonline-Service/issues/641

The reason we are seeing deleted (de-activated) Plans is that there is
no filter for plans with Roles active in the Org model's
org_admin_plans() method.

Change added .where(roles: { active: true }) to filter plans in
org_admin_plans() method of Org model.
