### PR TITLE
metadata standard does not always have locations

### DIFF
--- a/app/views/research_outputs/metadata_standards/_search_result.html.erb
+++ b/app/views/research_outputs/metadata_standards/_search_result.html.erb
@@ -5,7 +5,7 @@
 
   <p><%= sanitize(result.description) %></p>
 
-  <% website = result.locations.select { |loc| loc["type"] == "website" }.first %>
+  <% website = result&.locations&.select { |loc| loc["type"] == "website" }&.first %>
   <% if website.present? %>
     <div>
       <%= link_to website["url"], website["url"], target: "_blank", class: "has-new-window-popup-info" %>


### PR DESCRIPTION
Changes proposed in this PR:
- metadata.locations is sometimes `nil`, which makes this view crash
