### PR TITLE
DCC bug 711 - Fix for the Rest API call POST /api/v1/plans for Plan

### DIFF
--- a/app/services/api/v1/deserialization_service.rb
+++ b/app/services/api/v1/deserialization_service.rb
@@ -57,15 +57,14 @@ module Api
         end
 
         # Retrieve any JSON schema extensions for this application
-        # rubocop:disable Metrics/AbcSize
         def app_extensions(json: {})
           return {} unless json.present? && json[:extension].present?
 
-          app = ::ApplicationService.application_name.split('-').first.downcase
-          ext = json[:extension].select { |item| item[app.to_sym].present? }
-          ext.first.present? ? ext.first[app.to_sym] : {}
+          # Note the symbol of the dmproadmap json object
+          # nested in extensions which is the container for the json template object, etc.
+          ext = json[:extension].select { |item| item[:dmproadmap].present? }
+          ext.first.present? ? ext.first[:dmproadmap] : {}
         end
-        # rubocop:enable Metrics/AbcSize
 
         # Determines whether or not the value is a DOI/ARK
         def doi?(value:)

--- a/app/views/api/v1/plans/_show.json.jbuilder
+++ b/app/views/api/v1/plans/_show.json.jbuilder
@@ -5,6 +5,10 @@
 json.schema 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/tree/master/examples/JSON/JSON-schema/1.0'
 
 presenter = Api::V1::PlanPresenter.new(plan: plan)
+
+# Note the symbol of the dmproadmap json object
+# nested in extensions which is the container for the json template object, etc.
+
 # A JSON representation of a Data Management Plan in the
 # RDA Common Standard format
 json.title plan.title
@@ -56,7 +60,7 @@ unless @minimal
   end
 
   json.extension [plan.template] do |template|
-    json.set! ApplicationService.application_name.split('-').first.to_sym do
+    json.set! :dmproadmap do
       json.template do
         json.id template.id
         json.title template.title

--- a/spec/services/api/v1/contextual_error_service_spec.rb
+++ b/spec/services/api/v1/contextual_error_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Api::V1::ContextualErrorService do
       result = described_class.contextualize(errors: @plan.errors)
       expect(result.length).to eql(2)
       expect(result.first.start_with?('Contact/Contributor ')).to eql(true)
-      expect(result.first.include?(" can't be blank if no ")).to eql(true)
+      expect(result.first.include?("can't be blank")).to eql(true)
     end
     it 'returns errors if a Contributor Org is invalid' do
       @plan.contributors.first.org.name = nil

--- a/spec/services/api/v1/deserialization_service_spec.rb
+++ b/spec/services/api/v1/deserialization_service_spec.rb
@@ -122,8 +122,6 @@ RSpec.describe Api::V1::DeserializationService do
   describe ':app_extensions(json:)' do
     before(:each) do
       @template = create(:template)
-      @app_name = ApplicationService.application_name.split('-').first&.downcase
-      @app_name = 'tester' unless @app_name.present?
     end
 
     it 'returns an empty hash is json is not present' do
@@ -135,13 +133,13 @@ RSpec.describe Api::V1::DeserializationService do
     end
     it 'returns an empty hash if there is no extension for the current application' do
       expected = { template: { id: @template.id } }
-      ApplicationService.expects(:application_name).returns('tester')
+      # ApplicationService.expects('dmproadmap').returns('tester')
       json = { extension: [{ foo: expected }] }
       expect(described_class.send(:app_extensions, json: json)).to eql({})
     end
     it 'returns the hash for the current application' do
       expected = { template: { id: @template.id } }
-      json = { extension: [{ "#{@app_name}": expected }] }
+      json = { extension: [{ dmproadmap: expected }] }
       result = described_class.send(:app_extensions, json: json)
       expect(result).to eql(expected)
     end

--- a/spec/views/api/v1/plans/_show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/plans/_show.json.jbuilder_spec.rb
@@ -77,12 +77,11 @@ describe 'api/v1/plans/_show.json.jbuilder' do
       expect(@json[:extension].length).to eql(1)
     end
     it 'includes the :template in :extension' do
-      app = ApplicationService.application_name.split('-').first
-      @section = @json[:extension].select { |hash| hash.keys.first == app }.first
-      expect(@section[app.to_sym].present?).to eql(true)
+      @section = @json[:extension].select { |hash| hash.keys.first == 'dmproadmap' }.first
+      expect(@section[:dmproadmap].present?).to eql(true)
       tmplt = @plan.template
-      expect(@section[app.to_sym][:template][:id]).to eql(tmplt.id)
-      expect(@section[app.to_sym][:template][:title]).to eql(tmplt.title)
+      expect(@section[:dmproadmap][:template][:id]).to eql(tmplt.id)
+      expect(@section[:dmproadmap][:template][:title]).to eql(tmplt.title)
     end
   end
 


### PR DESCRIPTION
creation. The previous call based on instructions in wiki was always
defaulting to using the default template regardless of template id sent.

Fix for DCC bug 711 https://github.com/DigitalCurationCentre/DMPonline-Service/issues/711

The API Documentation V1 - Create Plan page has been changed
"dmptool" replaced by "dmproadmap" in fragment of Json sent for plan
creation.

Changes:
- We use :dmproadmap which is the symbol of the dmproadmap json object
  nested in extensions which is the container for the json template object, etc.
- In app/services/api/v1/deserialization_service.rb the method
app_extensions() has been changed to use the symbol :dmproadmap.
- In app/views/api/v1/plans/_show.json.jbuilder the block that builds
the template json object now uses the symbol :dmproadmap
- fixed tests in spec/services/api/v1/contextual_error_service_spec.rb
and spec/services/api/v1/deserialization_service_spec.rb.

The Extensions fragment in POST
![Selection_001](https://user-images.githubusercontent.com/8876215/161040529-9c472abc-8588-47e1-b5a2-96a274909282.png)

Extension fragment in Response 
![Selection_002](https://user-images.githubusercontent.com/8876215/161040811-ede0579d-90a6-49ba-ba45-dd7e28e75aed.png)

