### PR TITLE
Bug #3200 - Fix for the V1 API call GET /api/v1/plans returns duplica…

### DIFF
--- a/app/policies/api/v1/plans_policy.rb
+++ b/app/policies/api/v1/plans_policy.rb
@@ -27,7 +27,7 @@ module Api
 
           ids = @user.plans.pluck(&:id)
           ids += @user.org.plans.pluck(&:id) if @user.org.present?
-          ids
+          ids.uniq
         end
 
         def plans_for_user
@@ -36,7 +36,7 @@ module Api
           ids = @user.org.plans.organisationally_visible.pluck(:id)
           ids += @user.plans.pluck(:id)
           ids += @user.org.plans.pluck(:id) if @user.can_org_admin?
-          ids
+          ids.uniq
         end
 
         def initialize(client, plan)


### PR DESCRIPTION
…te plans in some cases.

Fix for issue #3200.

Changes in app/policies/api/v1/plans_policy.rb methods
plans_for_client() and plans_for_user() returns a unique array of plan
ids by finally calling the method uniq() on the ids the methods
previously returned.

