### PR TITLE
pluck with ampersand returns not id

### DIFF
--- a/app/policies/api/v1/plans_policy.rb
+++ b/app/policies/api/v1/plans_policy.rb
@@ -25,8 +25,8 @@ module Api
         def plans_for_client
           return [] unless @user.present?
 
-          ids = @user.plans.pluck(&:id)
-          ids += @user.org.plans.pluck(&:id) if @user.org.present?
+          ids = @user.plans.pluck(:id)
+          ids += @user.org.plans.pluck(:id) if @user.org.present?
           ids.uniq
         end
 


### PR DESCRIPTION
Changes proposed in this PR:
- `plans.pluck(&:id)` returns array of array values containing the plan attributes values. Probably typo. Should be `plans.pluck(:id)`
