### PR TITLE
fix authorize

### DIFF
--- a/app/controllers/paginable/contributors_controller.rb
+++ b/app/controllers/paginable/contributors_controller.rb
@@ -12,7 +12,7 @@ module Paginable
     # GET /paginable/plans/:plan_id/contributors/index/:page
     def index
       @plan = Plan.find_by(id: params[:plan_id])
-      authorize @plan
+      authorize @plan, :show?
       paginable_renderise(
         partial: 'index',
         scope: Contributor.where(plan_id: @plan.id),


### PR DESCRIPTION
Fixes [security issue with plan policy](https://github.com/DigitalCurationCentre/DMPonline-Service/issues/682).

Changes proposed in this PR:

    authorize on index method in contributors controller had no effect in essence allowing anyone access to any plan. See ticket above for an example. This change requires the :show? policy to be satisfied.
