### PR TITLE
Bug #3203 - Fix for download plans docx being malformed if it has

### DIFF
--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -78,8 +78,8 @@ class PlanExportsController < ApplicationController
   def show_docx
     # Using and optional locals_assign export_format
     render docx: "#{file_name}.docx",
-           content: render_to_string(partial: 'shared/export/plan',
-                                     locals: { export_format: 'docx' })
+           content: clean_html_for_docx_creation(render_to_string(partial: 'shared/export/plan',
+                                                                  locals: { export_format: 'docx' }))
   end
 
   def show_pdf
@@ -135,5 +135,12 @@ class PlanExportsController < ApplicationController
           .permit(:form, :project_details, :question_headings, :unanswered_questions,
                   :custom_sections, :research_outputs,
                   formatting: [:font_face, :font_size, { margin: %i[top right bottom left] }])
+  end
+
+  # A method to deal with problematic text combinations
+  # in html that break docx creation by htmltoword gem.
+  def clean_html_for_docx_creation(html)
+    # Replaces single backslash \ with \\ with gsub.
+    html.gsub(/\\/, '\&\&')
   end
 end


### PR DESCRIPTION
character combinations lik \0.. or \F.., e,g, as in
 G:\Hematologie\Onderzoek\Studie Team Hematologie\Studies op alfabet\studies\RODEO\00. DIGITAAL ISF\03. Contracts - Agreements\a. Clinical Trial Agreement.

Failing content ensures docx loses data:
![Selection_010](https://user-images.githubusercontent.com/8876215/184347084-e5a71a6b-6a93-4009-b17e-164fdcda1506.png)
 

Fix for issue #3203.

Change:
The htmltoword gem converts html to docx, so we clean the html string by
replacing single backslashes \ by double backslashes \\.

Failing content now fixed and document rendered in full
![Selection_009](https://user-images.githubusercontent.com/8876215/184346406-f7078a48-3b6a-423c-8146-b17200e86e12.png)
