### PR TITLE
DCC Bug 698 - Fix for broken Template History functionality.

### DIFF
--- a/app/controllers/paginable/templates_controller.rb
+++ b/app/controllers/paginable/templates_controller.rb
@@ -105,8 +105,9 @@ module Paginable
       paginable_renderise(
         partial: 'history',
         scope: @templates,
-        query_params: { sort_field: 'templates.title', sort_direction: :asc },
-        locals: { current: @templates.maximum(:version) }
+        query_params: { sort_field: 'templates.version', sort_direction: :desc },
+        locals: { current: @templates.maximum(:version) },
+        format: :json
       )
     end
   end


### PR DESCRIPTION
DCC Issue https://github.com/DigitalCurationCentre/DMPonline-Service/issues/698

Changes:
 - added
    format: json
   and
    changed sort option to
    sort_field: 'templates.version', sort_direction: :desc
  to the paginable_renderise call in the history() method of
paginable/templates_controller.

NOTE:
This fixes issue. But to see results you will need to change 

>   The largest page size allowed in requests to the API (all versions)
>     config.x.application.api_max_page_size = 100

which I have done
    **config.x.application.api_max_page_size = 5**

to see
![Selection_030](https://user-images.githubusercontent.com/8876215/163164572-ee68ea54-14e5-4ff7-8e4d-bb313a3fb464.png)

![Selection_031](https://user-images.githubusercontent.com/8876215/163164569-938a99ac-6f0f-49ec-b4dd-827afe4751cf.png)

![Selection_032](https://user-images.githubusercontent.com/8876215/163164566-55b7aa3e-3ca2-492e-bd6c-5a923fbf02d4.png)

Otherwise with
**config.x.application.api_max_page_size = 100**
 you see the same set of Templates for "View less" and "View all"

![Selection_034](https://user-images.githubusercontent.com/8876215/163165121-74ccaac1-7086-4965-b10c-6cba5c878f6d.png)
![Selection_033](https://user-images.githubusercontent.com/8876215/163165123-aac5b4d4-dbf2-4367-8b18-8a6f648cdc68.png)

