### PR TITLE
fix font face of pdf download

### DIFF
--- a/app/views/plans/_download_form.html.erb
+++ b/app/views/plans/_download_form.html.erb
@@ -119,7 +119,7 @@
             options_for_select(Settings::Template::VALID_MARGIN_RANGE.to_a,
                                @export_settings.formatting[:margin][:right]),
             class: 'form-control',
-            "data-default": @plan.template.settings(:export).formatting[:margin][:rigth] %>
+            "data-default": @plan.template.settings(:export).formatting[:margin][:right] %>
       </div>
     </div>
   </div>

--- a/app/views/shared/export/_plan_styling.erb
+++ b/app/views/shared/export/_plan_styling.erb
@@ -2,11 +2,11 @@
   @import 'https://fonts.googleapis.com/css?family=<%= font_face.downcase.include?('times') ? 'Times' : 'Helvetica' %>';
 
   body {
-    font-family: @font-face;
+    font-family: <%= font_face %>;
     font-size: <%= font_size %>;
     margin: <%= margin %>;
   }
-    h1 {
+  h1 {
       font-size: 1.5rem;
       font-weight: bold;
       padding: 0;
@@ -59,5 +59,5 @@
     }
     .bold {
       font-weight: bold;
-    }
+    }  
 </style>

--- a/config/locales/localization.en-CA.yml
+++ b/config/locales/localization.en-CA.yml
@@ -14,12 +14,14 @@ en-CA:
   date:
     formats:
       default: "%d-%m-%Y"
-      long: "%B %d, %Y"
+      long: "%d %B, %Y"
       short: "%d %b"
+      csv: "%d/%m/%Y"
+      readable: "%B %d, %Y"
     order:
-    - :year
-    - :month
     - :day
+    - :month
+    - :year
   number:
     currency:
       format:
@@ -62,6 +64,6 @@ en-CA:
       words_connector: ", "
   time:
     formats:
-      default: "%a, %d %b %Y %I:%M:%S %p %Z"
-      long: "%B %d, %Y %I:%M %p"
-      short: "%d %b %I:%M %p"
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%d %B, %Y %H:%M"
+      short: "%d %b %H:%M"


### PR DESCRIPTION
Fixes the font face of PDF download.

Upgrading DMP Assistant to 3.1.0 and found the font-face selection of PDF download not working (Times New Roman all the time). Switch variable name and it works.

Also, provide an updated en-CA locale. 