### PR TITLE
fix issue with string token for model save errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -105,7 +105,7 @@ class ApplicationController < ActionController::Base
   end
 
   def failure_message(obj, action = 'save')
-    format(_('Unable to %{action} the %{object}. {errors}'),
+    format(_('Unable to %{action} the %{object}. %{errors}'),
            object: obj_name_for_display(obj),
            action: action || 'save', errors: errors_for_display(obj))
   end


### PR DESCRIPTION
Fixes an issue with the string token for model errors which was causing messages for the user to appear as 'Unable to save your changes: {errors}'
