### PR TITLE
Roadmap bug 3086 - The share feature for Org plan visibility was broken:

### DIFF
--- a/app/models/phase.rb
+++ b/app/models/phase.rb
@@ -139,7 +139,7 @@ class Phase < ApplicationRecord
   end
 
   def visibility_allowed?(plan)
-    value = Rational(num_answered_questions(plan), plan.num_questions) * 100
+    value = Rational(num_answered_questions(plan), plan.num_questions).to_f * 100
     value >= Rails.configuration.x.plans.default_percentage_answered.to_f
   end
 end


### PR DESCRIPTION
one could only share plan if it is 100% completed. When this is set in
property config/initializers/_dmproadmap.rb, e.g.,
188:    config.x.plans.default_percentage_answered = 50.

Fix for Roadmap bug #3086.

In app/models/phase.rb method visibility_allowed?(plan) is broken
because the first line in method always return 0 unless the Rational()
is 1 in
  value = Rational(num_answered_questions(plan), plan.num_questions) * 100

Change:
- we fix issue by converting the Rational() value to a float as follows
    value = Rational(num_answered_questions(plan), plan.num_questions).to_f * 100

**Outputs within method** 

**Prior to fix** 
server_1       | 1   <-- num_answered_questions(plan)
server_1       | 8   <-- plan.num_questions
server_1       | 0   <-- value = Rational(num_answered_questions(plan), plan.num_questions) * 100


**After fix**

--------------------------------------
server_1       | 1     <-- num_answered_questions(plan)
server_1       | 8     <-- plan.num_questions
server_1       | 12.5  <-- value = value = Rational(num_answered_questions(plan), plan.num_questions).to_f * 100

**Repeated for another plan**
server_1       | 4
server_1       | 8
server_1       | 50.0
