### PR TITLE
DCC bug 406 - Download plan with coversheet is broken.

### DIFF
--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -133,13 +133,9 @@ module ExportablePlan
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
-    csv << [if hash[:attribution].many?
-              _('Creators: ')
-            else
-              _('Creator:')
-            end, format(_('%{authors}'), authors: hash[:attribution].join(', '))]
+    csv << [_('Creator:'), format(_('%{author}'), author: hash[:attribution])]
     csv << ['Affiliation: ', format(_('%{affiliation}'), affiliation: hash[:affiliation])]
     csv << if hash[:funder].present?
              [_('Template: '), format(_('%{funder}'), funder: hash[:funder])]
@@ -161,7 +157,7 @@ module ExportablePlan
     csv << []
     csv << []
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   # rubocop:disable Metrics/AbcSize, Metrics/BlockLength, Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity


### PR DESCRIPTION
DCC issue https://github.com/DigitalCurationCentre/DMPonline-Service/issues/703

Problem is that in concerns/exportable_plan.rb the method  prepare_coversheet_for_csv(csv, _headings, hash) assumes  hash[:attribution] is an  ActiveRecord::Relation when it is always a string with a single author created in prepare_coversheet() method.
Hence hash[:attribution].many? throws an error in
   csv << [if hash[:attribution].many?.

Changes for fix:
- in prepare_coversheet_for_csv(csv, _headings, hash) added
   csv << [_('Creator:'), format(_('%{author}'), author: hash[:attribution])]
instead and removed
  csv << [if hash[:attribution].many?...]


When one tried to download a plan as a csv file with coversheet one got an error.
![Selection_041](https://user-images.githubusercontent.com/8876215/163373161-a867c6be-cadf-4d8c-bc01-d10c60d3e596.png)
![Selection_040](https://user-images.githubusercontent.com/8876215/163373350-d1828a62-7989-4302-b8f8-e8f72c03e80f.png)
