### PR TITLE
Revert string format token changes made for Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -147,6 +147,9 @@ Style/DocumentDynamicEvalDefinition: # new in 1.1
   Enabled: true
 Style/EndlessMethod: # new in 1.8
   Enabled: true
+Style/FormatStringToken:
+  # Disabling this because Translation.io has trouble with the `%<variable>s` format
+  Enabled: false
 Style/HashConversion: # new in 1.10
   Enabled: true
 Style/HashExcept: # new in 1.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,8 +148,10 @@ Style/DocumentDynamicEvalDefinition: # new in 1.1
 Style/EndlessMethod: # new in 1.8
   Enabled: true
 Style/FormatStringToken:
-  # Disabling this because Translation.io has trouble with the `%<variable>s` format
-  Enabled: false
+  # Force use of the `%{variable}` style of tokens instead of `%<variable>s` because
+  # Translation.io has trouble with auto-translating it. It converts `%<variable>s` to
+  # `%<variable> s` (note the added space)
+  EnforcedStyle: template
 Style/HashConversion: # new in 1.10
   Enabled: true
 Style/HashExcept: # new in 1.7

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -22,7 +22,7 @@ class AnswersController < ApplicationController
       unless p.question_exists?(p_params[:question_id])
         # rubocop:disable Layout/LineLength
         render(status: :not_found, json: {
-                 msg: format(_('There is no question with id %<question_id>s associated to plan id %<plan_id>s for which to create or update an answer'), question_id: p_params[:question_id], plan_id: p_params[:plan_id])
+                 msg: format(_('There is no question with id %{question_id} associated to plan id %{plan_id} for which to create or update an answer'), question_id: p_params[:question_id], plan_id: p_params[:plan_id])
                })
         # rubocop:enable Layout/LineLength
         return
@@ -30,7 +30,7 @@ class AnswersController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       # rubocop:disable Layout/LineLength
       render(status: :not_found, json: {
-               msg: format(_('There is no plan with id %<id>s for which to create or update an answer'), id: p_params[:plan_id])
+               msg: format(_('There is no plan with id %{id} for which to create or update an answer'), id: p_params[:plan_id])
              })
       # rubocop:enable Layout/LineLength
       return

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -105,13 +105,13 @@ class ApplicationController < ActionController::Base
   end
 
   def failure_message(obj, action = 'save')
-    format(_('Unable to %<action>s the %<object>s.%<errors>s'),
+    format(_('Unable to %{action} the %{object}. {errors}'),
            object: obj_name_for_display(obj),
            action: action || 'save', errors: errors_for_display(obj))
   end
 
   def success_message(obj, action = 'saved')
-    format(_('Successfully %<action>s the %<object>s.'), object: obj_name_for_display(obj), action: action || 'save')
+    format(_('Successfully %{action} the %{object}.'), object: obj_name_for_display(obj), action: action || 'save')
   end
 
   def errors_for_display(obj)

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -180,7 +180,7 @@ module Paginable
          style="float: right; font-size: 1.2em;">
 
         <span class="screen-reader-text">
-          #{format(_('Sort by %<sort_field>'), sort_field: sort_field.split('.').first)}
+          #{format(_('Sort by %{sort_field}'), sort_field: sort_field.split('.').first)}
         </span>
       </i>
     HTML

--- a/app/controllers/identifiers_controller.rb
+++ b/app/controllers/identifiers_controller.rb
@@ -16,10 +16,10 @@ class IdentifiersController < ApplicationController
     if user.identifiers.include?(identifier)
       identifier.destroy!
       flash[:notice] =
-        format(_('Successfully unlinked your account from %<is>s.'), is: identifier.identifier_scheme&.description)
+        format(_('Successfully unlinked your account from %{is}.'), is: identifier.identifier_scheme&.description)
     else
       flash[:alert] =
-        format(_('Unable to unlink your account from %<is>s.'), is: identifier.identifier_scheme&.description)
+        format(_('Unable to unlink your account from %{is}.'), is: identifier.identifier_scheme&.description)
     end
 
     redirect_to edit_user_registration_path

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -33,7 +33,7 @@ module OrgAdmin
       if plan.complete_feedback(current_user)
         # rubocop:disable Layout/LineLength
         redirect_to(org_admin_plans_path,
-                    notice: format(_('%<plan_owner>s has been notified that you have finished providing feedback'), plan_owner: plan.owner.name(false)))
+                    notice: format(_('%{plan_owner} has been notified that you have finished providing feedback'), plan_owner: plan.owner.name(false)))
         # rubocop:enable Layout/LineLength
       else
         redirect_to org_admin_plans_path,

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -44,7 +44,7 @@ module OrgAdmin
 
       @orgs  = current_user.can_super_admin? ? Org.all : nil
       @title = if current_user.can_super_admin?
-                 format(_('%<org_name>s Templates'), org_name: current_user.org.name)
+                 format(_('%{org_name} Templates'), org_name: current_user.org.name)
                else
                  _('Own Templates')
                end
@@ -212,7 +212,7 @@ module OrgAdmin
       rescue ActiveSupport::JSON.parse_error
         render(json: {
                  status: :bad_request,
-                 msg: format(_('Error parsing links for a %<template>s'),
+                 msg: format(_('Error parsing links for a %{template}'),
                              template: template_type(template))
                })
         nil
@@ -340,7 +340,7 @@ module OrgAdmin
                    template: 'template_exports/template_export',
                    margin: @formatting[:margin],
                    footer: {
-                     center: format(_('Template created using the %<application_name>s service. Last modified %<date>s'), application_name: ApplicationService.application_name, date: l(@template.updated_at.to_date, formats: :short)),
+                     center: format(_('Template created using the %{application_name} service. Last modified %{date}'), application_name: ApplicationService.application_name, date: l(@template.updated_at.to_date, formats: :short)),
                      font_size: 8,
                      spacing: (@formatting[:margin][:bottom] / 2) - 4,
                      right: '[page] of [topage]',

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -82,7 +82,7 @@ class PlanExportsController < ApplicationController
     render pdf: file_name,
            margin: @formatting[:margin],
            footer: {
-             center: format(_('Created using %<application_name>s. Last modified %<date>s'),
+             center: format(_('Created using %{application_name}. Last modified %{date}'),
                             application_name: ApplicationService.application_name,
                             date: l(@plan.updated_at.to_date, format: :readable)),
              font_size: 8,

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -81,9 +81,9 @@ class PlansController < ApplicationController
 
       @plan.title = if plan_params[:title].blank?
                       if current_user.firstname.blank?
-                        format(_('My Plan (%<title>s)'), title: @plan.template.title)
+                        format(_('My Plan (%{title})'), title: @plan.template.title)
                       else
-                        format(_('%<user_name>s Plan'), user_name: "#{current_user.firstname}'s")
+                        format(_('%{user_name} Plan'), user_name: "#{current_user.firstname}'s")
                       end
                     else
                       plan_params[:title]
@@ -422,13 +422,13 @@ class PlansController < ApplicationController
       else
         # rubocop:disable Layout/LineLength
         render status: :forbidden, json: {
-          msg: format(_("Unable to change the plan's status since it is needed at least %<percentage}>s percentage responded"), percentage: Rails.configuration.x.plans.default_percentage_answered)
+          msg: format(_("Unable to change the plan's status since it is needed at least %{percentage} percentage responded"), percentage: Rails.configuration.x.plans.default_percentage_answered)
         }
         # rubocop:enable Layout/LineLength
       end
     else
       render status: :not_found,
-             json: { msg: format(_('Unable to find plan id %{<plan_id>s'),
+             json: { msg: format(_('Unable to find plan id %{plan_id}'),
                                  plan_id: params[:id]) }
     end
   end

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -64,7 +64,7 @@ class PublicPagesController < ApplicationController
                  template: 'template_exports/template_export',
                  margin: @formatting[:margin],
                  footer: {
-                   center: format(_('Template created using the %<application_name>s service. Last modified %<date>s'),
+                   center: format(_('Template created using the %{application_name} service. Last modified %{date}'),
                                   application_name: ApplicationService.application_name,
                                   date: l(@template.updated_at.to_date, formats: :short)),
                    font_size: 8,

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -32,7 +32,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     # Connect the new user with the identifier sent back by the OAuth provider
     flash[:notice] = format(_("Please make a choice below. After linking your
-                       details to a %<application_name>s account,
+                       details to a %{application_name} account,
                        you will be able to sign in directly with your
                        institutional credentials."), application_name: ApplicationService.application_name)
   end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -23,7 +23,7 @@ class RolesController < ApplicationController
        role_params[:user][:email].present? && plan.present?
 
       if @role.plan.owner.present? && @role.plan.owner.email == role_params[:user][:email]
-        flash[:notice] = format(_('Cannot share plan with %<email>s since that email matches
+        flash[:notice] = format(_('Cannot share plan with %{email} since that email matches
                                    with the owner of the plan.'),
                                 email: role_params[:user][:email])
       else
@@ -33,7 +33,7 @@ class RolesController < ApplicationController
                .count
                .positive? # role already exists
 
-          flash[:notice] = format(_('Plan is already shared with %<email>s.'),
+          flash[:notice] = format(_('Plan is already shared with %{email}.'),
                                   email: role_params[:user][:email])
         else
           # rubocop:disable Metrics/BlockNesting
@@ -44,12 +44,12 @@ class RolesController < ApplicationController
                            surname: _('Surname'),
                            org: current_user.org },
                          current_user)
-            message = format(_('Invitation to %<email>s issued successfully.'),
+            message = format(_('Invitation to %{email} issued successfully.'),
                              email: role_params[:user][:email])
             user = User.where_case_insensitive('email', role_params[:user][:email]).first
           end
 
-          message += format(_('Plan shared with %<email>s.'), email: user.email)
+          message += format(_('Plan shared with %{email}.'), email: user.email)
           @role.user = user
 
           if @role.save
@@ -87,7 +87,7 @@ class RolesController < ApplicationController
       end
       render json: {
         code: 1,
-        msg: format(_('Successfully changed the permissions for %<email>. They have been
+        msg: format(_('Successfully changed the permissions for %{email}. They have been
                        notified via email.'), email: @role.user.email)
       }
     else

--- a/app/controllers/super_admin/api_clients_controller.rb
+++ b/app/controllers/super_admin/api_clients_controller.rb
@@ -42,7 +42,7 @@ module SuperAdmin
       if @api_client.save
         UserMailer.api_credentials(@api_client).deliver_now
         msg = success_message(@api_client, _('created'))
-        msg += format(_('. The API credentials have been emailed to %<email>s'),
+        msg += format(_('. The API credentials have been emailed to %{email}'),
                       email: @api_client.contact_email)
         flash.now[:notice] = msg
         render :edit

--- a/app/controllers/super_admin/notifications_controller.rb
+++ b/app/controllers/super_admin/notifications_controller.rb
@@ -102,7 +102,7 @@ module SuperAdmin
     def set_notification
       @notification = Notification.find(params[:id] || params[:notification_id])
     rescue ActiveRecord::RecordNotFound
-      flash[:alert] = format(_('There is no notification associated with id  %<id>s'),
+      flash[:alert] = format(_('There is no notification associated with id  %{id}'),
                              id: params[:id])
       redirect_to action: :index
     end

--- a/app/controllers/super_admin/org_swaps_controller.rb
+++ b/app/controllers/super_admin/org_swaps_controller.rb
@@ -21,7 +21,7 @@ module SuperAdmin
         current_user.org = lookup
         if current_user.save
           redirect_back(fallback_location: root_path,
-                        notice: format(_('Your organisation affiliation has been changed. You may now edit templates for %<org_name>s.'),
+                        notice: format(_('Your organisation affiliation has been changed. You may now edit templates for %{org_name}.'),
                                        org_name: current_user.org.name))
         else
           redirect_back(fallback_location: root_path,

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -56,11 +56,11 @@ module Users
                                attrs: request.env['omniauth.auth'],
                                identifiable: current_user)
             flash[:notice] =
-              format(_('Your account has been successfully linked to %<scheme>s.'),
+              format(_('Your account has been successfully linked to %{scheme}.'),
                      scheme: scheme.description)
 
           else
-            flash[:alert] = format(_('Unable to link your account to %<scheme>s.'),
+            flash[:alert] = format(_('Unable to link your account to %{scheme}.'),
                                    scheme: scheme.description)
           end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -144,14 +144,14 @@ class UsersController < ApplicationController
       user.save!
       render json: {
         code: 1,
-        msg: format(_("Successfully %<action>s %<username>s's account."),
+        msg: format(_("Successfully %{action} %{username}'s account."),
                     action: user.active ? _('activated') : _('deactivated'),
                     username: user.name(false))
       }
     rescue StandardError
       render json: {
         code: 0,
-        msg: format(_('Unable to %<action>s %<username>s'),
+        msg: format(_('Unable to %{action} %{username}'),
                     action: user.active ? _('activate') : _('deactivate'),
                     username: user.name(false))
       }

--- a/app/helpers/conditions_helper.rb
+++ b/app/helpers/conditions_helper.rb
@@ -169,14 +169,14 @@ module ConditionsHelper
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def question_title(question)
-    raw format('Qn. %<question_nbr>s: %<title>s',
+    raw format('Qn. %{question_nbr}: %{title}',
                question_nbr: question.number.to_s,
                title: truncate(strip_tags(question.text), length: DISPLAY_LENGTH,
                                                           separator: ' ', escape: false))
   end
 
   def section_title(section)
-    raw format('Sec. %<section_nbr>s: %<title>s',
+    raw format('Sec. %{section_nbr}: %{title}',
                section_nbr: section.number.to_s,
                title: truncate(strip_tags(section.title), length: DISPLAY_LENGTH,
                                                           separator: ' ', escape: false))
@@ -194,7 +194,7 @@ module ConditionsHelper
       return_string += opts.join(' and ')
       if cond.action_type == 'add_webhook'
         subject_string = text_formatted(JSON.parse(cond.webhook_data)['subject'])
-        return_string += format(_(' will <b>send an email</b> with subject %<subject_name>s'),
+        return_string += format(_(' will <b>send an email</b> with subject %{subject_name}'),
                                 subject_name: subject_string)
       else
         remove_data = cond.remove_data

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -3,15 +3,15 @@
 # Helper methods for Feedback messages
 module FeedbacksHelper
   def feedback_confirmation_default_subject
-    _('%<application_name>s: Your plan has been submitted for feedback')
+    _('%{application_name}: Your plan has been submitted for feedback')
   end
 
   def feedback_confirmation_default_message
-    _('<p>Hello %<user_name>s.</p>'\
-      "<p>Your plan \"%<plan_name>s\" has been submitted for feedback from an
+    _('<p>Hello %{user_name}.</p>'\
+      "<p>Your plan \"%{plan_name}\" has been submitted for feedback from an
       administrator at your organisation. "\
       "If you have questions pertaining to this action, please contact us
-      at %<organisation_email>s.</p>")
+      at %{organisation_email}.</p>")
   end
 
   def feedback_constant_to_text(text, user, plan, org)

--- a/app/helpers/orgs_helper.rb
+++ b/app/helpers/orgs_helper.rb
@@ -11,9 +11,9 @@ module OrgsHelper
   # Returns String
   def sample_message_for_org_feedback_form(org)
     email = org.contact_email || EMAIL_PLACEHOLDER
-    format(_("<p>A data librarian from %<org_name>s will respond to your request within 48
+    format(_("<p>A data librarian from %{org_name} will respond to your request within 48
        hours. If you have questions pertaining to this action please contact us
-       at %<organisation_email>s.</p>"), organisation_email: email, org_name: org.name)
+       at %{organisation_email}.</p>"), organisation_email: email, org_name: org.name)
   end
 
   # The preferred logo url for the current configuration. If DRAGONFLY_AWS is true, return

--- a/app/helpers/super_admin/orgs/merge_helper.rb
+++ b/app/helpers/super_admin/orgs/merge_helper.rb
@@ -27,7 +27,7 @@ module SuperAdmin
                  when 'Department'
                    [entry.id, entry.name].join(' - ')
                  when 'Guidance'
-                   format(_('Guidance for: %<themes>s'), themes: entry.themes.collect(&:title).join(', '))
+                   format(_('Guidance for: %{themes}'), themes: entry.themes.collect(&:title).join(', '))
                  when 'Identifier'
                    [entry.identifier_scheme&.name, entry.value].join(' - ')
                  when 'TokenPermissionType'
@@ -50,7 +50,7 @@ module SuperAdmin
       def merge_column_content(entries:, orcid:, to_org_name:)
         return _('Nothing to merge') unless entries.present? && entries.any?
 
-        html = format(_("<p>The following %<object_types>s will be moved over to '%<org_name>s':</p>"),
+        html = format(_("<p>The following %{object_types} will be moved over to '%{org_name}':</p>"),
                       object_types: entries.first.class.name.pluralize, org_name: to_org_name)
         html + column_content(entries: entries, orcid: orcid)
       end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,14 +14,14 @@ class UserMailer < ActionMailer::Base
   def welcome_notification(user)
     @user           = user
     @username       = @user.name
-    @email_subject  = format(_('Query or feedback related to %<tool_name>s'), tool_name: tool_name)
+    @email_subject  = format(_('Query or feedback related to %{tool_name}'), tool_name: tool_name)
     # Override the default Rails route helper for the contact_us page IF an alternate contact_us
     # url was defined in the dmproadmap.rb initializer file
     @contact_us     = Rails.application.config.x.organisation.contact_us_url || contact_us_url
 
     I18n.with_locale I18n.default_locale do
       mail(to: @user.email,
-           subject: format(_('Welcome to %<tool_name>s'), tool_name: tool_name))
+           subject: format(_('Welcome to %{tool_name}'), tool_name: tool_name))
     end
   end
   # rubocop:enable Metrics/AbcSize
@@ -56,7 +56,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: @role.user.email,
-           subject: format(_('A Data Management Plan in %<tool_name>s has been shared with you'),
+           subject: format(_('A Data Management Plan in %{tool_name} has been shared with you'),
                            tool_name: tool_name))
     end
   end
@@ -72,7 +72,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: @recepient.email,
-           subject: format(_('Changed permissions on a Data Management Plan in %<tool_name>s'),
+           subject: format(_('Changed permissions on a Data Management Plan in %{tool_name}'),
                            tool_name: tool_name))
     end
   end
@@ -86,7 +86,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: @user.email,
-           subject: format(_('Permissions removed on a DMP in %<tool_name>s'),
+           subject: format(_('Permissions removed on a DMP in %{tool_name}'),
                            tool_name: tool_name))
     end
   end
@@ -103,7 +103,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: @recipient.email,
-           subject: format(_('%<user_name>s has requested feedback on a %<tool_name>s plan'),
+           subject: format(_('%{user_name} has requested feedback on a %{tool_name} plan'),
                            tool_name: tool_name, user_name: @user.name(false)))
     end
   end
@@ -125,7 +125,7 @@ class UserMailer < ActionMailer::Base
 
       mail(to: recipient.email,
            from: sender,
-           subject: format(_('%<tool_name>s: Expert feedback has been provided for %<plan_title>s'),
+           subject: format(_('%{tool_name}: Expert feedback has been provided for %{plan_title}'),
                            tool_name: tool_name, plan_title: @plan.title))
     end
   end
@@ -142,7 +142,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: @user.email,
-           subject: format(_('DMP Visibility Changed: %<plan_title>s'), plan_title: @plan.title))
+           subject: format(_('DMP Visibility Changed: %{plan_title}'), plan_title: @plan.title))
     end
   end
 
@@ -170,7 +170,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: @plan.owner.email,
-           subject: format(_('%<tool_name>s: A new comment was added to %<plan_title>s'),
+           subject: format(_('%{tool_name}: A new comment was added to %{plan_title}'),
                            tool_name: tool_name, plan_title: @plan.title))
     end
   end
@@ -185,7 +185,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: user.email,
-           subject: format(_('Administrator privileges granted in %<tool_name>s'),
+           subject: format(_('Administrator privileges granted in %{tool_name}'),
                            tool_name: tool_name))
     end
   end
@@ -201,7 +201,7 @@ class UserMailer < ActionMailer::Base
 
     I18n.with_locale I18n.default_locale do
       mail(to: @api_client.contact_email,
-           subject: format(_('%<tool_name>s API changes'), tool_name: tool_name))
+           subject: format(_('%{tool_name} API changes'), tool_name: tool_name))
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/concerns/date_rangeable.rb
+++ b/app/models/concerns/date_rangeable.rb
@@ -15,7 +15,7 @@ module DateRangeable
     def by_date_range(field, term)
       date = Date.parse(term) if term[0..1].match(/[0-9]{2}/).present?
       date = Date.parse("1st #{term}") unless date.present?
-      query = format('%<table>s.%<field>s BETWEEN ? AND ?', table: table_name, field: field)
+      query = format('%{table}.%{field} BETWEEN ? AND ?', table: table_name, field: field)
       where(query, date, date.end_of_month)
     end
   end

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -139,18 +139,18 @@ module ExportablePlan
               _('Creators: ')
             else
               _('Creator:')
-            end, format(_('%<authors>s'), authors: hash[:attribution].join(', '))]
-    csv << ['Affiliation: ', format(_('%<affiliation>s'), affiliation: hash[:affiliation])]
+            end, format(_('%{authors}'), authors: hash[:attribution].join(', '))]
+    csv << ['Affiliation: ', format(_('%{affiliation}'), affiliation: hash[:affiliation])]
     csv << if hash[:funder].present?
-             [_('Template: '), format(_('%<funder>s'), funder: hash[:funder])]
+             [_('Template: '), format(_('%{funder}'), funder: hash[:funder])]
            else
-             [_('Template: '), format(_('%<template>s'), template: hash[:template] + hash[:customizer])]
+             [_('Template: '), format(_('%{template}'), template: hash[:template] + hash[:customizer])]
            end
-    csv << [_('Grant number: '), format(_('%<grant_number>s'), grant_number: grant&.value)] if grant&.value.present?
+    csv << [_('Grant number: '), format(_('%{grant_number}'), grant_number: grant&.value)] if grant&.value.present?
     if description.present?
-      csv << [_('Project abstract: '), format(_('%<description>s'), description: Nokogiri::HTML(description).text)]
+      csv << [_('Project abstract: '), format(_('%{description}'), description: Nokogiri::HTML(description).text)]
     end
-    csv << [_('Last modified: '), format(_('%<date>s'), date: updated_at.to_date.strftime('%d-%m-%Y'))]
+    csv << [_('Last modified: '), format(_('%{date}'), date: updated_at.to_date.strftime('%d-%m-%Y'))]
     csv << [_('Copyright information:'),
             _("The above plan creator(s) have agreed that others may use as
              much of the text of this plan as they would like in their own plans,

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -379,7 +379,7 @@ class Template < ApplicationRecord
         family_id: new_family_id,
         org: org,
         is_default: false,
-        title: format(_('Copy of %<template>s'), template: title)
+        title: format(_('Copy of %{template}'), template: title)
       }, modifiable: true, save: true
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -381,7 +381,7 @@ class User < ApplicationRecord
 
   # Override devise_invitable email title
   def deliver_invitation(options = {})
-    super(options.merge(subject: format(_('A Data Management Plan in %<application_name>s has been shared with you'),
+    super(options.merge(subject: format(_('A Data Management Plan in %{application_name} has been shared with you'),
                                         application_name: ApplicationService.application_name))
     )
   end

--- a/app/validators/after_validator.rb
+++ b/app/validators/after_validator.rb
@@ -2,7 +2,7 @@
 
 # Validation to ensure that an end date must come after a begin/start date
 class AfterValidator < ActiveModel::EachValidator
-  DEFAULT_MESSAGE = _('must be after %<date>s')
+  DEFAULT_MESSAGE = _('must be after %{date}')
 
   # rubocop:disable Metrics/AbcSize
   def validate_each(record, attribute, value)

--- a/app/validators/template_links_validator.rb
+++ b/app/validators/template_links_validator.rb
@@ -12,11 +12,11 @@ class TemplateLinksValidator < ActiveModel::Validator
       expected_keys.each do |k|
         if links.key?(k)
           unless valid_links?(links[k])
-            msg = _('The key %<key>s does not have a valid set of object links')
+            msg = _('The key %{key} does not have a valid set of object links')
             record.errors[:links] << (format(msg, key: k))
           end
         else
-          record.errors[:links] << (format(_('A key %<key>s is expected for links hash'), key: k))
+          record.errors[:links] << (format(_('A key %{key} is expected for links hash'), key: k))
         end
       end
     else

--- a/lib/cleanup/deprecators/get_deprecator.rb
+++ b/lib/cleanup/deprecators/get_deprecator.rb
@@ -11,8 +11,8 @@ module Cleanup
     class GetDeprecator
       ##
       # Default message to display to developer when deprecated method called.
-      MESSAGE = '%<deprecated_method>s is deprecated. '\
-                'Instead, you should use: %<new_method>s. '\
+      MESSAGE = '%{deprecated_method} is deprecated. '\
+                'Instead, you should use: %{new_method}. '\
                 "Read #{__FILE__} for more information."
 
       # Message printed to STDOUT when a deprecated method is called.

--- a/lib/cleanup/deprecators/predicate_deprecator.rb
+++ b/lib/cleanup/deprecators/predicate_deprecator.rb
@@ -10,8 +10,8 @@ module Cleanup
     class PredicateDeprecator
       ##
       # Default message to display to developer when deprecated method called.
-      MESSAGE = '%<deprecated_method>s is deprecated. '\
-                'Instead, you should use: %<new_method>s. '\
+      MESSAGE = '%{deprecated_method} is deprecated. '\
+                'Instead, you should use: %{new_method}. '\
                 "Read #{__FILE__} for more information."
 
       # Message printed to STDOUT when a deprecated method is called.

--- a/lib/cleanup/deprecators/set_deprecator.rb
+++ b/lib/cleanup/deprecators/set_deprecator.rb
@@ -11,8 +11,8 @@ module Cleanup
     class SetDeprecator
       ##
       # Default message to display to developer when deprecated method called.
-      MESSAGE = '%<deprecated_method>s is deprecated. '\
-                'Instead, you should use: %<new_method>s. '\
+      MESSAGE = '%{deprecated_method} is deprecated. '\
+                'Instead, you should use: %{new_method}. '\
                 "Read #{__FILE__} for more information."
 
       # Message printed to STDOUT when a deprecated method is called.

--- a/lib/generators/data_cleanup_rule/data_cleanup_rule_generator.rb
+++ b/lib/generators/data_cleanup_rule/data_cleanup_rule_generator.rb
@@ -42,7 +42,7 @@ class DataCleanupRuleGenerator < Rails::Generators::NamedBase
   #
   # Returns String
   def default_description
-    format('%<rule_name>s on %<model_name>s',
+    format('%{rule_name} on %{model_name}',
            rule_name: rule_class_name.underscore
                                      .split('_')
                                      .join(' ')


### PR DESCRIPTION
We switched the way we handle string formatting tokens when we upgraded Rubocop. Rubocop's new default is to use `%<variable>s` instead of `%{variable}`.

This has caused quite a bit of confusion for our translators, and I discovered today that Translation.io is not properly auto-translating these. It takes `%<variable>s some text` and translates it to `%<variable> s un peu de texte`. Note the space between the closing bracket '>' and the 's' character.

This update reverts the changes we made to use `%<variable>s` and updates the `.rubocop.yml` file to enforce use of the `template` style, `%{variable}` going forward.

Once merged, translations will need to be resynced!
