### PR TITLE
Add array judgement for creators in text and csv download 

### DIFF
--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -135,7 +135,12 @@ module ExportablePlan
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
-    csv << [_('Creator:'), format(_('%{author}'), author: hash[:attribution])]
+    ## csv << [_('Creator:'), format(_('%{author}'), author: hash[:attribution])]
+    if Array(hash[:attribution]).many?
+      csv << [_('Creators: '), format(_('%{authors}'), authors: Array(hash[:attribution]).join(', '))]
+    else
+      csv << [ _('Creator:'), format(_('%{authors}'), authors: hash[:attribution])]
+    end
     csv << ['Affiliation: ', format(_('%{affiliation}'), affiliation: hash[:affiliation])]
     csv << if hash[:funder].present?
              [_('Template: '), format(_('%{funder}'), funder: hash[:funder])]

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -135,11 +135,11 @@ module ExportablePlan
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
-    csv << if Array(hash[:attribution]).many? 
-            [_('Creators: '), format(_('%{authors}'), authors: Array(hash[:attribution]).join(', '))]
-          else 
-            [ _('Creator:'), format(_('%{authors}'), authors: hash[:attribution])]
-          end
+    csv << if Array(hash[:attribution]).many?
+             [_('Creators: '), format(_('%{authors}'), authors: Array(hash[:attribution]).join(', '))]
+           else
+             [_('Creator:'), format(_('%{authors}'), authors: hash[:attribution])]
+           end
     csv << ['Affiliation: ', format(_('%{affiliation}'), affiliation: hash[:affiliation])]
     csv << if hash[:funder].present?
              [_('Template: '), format(_('%{funder}'), funder: hash[:funder])]

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -135,7 +135,6 @@ module ExportablePlan
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
-    ## csv << [_('Creator:'), format(_('%{author}'), author: hash[:attribution])]
     if Array(hash[:attribution]).many?
       csv << [_('Creators: '), format(_('%{authors}'), authors: Array(hash[:attribution]).join(', '))]
     else

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -131,7 +131,6 @@ module ExportablePlan
     hash
   end
   # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
@@ -164,7 +163,6 @@ module ExportablePlan
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   # rubocop:disable Metrics/AbcSize, Metrics/BlockLength, Metrics/MethodLength
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   # rubocop:disable Metrics/ParameterLists
   def show_section_for_csv(csv, phase, section, headings, unanswered, hash)
     section[:questions].each do |question|

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -135,11 +135,11 @@ module ExportablePlan
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
-    if Array(hash[:attribution]).many?
-      csv << [_('Creators: '), format(_('%{authors}'), authors: Array(hash[:attribution]).join(', '))]
-    else
-      csv << [ _('Creator:'), format(_('%{authors}'), authors: hash[:attribution])]
-    end
+    csv << if Array(hash[:attribution]).many? 
+            [_('Creators: '), format(_('%{authors}'), authors: Array(hash[:attribution]).join(', '))]
+          else 
+            [ _('Creator:'), format(_('%{authors}'), authors: hash[:attribution])]
+          end
     csv << ['Affiliation: ', format(_('%{affiliation}'), affiliation: hash[:affiliation])]
     csv << if hash[:funder].present?
              [_('Template: '), format(_('%{funder}'), funder: hash[:funder])]

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -1,7 +1,7 @@
 <%= "#{@plan.title}" %>
 <%= "----------------------------------------------------------\n" %>
 <% if @show_coversheet %>
-<%= @hash[:attribution].length > 1 ? _("Creators: ") : _('Creator:') %> <%= @hash[:attribution].join(', ') %>
+<%= Array(@hash[:attribution]).many? ? _("Creators: ") + Array(@hash[:attribution]).join(", ")  : _('Creator:') + @hash[:attribution] %>
 <%= _("Affiliation: ") + @hash[:affiliation] %>
   <% if @hash[:funder].present? %>
 <%= _("Template: ") + @hash[:funder] %>


### PR DESCRIPTION
The `join` method was used to cause errors for `@hash[:attribution]` after it was changed to string. Add judgment in case some organizations want to include more than one creator.