### PR TITLE
add contributor to coversheet and add plan title to csv export

### DIFF
--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -43,7 +43,7 @@ class PlanExportsController < ApplicationController
                              .detect { |p| p.visibility_allowed?(@plan) }
                       end
 
-    # Added contributors to coverage of plans. 
+    # Added contributors to coverage of plans.
     # Users will see both roles and contributor names if the role is filled
     @hash[:data_curation] = Contributor.where(plan_id: @plan.id).data_curation
     @hash[:investigation] = Contributor.where(plan_id: @plan.id).investigation

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -43,11 +43,11 @@ class PlanExportsController < ApplicationController
                              .detect { |p| p.visibility_allowed?(@plan) }
                       end
 
-     #portagenetwork/roadmap#202: add contributor to cover page
-     @hash[:data_curation] = Contributor.where(:plan_id => @plan.id).data_curation
-     @hash[:investigation] = Contributor.where(:plan_id => @plan.id).investigation
-     @hash[:pa] = Contributor.where(:plan_id => @plan.id).project_administration
-     @hash[:other] = Contributor.where(:plan_id => @plan.id).other
+    # portagenetwork/roadmap#202: add contributor to cover page
+    @hash[:data_curation] = Contributor.where(plan_id: @plan.id).data_curation
+    @hash[:investigation] = Contributor.where(plan_id: @plan.id).investigation
+    @hash[:pa] = Contributor.where(plan_id: @plan.id).project_administration
+    @hash[:other] = Contributor.where(plan_id: @plan.id).other
 
     respond_to do |format|
       format.html { show_html }

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -43,6 +43,12 @@ class PlanExportsController < ApplicationController
                              .detect { |p| p.visibility_allowed?(@plan) }
                       end
 
+     #portagenetwork/roadmap#202: add contributor to cover page
+     @hash[:data_curation] = Contributor.where(:plan_id => @plan.id).data_curation
+     @hash[:investigation] = Contributor.where(:plan_id => @plan.id).investigation
+     @hash[:pa] = Contributor.where(:plan_id => @plan.id).project_administration
+     @hash[:other] = Contributor.where(:plan_id => @plan.id).other
+
     respond_to do |format|
       format.html { show_html }
       format.csv  { show_csv }

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -43,7 +43,8 @@ class PlanExportsController < ApplicationController
                              .detect { |p| p.visibility_allowed?(@plan) }
                       end
 
-    # portagenetwork/roadmap#202: add contributor to cover page
+    # Added contributors to coverage of plans. 
+    # Users will see both roles and contributor names if the role is filled
     @hash[:data_curation] = Contributor.where(plan_id: @plan.id).data_curation
     @hash[:investigation] = Contributor.where(plan_id: @plan.id).investigation
     @hash[:pa] = Contributor.where(plan_id: @plan.id).project_administration

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -97,11 +97,12 @@ module ExportablePlan
 
     hash
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
   # rubocop:enable Style/OptionalBooleanParameter
 
   # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet
     hash = {}
     # Use the name of the DMP owner/creator OR the first Co-owner if there is no

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -100,9 +100,7 @@ module ExportablePlan
 
   # rubocop:enable Style/OptionalBooleanParameter
 
-  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet
     hash = {}
     # Use the name of the DMP owner/creator OR the first Co-owner if there is no
@@ -111,7 +109,7 @@ module ExportablePlan
     roles.administrator.not_creator.first&.user&.name(false) unless attribution.present?
     hash[:attribution] = attribution
 
-    # Added contributors to coverage of plans. 
+    # Added contributors to coverage of plans.
     # Users will see both roles and contributor names if the role is filled
     hash[:data_curation] = Contributor.where(plan_id: id).data_curation
     hash[:investigation] = Contributor.where(plan_id: id).investigation
@@ -140,7 +138,7 @@ module ExportablePlan
   end
   # rubocop:enable Metrics/AbcSize
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
     csv << [_('Title: '), format(_('%{title}'), title: title)]
     csv << if Array(hash[:attribution]).many?

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -110,11 +110,11 @@ module ExportablePlan
     roles.administrator.not_creator.first&.user&.name(false) unless attribution.present?
     hash[:attribution] = attribution
 
-    #portagenetwork/roadmap#202: add contributor to cover page
-    hash[:data_curation] = Contributor.where(:plan_id => id).data_curation
-    hash[:investigation] = Contributor.where(:plan_id => id).investigation
-    hash[:pa] = Contributor.where(:plan_id => id).project_administration
-    hash[:other] = Contributor.where(:plan_id => id).other
+    # portagenetwork/roadmap#202: add contributor to cover page
+    hash[:data_curation] = Contributor.where(plan_id: id).data_curation
+    hash[:investigation] = Contributor.where(plan_id: id).investigation
+    hash[:pa] = Contributor.where(plan_id: id).project_administration
+    hash[:other] = Contributor.where(plan_id: id).other
 
     # Org name of plan owner's org
     hash[:affiliation] = owner.present? ? owner.org.name : ''
@@ -140,25 +140,27 @@ module ExportablePlan
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def prepare_coversheet_for_csv(csv, _headings, hash)
-    csv << [_("Title: "), _("%{title}") % { title: title }]
+    csv << [_('Title: '), format(_('%{title}'), title: title)]
     csv << if Array(hash[:attribution]).many?
              [_('Creators: '), format(_('%{authors}'), authors: Array(hash[:attribution]).join(', '))]
            else
              [_('Creator:'), format(_('%{authors}'), authors: hash[:attribution])]
            end
-           if hash[:investigation].present? 
-            csv <<  [_("Principal Investigator: "), _("%{investigation}") % { investigation: hash[:investigation].map(&:name).join(', ') }] 
-          end
-          if hash[:data_curation].present? 
-            csv << [_("Date Manager: "), _("%{data_curation}") % { data_curation: hash[:data_curation].map(&:name).join(', ') }] 
-          end
-          if hash[:pa].present? 
-            csv << [_("Project Administrator: "), _("%{pa}") % { pa: hash[:pa].map(&:name).join(', ') }] 
-          end
-          if hash[:other].present? 
-            csv << [_("Contributor: "), _("%{other}") % { other: hash[:other].map(&:name).join(', ') }] 
-          end
-          csv << [_("Affiliation: "), _("%{affiliation}") % { affiliation: hash[:affiliation] }]
+    if hash[:investigation].present?
+      csv << [_('Principal Investigator: '),
+              format(_('%{investigation}'), investigation: hash[:investigation].map(&:name).join(', '))]
+    end
+    if hash[:data_curation].present?
+      csv << [_('Date Manager: '),
+              format(_('%{data_curation}'), data_curation: hash[:data_curation].map(&:name).join(', '))]
+    end
+    if hash[:pa].present?
+      csv << [_('Project Administrator: '), format(_('%{pa}'), pa: hash[:pa].map(&:name).join(', '))]
+    end
+    if hash[:other].present?
+      csv << [_('Contributor: '), format(_('%{other}'), other: hash[:other].map(&:name).join(', '))]
+    end
+    csv << [_('Affiliation: '), format(_('%{affiliation}'), affiliation: hash[:affiliation])]
     csv << ['Affiliation: ', format(_('%{affiliation}'), affiliation: hash[:affiliation])]
     csv << if hash[:funder].present?
              [_('Template: '), format(_('%{funder}'), funder: hash[:funder])]

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -111,7 +111,8 @@ module ExportablePlan
     roles.administrator.not_creator.first&.user&.name(false) unless attribution.present?
     hash[:attribution] = attribution
 
-    # portagenetwork/roadmap#202: add contributor to cover page
+    # Added contributors to coverage of plans. 
+    # Users will see both roles and contributor names if the role is filled
     hash[:data_curation] = Contributor.where(plan_id: id).data_curation
     hash[:investigation] = Contributor.where(plan_id: id).investigation
     hash[:pa] = Contributor.where(plan_id: id).project_administration

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -7,6 +7,21 @@
 
   <p><strong><%= _("Creator:") %></strong><%= @hash[:attribution] %></p><br>
 
+  <%# portagenetwork/roadmap#202: add contributor to cover page %>
+  <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
+  <% if @hash[:investigation].present? %>
+  <p><b><%= _("Principal Investigator: ") %></b><%= @hash[:investigation].map(&:name).join(', ') %></p><br>
+  <% end %>
+  <% if @hash[:data_curation].present? %>
+  <p><b><%= _("Data Manager: ") %></b><%= @hash[:data_curation].map(&:name).join(', ') %></p><br>
+  <% end %>
+  <% if @hash[:pa].present? %>
+  <p><b><%= _("Project Administrator: ") %></b><%= @hash[:pa].map(&:name).join(', ') %></p><br>
+  <% end %>
+  <% if @hash[:other].present? %>
+  <p><b><%= _("Contributor: ") %></b><%= @hash[:other].map(&:name).join(', ') %></p><br>
+  <% end %>
+
   <p><b><%= _("Affiliation: ") %></b><%= @hash[:affiliation] %></p><br>
 
   <% if @hash[:funder].present? %>

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -7,7 +7,8 @@
 
   <p><strong><%= _("Creator:") %></strong><%= @hash[:attribution] %></p><br>
 
-  <%# portagenetwork/roadmap#202: add contributor to cover page %>
+  <%# Added contributors to coverage of plans. 
+    # Users will see both roles and contributor names if the role is filled %>
   <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
   <% if @hash[:investigation].present? %>
   <p><b><%= _("Principal Investigator: ") %></b><%= @hash[:investigation].map(&:name).join(', ') %></p><br>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -2,7 +2,8 @@
 <%= "----------------------------------------------------------\n" %>
 <% if @show_coversheet %>
 <%= Array(@hash[:attribution]).many? ? _("Creators: ") + Array(@hash[:attribution]).join(", ")  : _('Creator:') + @hash[:attribution] %>
-<%# portagenetwork/roadmap#202: add contributor to cover page %>
+<%# Added contributors to coverage of plans. 
+  # Users will see both roles and contributor names if the role is filled %>
 <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
   <% if @hash[:investigation].present? %>
 <%= _("Principal Investigator: ") + @hash[:investigation].map(&:name).join(', ') %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -2,6 +2,20 @@
 <%= "----------------------------------------------------------\n" %>
 <% if @show_coversheet %>
 <%= Array(@hash[:attribution]).many? ? _("Creators: ") + Array(@hash[:attribution]).join(", ")  : _('Creator:') + @hash[:attribution] %>
+<%# portagenetwork/roadmap#202: add contributor to cover page %>
+<%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
+  <% if @hash[:investigation].present? %>
+<%= _("Principal Investigator: ") + @hash[:investigation].map(&:name).join(', ') %>
+  <% end %>
+  <% if @hash[:data_curation].present? %>
+<%= _("Data Manager: ") +  @hash[:data_curation].map(&:name).join(', ') %>
+  <% end %>
+  <% if @hash[:pa].present? %>
+<%= _("Project Administrator: ") + @hash[:pa].map(&:name).join(', ') %>
+  <% end %>
+  <% if @hash[:other].present? %>
+<%= _("Contributor: ") + @hash[:other].map(&:name).join(', ') %>
+  <% end %>
 <%= _("Affiliation: ") + @hash[:affiliation] %>
   <% if @hash[:funder].present? %>
 <%= _("Template: ") + @hash[:funder] %>


### PR DESCRIPTION
A user of DMP Assistant asks us to add contributors to coverage since they are the ones to be more valuable to DMP than creators. This PR achieves this function, also adds 'Title' to csv DMPs.

Changes proposed in this PR:

- Added contributors to coverage of plans. Users will see both roles and contributor names if the role is filled ('Other' is replaced by 'Contributor' as the role name). A role can have many contributors and the same contributor can have more than one role:

![Screen Shot 2022-05-19 at 17 25 54](https://user-images.githubusercontent.com/92752107/169407300-22fde5bf-6715-4d65-9080-d4325a974306.png)

- For JSON export, it will show as part of JSON object with the whole contributor information:

`"contributor":[{"name":"Wendy Shan Both","mbox":"test@test.com","role":["http://credit.niso.org/contributor-roles//data-curation","http://credit.niso.org/contributor-roles//investigation"],"affiliation":{"name":"University of British Columbia","abbreviation":"UBC","region":null}},{"name":"Wendy Shan","mbox":"test@test.com","role":["http://credit.niso.org/contributor-roles//investigation","other"],"affiliation":{"name":"University of British Columbia","abbreviation":"UBC","region":null}}]`

- Added plan title to csv file
