### PR TITLE
Feature #3063 - Feature to be able to configure whether the download

### DIFF
--- a/app/views/plans/_download_form.html.erb
+++ b/app/views/plans/_download_form.html.erb
@@ -1,3 +1,6 @@
+<%
+ download_coversheet_tickbox_checked = Rails.configuration.x.plans.download_coversheet_tickbox_checked || false
+%>
 <%= form_tag(plan_export_path(@plan), method: :get, target: '_blank', id: 'download_form') do |f| %>
 
   <h2><%= _('Format') %></h2>
@@ -23,7 +26,7 @@
       <legend><%= _("Optional plan components") %></legend>
       <div class="checkbox">
         <%= label_tag 'export[project_details]' do %>
-          <%= check_box_tag 'export[project_details]', true, false %>
+          <%= check_box_tag 'export[project_details]', true, download_coversheet_tickbox_checked %>
           <%= _('project details coversheet') %>
         <% end %>
       </div>

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -194,6 +194,9 @@ module DMPRoadmap
     # regardless of the plans visibility and whether or not the plan has been shared
     config.x.plans.super_admins_read_all = true
 
+    # Check download of a plan coversheet tickbox
+    config.x.plans.download_coversheet_tickbox_checked = false
+
     # ---------------------------------------------------- #
     # CACHING - all values are in seconds (86400 == 1 Day) #
     # ---------------------------------------------------- #


### PR DESCRIPTION
plans details coversheet is ticked by default.

Fix for issue #3063.

Changes:
- added a configurable property to
    \# Check download of a plan coversheet tickbox
    config.x.plans.download_coversheet_tickbox_checked = false
- use property to check "project details coversheet" by default or not
if property set. If property is unset, the tickbox is unchecked.

