### PR TITLE
Bug dcc 713 admins don't have access to share tab

### DIFF
--- a/app/policies/plan_policy.rb
+++ b/app/policies/plan_policy.rb
@@ -16,7 +16,7 @@ class PlanPolicy < ApplicationPolicy
   def share?
     @record.editable_by?(@user.id) ||
       (@user.can_org_admin? &&
-       @user.org.plans.include?(@plan))
+       @user.org.plans.include?(@record))
   end
 
   def export?


### PR DESCRIPTION
DCC issue https://github.com/DigitalCurationCentre/DMPonline-Service/issues/713

Caused by variable @plan used instead of @record in method share?() in app/policies/plan_policy.rb
 @user.org.plans.include?(@plan)) <---- SHOULD BE @user.org.plans.include?(@record)

