### PR TITLE
DCC BUG #710 - Fix for "Error using unassign_users from a Department …

### DIFF
--- a/app/controllers/api/v0/departments_controller.rb
+++ b/app/controllers/api/v0/departments_controller.rb
@@ -47,16 +47,24 @@ module Api
         raise Pundit::NotAuthorizedError unless Api::V0::DepartmentsPolicy.new(@user, @department).assign_users?
 
         assign_users_to(@department.id)
-        redirect_to users_api_v0_departments_path
+
+        # Added "status: :see_other" to redirect_to (as we require rediect to be a GET).
+        # See https://makandracards.com/makandra/38347-redirecting-responses-for-patch-or-delete-will-not-redirect-with-get
+        redirect_to users_api_v0_departments_path, status: :see_other
       end
 
       ##
       # Remove departments from the list of users
       def unassign_users
-        raise Pudndit::NotAuthorizedError unless Api::V0::DepartmentsPolicy.new(@user, @department).assign_users?
+        @department = Department.find(params[:id])
+
+        raise Pundit::NotAuthorizedError unless Api::V0::DepartmentsPolicy.new(@user, @department).assign_users?
 
         assign_users_to(nil)
-        redirect_to users_api_v0_departments_path
+
+        # Added "status: :see_other" to redirect_to (as we require rediect to be a GET).
+        # See https://makandracards.com/makandra/38347-redirecting-responses-for-patch-or-delete-will-not-redirect-with-get
+        redirect_to users_api_v0_departments_path, status: :see_other
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,9 +162,9 @@ Rails.application.routes.draw do
       resources :departments, only: %i[create index] do
         collection do
           get :users
-          patch :unassign_users
         end
         member do
+          patch :unassign_users
           patch :assign_users
         end
       end


### PR DESCRIPTION
…using API V0".

Fix for DCC issue https://github.com/DigitalCurationCentre/DMPonline-Service/issues/710

Changes:
- the route for PATCH unassign_users_api_v0_department was wrongly
defined, it was missing the parameter for department id.
- In app/controllers/api/v0/departments_controller.rb
  - fixed a typo in unassign_users() method raise Pudndit::NotAuthorizedError
instead of Pundit::NotAuthorizedError
  - in assign_users() and assign_users() the redirect_to was failing
    as it was treated as a PATCH based on original API call, rather than
    being redirect as GET. Fixed by adding status "See Other" to
    redirect_to
      redirect_to users_api_v0_departments_path, status: :see_other
    based on https://makandracards.com/makandra/38347-redirecting-responses-for-patch-or-delete-will-not-redirect-with-get

