### PR TITLE
do not repeat help instructions for every guidance group

### DIFF
--- a/app/views/org_admin/questions/_show.html.erb
+++ b/app/views/org_admin/questions/_show.html.erb
@@ -108,14 +108,15 @@
                     ) %>
                   <% if theme_guidances.length > 0 %>
                     <% has_org_themed_guidance = true %>
-                    <p><%= _("Click the links below to view organisational guidance
-                        related to the themes associated with this question.") %></p>
-                      <% break %>
+                    <% break %>
                   <% end %>
                 <% end %>
+                <% break if has_org_themed_guidance %>
               <% end %>
 
               <% if has_org_themed_guidance %>
+                <p><%= _("Click the links below to view organisational guidance
+                        related to the themes associated with this question.") %></p>
                 <% ggs.each do |guidance_group| %>
                   <% themes_q.each do |theme| %>
                     <% theme_guidances = theme.guidances.where(


### PR DESCRIPTION
Context: if you open the template editor, in the org admin interface, and then open a question for editing,
you'll see some themed guidance next to that question.

If you have multiple guidance groups that match the theme
of the current question, then the help text `Click the links below to view organisational guidance related to the themes associated with this question.` as many times.

The cause is a missing break statement for the outer loop [here](https://github.com/DMPRoadmap/roadmap/blob/development/app/views/org_admin/questions/_show.html.erb#L115)
I believe the only reason for this loop was set to set variable `has_org_themed_guidance` to `true`, right?
In that case that one `break` is not enough, as there another outer loop also.

I've moved that help text also too.

Unless of course, this has a different purpose.