### PR TITLE
DCC Issue 679 - Fix for issue that Super Admins unable to create new

### DIFF
--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -153,7 +153,8 @@ module SuperAdmin
       params.require(:org).permit(:name, :abbreviation, :logo, :managed,
                                   :contact_email, :contact_name,
                                   :remove_logo, :feedback_enabled, :feedback_msg,
-                                  :org_id, :org_name, :org_crosswalk)
+                                  :org_id, :org_name, :org_crosswalk,
+                                  :funder, :institution, :organisation)
     end
 
     def merge_params

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -94,8 +94,6 @@ class Org < ApplicationRecord
   validates :name, presence: { message: PRESENCE_MESSAGE },
                    uniqueness: { message: UNIQUENESS_MESSAGE }
 
-  validates :abbreviation, presence: { message: PRESENCE_MESSAGE }
-
   validates :is_other, inclusion: { in: BOOLEAN_VALUES,
                                     message: PRESENCE_MESSAGE }
 

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -25,7 +25,7 @@
     <div class="row">
       <div class="form-group col-xs-8">
         <%= f.label :abbreviation, _('Organisation abbreviated name'), class: "control-label" %>
-        <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control", "aria-required": true %>
+        <%= f.text_field :abbreviation, id: "org_abbreviation", class: "form-control" %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/org_selectors/_external_only.html.erb
+++ b/app/views/shared/org_selectors/_external_only.html.erb
@@ -13,8 +13,8 @@ presenter = OrgSelectionPresenter.new(orgs: [default_org],
 placeholder = _("Begin typing to see a list of suggestions.")
 %>
 
-<%= form.label :org_name, label %>
-<%= form.text_field :org_name, class: "form-control autocomplete",
+<%= form.label :name, label %>
+<%= form.text_field :name, class: "form-control autocomplete",
                             placeholder: placeholder,
                             value: presenter.name,
                             spellcheck: true,

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe Org, type: :model do
         .with_message('must be unique')
     }
 
-    it "is expected to have an abbeviation" do
-      pp "ORG:"
-      pp subject
-      is_expected.to validate_presence_of(:abbreviation)
-    end
-
     it { is_expected.to allow_values(true, false).for(:is_other) }
 
     it { is_expected.not_to allow_value(nil).for(:is_other) }

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -11,9 +11,12 @@ RSpec.describe Org, type: :model do
       is_expected.to validate_uniqueness_of(:name)
         .with_message('must be unique')
     }
-    pp "ORG:"
-    pp subject
-    it { is_expected.to validate_presence_of(:abbreviation) }
+
+    it "is expected to have an abbeviation" do
+      pp "ORG:"
+      pp subject
+      is_expected.to validate_presence_of(:abbreviation)
+    end
 
     it { is_expected.to allow_values(true, false).for(:is_other) }
 

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Org, type: :model do
       is_expected.to validate_uniqueness_of(:name)
         .with_message('must be unique')
     }
-
+    pp "ORG:"
+    pp subject
     it { is_expected.to validate_presence_of(:abbreviation) }
 
     it { is_expected.to allow_values(true, false).for(:is_other) }

--- a/spec/services/api/v1/persistence_service_spec.rb
+++ b/spec/services/api/v1/persistence_service_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Api::V1::PersistenceService do
       plan.contributors << contributor
       plan.contributors << contributor2
       result = described_class.safe_save(plan: plan)
+      pp "CONTRIBUTORS:"
+      pp result.contributors
       expect(result.contributors.length).to eql(2)
       expect(result.contributors.first.org).to eql(result.contributors.last.org)
     end

--- a/spec/services/api/v1/persistence_service_spec.rb
+++ b/spec/services/api/v1/persistence_service_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe Api::V1::PersistenceService do
       plan.contributors << contributor
       plan.contributors << contributor2
       result = described_class.safe_save(plan: plan)
-      pp "CONTRIBUTORS:"
-      pp result.contributors
       expect(result.contributors.length).to eql(2)
       expect(result.contributors.first.org).to eql(result.contributors.last.org)
     end


### PR DESCRIPTION
Orgs.

Fix for DCC issue https://github.com/DigitalCurationCentre/DMPonline-Service/issues/679

Changes:
- in **app/controllers/super_admin/orgs_controller.rb** added missing params
to **orgs_params** method
     **:funder, :institution, :organisation**
- in **app/models/org.rb** removed (as it is never set on Org creation)
      **validates :abbreviation, presence: { message: PRESENCE_MESSAGE }**
- in **app/views/orgs/_profile_form.html.erb** removed :abbreviation required
      **"aria-required": true**
- in **app/views/shared/org_selectors/_external_only.html.erb** renamed wrongly named text field **:org_name** to **:name**
      **<%= form.label :name, label %>
      <%= form.text_field :name, class: "form-control autocomplete",**
