### PR TITLE
fix issue with logos disappearing when other Org data is saved

### DIFF
--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -33,7 +33,11 @@ class OrgsController < ApplicationController
     @org = Org.find(params[:id])
     authorize @org
 
-    @org.logo = attrs[:logo] if attrs[:logo]
+    # If a new logo was supplied then use it, otherwise retain the existing one
+    attrs[:logo] = attrs[:logo].present? ? attrs[:logo] : @org.logo
+    # Remove the logo if the user checked the box
+    attrs[:logo] = nil if attrs[:remove_logo] == '1'
+
     tab = (attrs[:feedback_enabled].present? ? 'feedback' : 'profile')
     @org.links = ActiveSupport::JSON.decode(params[:org_links]) if params[:org_links].present?
 


### PR DESCRIPTION
I discovered an issue with logos disappearing if a user went into the Org details page and saved a change to links, or an email.

I am uncertain if this impacts everyone or just when the logo is stored in S3. 

To replicate:
- Login as an admin
- Edit an Org's details
- Add a logo and save
- Ensure the logo appears 
- Change the contact email or another data element and save

After the second save, the logo has been deleted.