### PR TITLE
Referenced in DCC Bug 698 - The School departments functionality broken.

### DIFF
--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -6,8 +6,7 @@ class DepartmentPolicy < ApplicationPolicy
   # NOTE: @user is the signed_in_user and @record is an instance of Department
 
   def index?
-    (@user.can_org_admin? && @user.org.id == @department.org_id) ||
-      @user.can_super_admin?
+    @user.can_org_admin? || @user.can_super_admin?
   end
 
   def new?


### PR DESCRIPTION
Referenced in a comment in DCC bug 698 https://github.com/DigitalCurationCentre/DMPonline-Service/issues/698#issuecomment-1096577463

Fix involved following change:
 - in app/policies/department_policy the index?() policy method
 reference @department (which does not exist). Even changing @department
to @record fails as @record is the Department class (not an instance of
Department). Inspect of @record in index?() shows
 "Department(id: integer, name: string, code: string, org_id: integer,
created_at: datetime, updated_at: datetime)".
So replaced
    (@user.can_org_admin? && @user.org.id == @department.org_id) ||
     @user.can_super_admin?
by    @user.can_org_admin? || @user.can_super_admin?
as @department is nil and @record.org_id id not defined for a Class
object Department.

This fixes issue. But to see results you will need to change

> 
>     The largest page size allowed in requests to the API (all versions)
>     config.x.application.api_max_page_size = 100

which I have done
**config.x.application.api_max_page_size = 10**

![Selection_035](https://user-images.githubusercontent.com/8876215/163176985-70307cbf-c789-4971-b1f4-42a792ac9b1f.png)

![Selection_037](https://user-images.githubusercontent.com/8876215/163176979-78f1114f-f3a9-42c4-a1b2-d220729a7faa.png)

**"View all"** shows
![Selection_036](https://user-images.githubusercontent.com/8876215/163176984-afa2d568-8cf1-4581-8679-e2a1fce5aa98.png)

Reverting back to with
**config.x.application.api_max_page_size = 100**
you see the same set of Departments for **"View less"** and **"View all"**
![Selection_039](https://user-images.githubusercontent.com/8876215/163177422-e805d51f-591f-4c02-93fb-75c6b60eb98c.png)
![Selection_038](https://user-images.githubusercontent.com/8876215/163177426-58f5a40d-f279-491e-a03b-268ff317357e.png)

