### PR TITLE
fix for issue invoking the public page policy for template exports

### DIFF
--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -30,7 +30,7 @@ class PublicPagesController < ApplicationController
     @template = Template.live(params[:id])
     # covers authorization for this action.
     # Pundit dosent support passing objects into scoped policies
-    unless PublicPagePolicy.new(@template).template_export?
+    unless PublicPagePolicy.new(current_user, @template).template_export?
       msg = 'You are not authorized to export that template'
       redirect_to public_templates_path, notice: msg and return
       # raise Pundit::NotAuthorizedError

--- a/app/policies/public_page_policy.rb
+++ b/app/policies/public_page_policy.rb
@@ -3,7 +3,12 @@
 # Security rules for the public pages
 # Note the method names here correspond with controller actions
 class PublicPagePolicy < ApplicationPolicy
-  # NOTE: @user is the signed_in_user and @record is an instance of Plan
+  # rubocop:disable Lint/MissingSuper
+  def initialize(object, object2 = nil)
+    @object = object
+    @object2 = object2
+  end
+  # rubocop:enable Lint/MissingSuper
 
   def plan_index?
     true
@@ -14,18 +19,19 @@ class PublicPagePolicy < ApplicationPolicy
   end
 
   def template_export?
-    @record.present? && @record.published?
+    @object.present? && @object2.published?
   end
 
   def plan_export?
-    @record.publicly_visible?
+    @object2.publicly_visible?
   end
 
   def plan_organisationally_exportable?
-    if @record.is_a?(Plan) && @user.is_a?(User)
-      return @record.publicly_visible? ||
-             (@record.organisationally_visible? && @record.owner.present? &&
-              @record.owner.org_id == @user.org_id)
+    plan = @object
+    user = @object2
+    if plan.is_a?(Plan) && user.is_a?(User)
+      return plan.publicly_visible? || (plan.organisationally_visible? && plan.owner.present? &&
+        plan.owner.org_id == user.org_id)
     end
 
     false


### PR DESCRIPTION
Fix for Issue exporting public templates. Was receiving a 'unknown method published? for nil class'.

Issue was due to direct instantiation of the PublicPagePolicy and only supplying one argument. Fixed by adding 'current_user'
