### PR TITLE
fix issue where address lines that include a comma are interpretted a…

### DIFF
--- a/app/views/contact_us/contacts/_new_right.html.erb
+++ b/app/views/contact_us/contacts/_new_right.html.erb
@@ -7,7 +7,7 @@
       Rails.configuration.x.organisation.address.fetch(:line4, ""),
       Rails.configuration.x.organisation.address.fetch(:country, "")].compact.each do |addr_line| %>
 <% if addr_line.present? %>
-    <%= addr_line %><br>
+  <%= addr_line.is_a?(Array) ? addr_line.join(' ') : addr_line %><br>
 <% end %>
 <% end %>
 </address>


### PR DESCRIPTION
Discovered an issue with the way address lines appear on the contact us page.

If a line includes a comma (e.g. 'Oakland, CA 94607') then `Rails.configuration.x.organisation.address.fetch(line[n], '')` returns ["Oakland", "CA 94607"] and displays that as an array on the page.

