### PR TITLE
DCC Bug 711 - Fix for broken creation of a Plan using the V0 API.

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -74,6 +74,10 @@ module Api
         params.permit(:page, :per_page)
       end
 
+      def plan_params
+        params.permit(:template_id, :plan[:title], :plan[:email])
+      end
+
       # The resource class based on the controller
       #
       # Returns Object

--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -29,6 +29,7 @@ module Api
 
         # initialize the plan
         @plan = Plan.new
+        @plan.org = @user.org
 
         # Attach the user as the PI and Data Contact
         @plan.contributors << Contributor.new(
@@ -48,8 +49,9 @@ module Api
                           end
         @plan.template = @template
         @plan.title = params[:plan][:title]
+
         if @plan.save
-          @plan.assign_creator(plan_user)
+          @plan.add_user!(plan_user.id, :creator)
           respond_with @plan
         else
           # the plan did not save


### PR DESCRIPTION
Issue fixed DCC bug for /api/v0/plans for creating a Plan given a
template id https://github.com/DigitalCurationCentre/DMPonline-Service/issues/711

Changes:
  - in app/controllers/api/v0/base_controller.rb: added strong
parameters function plan_params.
  - in app/controllers/api/v0/plans_controller.rb: in method create()
added
  @plan.org = @user.org
and
 replaced
    @plan.assign_creator(plan_user)
 by
    @plan.add_user!(plan_user.id, :creator).

