### PR TITLE
DCC Issue 710: The V0 API calls for assign_users and unassign_users to

### DIFF
--- a/app/controllers/api/v0/departments_controller.rb
+++ b/app/controllers/api/v0/departments_controller.rb
@@ -48,9 +48,8 @@ module Api
 
         assign_users_to(@department.id)
 
-        # Added "status: :see_other" to redirect_to (as we require rediect to be a GET).
-        # See https://makandracards.com/makandra/38347-redirecting-responses-for-patch-or-delete-will-not-redirect-with-get
-        redirect_to users_api_v0_departments_path, status: :see_other
+        @users = @user.org.users.includes(:department)
+        render users_api_v0_departments_path
       end
 
       ##
@@ -62,9 +61,8 @@ module Api
 
         assign_users_to(nil)
 
-        # Added "status: :see_other" to redirect_to (as we require rediect to be a GET).
-        # See https://makandracards.com/makandra/38347-redirecting-responses-for-patch-or-delete-will-not-redirect-with-get
-        redirect_to users_api_v0_departments_path, status: :see_other
+        @users = @user.org.users.includes(:department)
+        render users_api_v0_departments_path
       end
 
       private


### PR DESCRIPTION
departments was broken.

DCC Issue https://github.com/DigitalCurationCentre/DMPonline-Service/issues/710

The fix involved making the following changes to the assign_users() and
unassign_users() methods in
app/controllers/api/v0/departments_controller.rb:
- Removed the previous redirect_to in each method and replaced it with
          render users_api_v0_departments_path
- Ensured the @users variable was set as follows
          @users = @user.org.users.includes(:department)
which is the way @users is set in the users() method in the controller.
The Json was called without this value during rendering.

