### PR TITLE
DCC bug 722 - Fix for dealing with situation where Rest API call

### DIFF
--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -73,10 +73,10 @@ module Api
 
         # Get all the Org Admin plans
         org_admin_plans = @user.org.org_admin_plans
-        @plans = org_admin_plans.includes([{ roles: :user }, { answers: :question_options },
-                                           template: [{ phases: {
-                                             sections: { questions: %i[question_format themes] }
-                                           } }, :org]])
+        @plans = org_admin_plans.preload([{ roles: :user }, { answers: :question_options },
+                                          template: [{ phases: {
+                                            sections: { questions: %i[question_format themes] }
+                                          } }, :org]])
 
         # Filter on list of users
         user_ids = extract_param_list(params, 'user')


### PR DESCRIPTION
          "/api/v0/plans?page=ALL"
was timing out because the processing was taking too long.

Fix for bug https://github.com/DigitalCurationCentre/DMPonline-Service/issues/722

The following change seems to make a difference:
- in /api/v0/plans_controller.rb the index() method
   replaced includes() with preload():
    @plans = org_admin_plans.includes([{ roles: :user }, { answers: :question_options },
                                           template: [{ phases: {
                                             sections: { questions: %i[question_format themes] }
                                           } }, :org]])

