### PR TITLE
Fix downloads

### DIFF
--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -161,7 +161,9 @@ module Paginable
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def sort_direction
-    @sort_direction ||= SortDirection.new(@args[:sort_direction])
+    sd = "asc"
+    sd = "desc" if @args[:sort_direction] == "desc"
+    @sort_direction ||= SortDirection.new(sd)
   end
 
   # Returns the sort link name for a given sort_field. The link name includes

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -148,8 +148,9 @@ module Paginable
         scope = scope.order(order_field.to_sym => sort_direction.to_s)
       else
         order_field = ActiveRecord::Base.sanitize_sql(@args[:sort_field])
+        sd = ActiveRecord::Base.sanitize_sql(sort_direction)
         scope = scope.includes(table_part.singularize.to_sym)
-                     .order("#{order_field} #{sort_direction}")
+                     .order("#{order_field} #{sd}")
       end
     end
     if @args[:page] != 'ALL'
@@ -161,9 +162,7 @@ module Paginable
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def sort_direction
-    sd = "asc"
-    sd = "desc" if @args[:sort_direction] == "desc"
-    @sort_direction ||= SortDirection.new(sd)
+    @sort_direction ||= SortDirection.new(@args[:sort_direction])
   end
 
   # Returns the sort link name for a given sort_field. The link name includes

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -68,9 +68,9 @@ module OrgAdmin
           csv << [
             plan.title.to_s,
             plan.template.title.to_s,
-            (plan.owner.org.present? ? plan.owner.org.name : '').to_s,
-            plan.owner.name(false).to_s,
-            plan.owner.email.to_s,
+            (plan.owner&.org&.present? ? plan.owner.org.name : "").to_s,
+            plan.owner&.name(false)&.to_s,
+            plan.owner&.email&.to_s,
             l(plan.latest_update.to_date, format: :csv).to_s,
             Plan::VISIBILITY_MESSAGE[plan.visibility.to_sym].capitalize.to_s
           ]

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -81,6 +81,6 @@ module OrgAdmin
         format.csv  { send_data plans, filename: "#{file_name}.csv" }
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   end
 end

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -43,7 +43,7 @@ module OrgAdmin
     # rubocop:enable Metrics/AbcSize
 
     # GET /org_admin/download_plans
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def download_plans
       # Test auth directly and throw Pundit error sincePundit
       # is unaware of namespacing
@@ -68,7 +68,7 @@ module OrgAdmin
           csv << [
             plan.title.to_s,
             plan.template.title.to_s,
-            (plan.owner&.org&.present? ? plan.owner.org.name : "").to_s,
+            (plan.owner&.org&.present? ? plan.owner.org.name : '').to_s,
             plan.owner&.name(false)&.to_s,
             plan.owner&.email&.to_s,
             l(plan.latest_update.to_date, format: :csv).to_s,

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -78,7 +78,7 @@
                     <br>
                   <%# case for displaying comments OR text %>
                   <% elsif !blank %>
-                    <%= sanitize answer.text %>
+                    <%= sanitize answer&.text %>
                     <br><br>
                   <% end %>
                 <% end %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -1,7 +1,7 @@
 <%= "#{@plan.title}" %>
 <%= "----------------------------------------------------------\n" %>
 <% if @show_coversheet %>
-<%= @hash[:attribution].many? ? _("Creators: ") : _('Creator:') %> <%= @hash[:attribution].join(', ') %>
+<%= @hash[:attribution].length > 1 ? _("Creators: ") : _('Creator:') %> <%= @hash[:attribution].join(', ') %>
 <%= _("Affiliation: ") + @hash[:affiliation] %>
   <% if @hash[:funder].present? %>
 <%= _("Template: ") + @hash[:funder] %>
@@ -24,7 +24,7 @@
 <% @hash[:phases].each do |phase| %>
 <%# Only render selected phase %>
 <% if phase[:title] == @selected_phase.title %>
-<%= (@hash[:phases].many? ? "#{phase[:title]}" : "") %>
+<%= (@hash[:phases].length > 1 ? "#{phase[:title]}" : "") %>
   <% phase[:sections].each do |section| %>
     <% if display_section?(@hash[:customization], section, @show_custom_sections) && num_section_questions(@plan, section, phase) > 0 %>
       <% if @show_sections_questions %>


### PR DESCRIPTION
Fixes #3074.

    Addresses an issue when downloading a plan with a blank answer
    Fixes an issue that was preventing an Org Admin from downloading their Org's plans as CSV if any plan had a nil owner
    Fixes an issue downloading a plan as text

(Originally done by @briri but redone here to just have the needed change since master has changed so much since it was done)
