### PR TITLE
Bug #3104 - Fix for pre-ticked answers do not appear in Template

### DIFF
--- a/app/views/template_exports/template_export.docx.erb
+++ b/app/views/template_exports/template_export.docx.erb
@@ -26,7 +26,7 @@
             <% if q_format.option_based? %>
               <ul>
                 <% question.question_options.each do |option| %>
-                  <li><%= option.text.chomp.strip %></li>
+                  <li><%= option.text.chomp.strip %><%= option.is_default? ? ' - ' + _('default') : '' %></li>
                 <% end %>
               </ul>
             <% end %>

--- a/app/views/template_exports/template_export.pdf.erb
+++ b/app/views/template_exports/template_export.pdf.erb
@@ -70,7 +70,7 @@
           <% if q_format.option_based? %>
             <ul>
             <% question.question_options.each do |option| %>
-              <li><%= option.text.chomp.strip %></li>
+              <li><%= option.text.chomp.strip %><%= option.is_default? ? ' - ' + _('default') : '' %></li>
             <% end %>
             </ul>
           <% end %>


### PR DESCRIPTION
download.

Fix for Roadmap issue #3104.

Changes:
- added <%= option.is_default? ? ' - ' + _('default') : '' %> to
  option text in export template in docx and pdf.

Example screenshots of template:
**Export pdf**
![Selection_017](https://user-images.githubusercontent.com/8876215/166442038-4c231004-1c49-4825-8f48-4f152e4cad0a.png)
**Preview**
![Selection_018](https://user-images.githubusercontent.com/8876215/166442415-e5f3fe5c-5a8d-4cc7-8691-8171694a0f1b.png)

