### PR TITLE
Force local time in UI - DO NOT MERGE FOR PR

### DIFF
--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -117,8 +117,8 @@ module Api
       # takes in the params hash and converts to a date-range
       def dates_to_range(hash, start, stop)
         today = Date.today
-        start_date = Date.parse(hash.fetch(start, today.prev_month.to_date.to_s))
-        end_date = Date.parse(hash.fetch(stop, today.to_date.to_s)) + 1.day
+        start_date = Date.parse(hash.fetch(start, today.prev_month.localtime.to_date.to_s))
+        end_date = Date.parse(hash.fetch(stop, today.localtime.to_date.to_s)) + 1.day
         start_date..end_date
       end
     end

--- a/app/controllers/api/v0/statistics_controller.rb
+++ b/app/controllers/api/v0/statistics_controller.rb
@@ -234,8 +234,8 @@ module Api
       # Convert start/end dates in hash to a range of Dates
       def dates_to_range(hash)
         today = Date.today
-        start_date = Date.parse(hash.fetch('start_date', today.prev_month.to_date.to_s))
-        end_date = Date.parse(hash.fetch('end_date', today.to_date.to_s)) + 1.day
+        start_date = Date.parse(hash.fetch('start_date', today.prev_month.localtime.to_date.to_s))
+        end_date = Date.parse(hash.fetch('end_date', today.localtime.to_date.to_s)) + 1.day
         start_date..end_date
       end
     end

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -71,7 +71,7 @@ module OrgAdmin
             (plan.owner&.org&.present? ? plan.owner.org.name : '').to_s,
             plan.owner&.name(false)&.to_s,
             plan.owner&.email&.to_s,
-            l(plan.latest_update.to_date, format: :csv).to_s,
+            l(plan.latest_update.localtime.to_date, format: :csv).to_s,
             Plan::VISIBILITY_MESSAGE[plan.visibility.to_sym].capitalize.to_s
           ]
         end

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -341,7 +341,7 @@ module OrgAdmin
                    template: 'template_exports/template_export',
                    margin: @formatting[:margin],
                    footer: {
-                     center: format(_('Template created using the %{application_name} service. Last modified %{date}'), application_name: ApplicationService.application_name, date: l(@template.updated_at.to_date, formats: :short)),
+                     center: format(_('Template created using the %{application_name} service. Last modified %{date}'), application_name: ApplicationService.application_name, date: l(@template.updated_at.localtime.to_date, formats: :short)),
                      font_size: 8,
                      spacing: (@formatting[:margin][:bottom] / 2) - 4,
                      right: '[page] of [topage]',

--- a/app/controllers/plan_exports_controller.rb
+++ b/app/controllers/plan_exports_controller.rb
@@ -98,7 +98,7 @@ class PlanExportsController < ApplicationController
            footer: {
              center: format(_('Created using %{application_name}. Last modified %{date}'),
                             application_name: ApplicationService.application_name,
-                            date: l(@plan.updated_at.to_date, format: :readable)),
+                            date: l(@plan.updated_at.localtime.to_date, format: :readable)),
              font_size: 8,
              spacing: (Integer(@formatting[:margin][:bottom]) / 2) - 4,
              right: '[page] of [topage]',

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -66,7 +66,7 @@ class PublicPagesController < ApplicationController
                  footer: {
                    center: format(_('Template created using the %{application_name} service. Last modified %{date}'),
                                   application_name: ApplicationService.application_name,
-                                  date: l(@template.updated_at.to_date, formats: :short)),
+                                  date: l(@template.updated_at.localtime.to_date, formats: :short)),
                    font_size: 8,
                    spacing: (@formatting[:margin][:bottom] / 2) - 4,
                    right: '[page] of [topage]',

--- a/app/models/concerns/exportable_plan.rb
+++ b/app/models/concerns/exportable_plan.rb
@@ -171,7 +171,7 @@ module ExportablePlan
     if description.present?
       csv << [_('Project abstract: '), format(_('%{description}'), description: Nokogiri::HTML(description).text)]
     end
-    csv << [_('Last modified: '), format(_('%{date}'), date: updated_at.to_date.strftime('%d-%m-%Y'))]
+    csv << [_('Last modified: '), format(_('%{date}'), date: updated_at.localtime.to_date.strftime('%d-%m-%Y'))]
     csv << [_('Copyright information:'),
             _("The above plan creator(s) have agreed that others may use as
              much of the text of this plan as they would like in their own plans,

--- a/app/models/user/at_csv.rb
+++ b/app/models/user/at_csv.rb
@@ -19,8 +19,8 @@ class User
         @users.each do |user|
           name = "#{user.firstname} #{user.surname}"
           email = user.email
-          created = I18n.l user.created_at.to_date, format: :csv
-          last_activity = I18n.l user.updated_at.to_date, format: :csv
+          created = I18n.l user.created_at.localtime.to_date, format: :csv
+          last_activity = I18n.l user.updated_at.localtime.to_date, format: :csv
           plans = user.plans.size
           active = user.active ? 'Yes' : 'No'
 

--- a/app/presenters/plan_presenter.rb
+++ b/app/presenters/plan_presenter.rb
@@ -10,8 +10,8 @@ class PlanPresenter
 
   # Converts the Project Start and End Dates into human readable text
   def project_dates_to_readonly_display
-    sd = I18n.l(@plan.start_date.to_date, formats: :short) if @plan.start_date.present?
-    ed = I18n.l(@plan.end_date.to_date, formats: :short) if @plan.end_date.present?
+    sd = I18n.l(@plan.start_date.localtime.to_date, formats: :short) if @plan.start_date.present?
+    ed = I18n.l(@plan.end_date.localtime.to_date, formats: :short) if @plan.end_date.present?
 
     return "#{sd} to #{ed}" if sd.present? && ed.present?
     return "Starts on #{sd}" if sd.present?

--- a/app/presenters/plan_presenter.rb
+++ b/app/presenters/plan_presenter.rb
@@ -9,6 +9,7 @@ class PlanPresenter
   end
 
   # Converts the Project Start and End Dates into human readable text
+  # rubocop:disable Metrics/AbcSize
   def project_dates_to_readonly_display
     sd = I18n.l(@plan.start_date.localtime.to_date, formats: :short) if @plan.start_date.present?
     ed = I18n.l(@plan.end_date.localtime.to_date, formats: :short) if @plan.end_date.present?
@@ -19,4 +20,5 @@ class PlanPresenter
 
     ''
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/presenters/research_output_presenter.rb
+++ b/app/presenters/research_output_presenter.rb
@@ -146,7 +146,7 @@ class ResearchOutputPresenter
   def display_release
     return _('Unspecified') unless @research_output.release_date.present?
 
-    @research_output.release_date.to_date
+    @research_output.release_date.localtime.to_date
   end
 
   # Return 'Yes', 'No' or 'Unspecified' depending on the value

--- a/app/validators/after_validator.rb
+++ b/app/validators/after_validator.rb
@@ -11,7 +11,7 @@ class AfterValidator < ActiveModel::EachValidator
     return if record.new_record? && options[:on].to_s == 'update'
 
     msg = options.fetch(:message, format(DEFAULT_MESSAGE, date: options[:date]))
-    record.errors.add(attribute, msg) if value.to_date < options[:date]
+    record.errors.add(attribute, msg) if value.localtime.to_date < options[:date]
   end
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/validators/after_validator.rb
+++ b/app/validators/after_validator.rb
@@ -11,7 +11,7 @@ class AfterValidator < ActiveModel::EachValidator
     return if record.new_record? && options[:on].to_s == 'update'
 
     msg = options.fetch(:message, format(DEFAULT_MESSAGE, date: options[:date]))
-    record.errors.add(attribute, msg) if value.localtime.to_date < options[:date]
+    record.errors.add(attribute, msg) if value.to_date < options[:date]
   end
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -45,13 +45,13 @@
   <div class="form-group col-xs-8">
     <%= label_tag(:created_at, _('Created at'), class: "control-label") %>
     <p class="form-control-static">
-      <%= l f.object.created_at.to_date, formats: :short %>
+      <%= l f.object.created_at.localtime.to_date, formats: :short %>
     </p>
   </div>
   <div class="form-group col-xs-8">
     <%= label_tag(:updated, _('Last updated'), class: "control-label") %>
     <p class="form-control-static">
-      <%= l f.object.updated_at.to_date, formats: :short %>
+      <%= l f.object.updated_at.localtime.to_date, formats: :short %>
     </p>
   </div>
 <% end %>

--- a/app/views/org_admin/templates/_row.html.erb
+++ b/app/views/org_admin/templates/_row.html.erb
@@ -18,6 +18,6 @@
   </td>
   <td>
     <% last_temp_updated = template.updated_at %>
-    <%= l last_temp_updated.to_date, formats: :short %>
+    <%= l last_temp_updated.localtime.to_date, formats: :short %>
   </td>
 </tr>

--- a/app/views/org_admin/templates/_show.html.erb
+++ b/app/views/org_admin/templates/_show.html.erb
@@ -39,9 +39,9 @@
     </dd>
   <% end %>
   <dt><%= _('Created at') %></dt>
-  <dd><%= l template.created_at.to_date, formats: :short %></dd>
+  <dd><%= l template.created_at.localtime.to_date, formats: :short %></dd>
   <dt><%= _('Last updated') %></dt>
-  <dd><%= l template.updated_at.to_date, formats: :short %></dd>
+  <dd><%= l template.updated_at.localtime.to_date, formats: :short %></dd>
 </dl>
 
 <%# passing phases separately here because we're only pulling down the necessary attributes %>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -80,7 +80,7 @@
                    links: org.links.fetch("org", []),
                    max_number_links: Rails.configuration.x.max_number_links_funder,
                    tooltip: shared_links_tooltip }) %>
-      <%= hidden_field_tag('org_links', org.links) %>
+      <%= hidden_field_tag('org_links', value: org.links) %>
     </div>
   </div>
 

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -80,7 +80,7 @@
                    links: org.links.fetch("org", []),
                    max_number_links: Rails.configuration.x.max_number_links_funder,
                    tooltip: shared_links_tooltip }) %>
-      <%= hidden_field_tag('org_links', value: org.links) %>
+      <%= hidden_field_tag('org_links', org.links) %>
     </div>
   </div>
 

--- a/app/views/paginable/api_clients/_index.html.erb
+++ b/app/views/paginable/api_clients/_index.html.erb
@@ -27,7 +27,7 @@
           <td><%= client.org&.name %></td>
           <td><%= client.homepage.present? ? link_to(client.homepage) : "" %></td>
           <td><%= client.contact_email.present? ? link_to(client.contact_email, "mailto:#{client.contact_email}") : "" %></td>
-          <td><%= client.last_access.present? ? l(client.last_access.to_date, formats: :short) : _("Never") %></td>
+          <td><%= client.last_access.present? ? l(client.last_access.localtime.to_date, formats: :short) : _("Never") %></td>
           <td>
             <div class="dropdown">
               <button

--- a/app/views/paginable/guidance_groups/_index.html.erb
+++ b/app/views/paginable/guidance_groups/_index.html.erb
@@ -33,7 +33,7 @@
                 <%= _('Yes')%>
             <% end %>
           </td>
-          <td class="text-center"><%= l guidance_gr.updated_at.to_date, formats: :short %></td>
+          <td class="text-center"><%= l guidance_gr.updated_at.localtime.to_date, formats: :short %></td>
           <td>
             <div class="dropdown">
               <button

--- a/app/views/paginable/guidances/_index.html.erb
+++ b/app/views/paginable/guidances/_index.html.erb
@@ -38,7 +38,7 @@
               <% end %>
             </td>
             <td>
-              <%= l guidance.updated_at.to_date, formats: :short %>
+              <%= l guidance.updated_at.localtime.to_date, formats: :short %>
             </td>
             <td>
               <div class="dropdown">

--- a/app/views/paginable/plans/_index.html.erb
+++ b/app/views/paginable/plans/_index.html.erb
@@ -23,7 +23,7 @@
           <td><%= plan.template.title %></td>
           <td><%= plan.owner.org.name if plan.owner.present? %></td>
           <td><%= plan.owner.name(false) if plan.owner.present? %></td>
-          <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
+          <td><%= l(plan.updated_at.localtime.to_date, formats: :short) %></td>
           <td class="plan-visibility">
             <%= plan.visibility === 'is_test' ? _('Test') : sanitize(display_visibility(plan.visibility)) %>
           </td>

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -37,8 +37,8 @@
           <td><%= plan.template.title %></td>
           <td><%= plan.owner&.org&.name %></td>
           <td><%= plan.owner&.name(false) %></td>
-          <td><%= l(plan.created_at.to_date, formats: :short) %></td>
-          <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
+          <td><%= l(plan.created_at.localtime.to_date, formats: :short) %></td>
+          <td><%= l(plan.updated_at.localtime.to_date, formats: :short) %></td>
           <td class="plan-visibility">
             <%= plan.visibility === 'is_test' ? _('Test') : sanitize(display_visibility(plan.visibility)) %>
           </td>

--- a/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_organisationally_or_publicly_visible.html.erb
@@ -29,7 +29,7 @@
                 </td>
                 <td><%= plan.template.title %></td>
                 <td><%= plan.owner.present? ? plan.owner.name : _('Unknown') %></td>
-                <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
+                <td><%= l(plan.updated_at.localtime.to_date, formats: :short) %></td>
                 <td class="text-center">
                   <%= link_to plan_export_path(plan, format: :pdf, export: { question_headings: true }),
                       class: 'has-new-window-popup-info',

--- a/app/views/paginable/plans/_privately_visible.html.erb
+++ b/app/views/paginable/plans/_privately_visible.html.erb
@@ -23,7 +23,7 @@
                 plan_path(plan) %>
           </td>
           <td><%= plan.template.title %></td>
-          <td><%= l(plan.updated_at.to_date, formats: :short) %></td>
+          <td><%= l(plan.updated_at.localtime.to_date, formats: :short) %></td>
           <td><%= display_role(my_plan_roles.first) %></td>
           <td class="text-center">
             <% if plan.administerable_by?(current_user.id) then %>

--- a/app/views/paginable/templates/_customisable.html.erb
+++ b/app/views/paginable/templates/_customisable.html.erb
@@ -43,7 +43,7 @@
         </td>
         <td>
           <% last_temp_updated = template.updated_at %>
-          <%= l last_temp_updated.to_date, formats: :short %>
+          <%= l last_temp_updated.localtime.to_date, formats: :short %>
         </td>
         <td>
           <div class="dropdown">

--- a/app/views/paginable/templates/_history.html.erb
+++ b/app/views/paginable/templates/_history.html.erb
@@ -42,7 +42,7 @@
             <%= (template.published? ? _('Yes') : _('No')) %>
           </td>
           <td>
-            <%= l template.updated_at.to_date, formats: :short %>
+            <%= l template.updated_at.localtime.to_date, formats: :short %>
           </td>
           <td class="text-center">
             <% if template.customization_of.present? %>

--- a/app/views/paginable/templates/_organisational.html.erb
+++ b/app/views/paginable/templates/_organisational.html.erb
@@ -44,7 +44,7 @@
           </td>
           <td>
             <% last_temp_updated = template.updated_at %>
-            <%= l last_temp_updated.to_date, formats: :short %>
+            <%= l last_temp_updated.localtime.to_date, formats: :short %>
           </td>
           <% if action_name != 'index' %>
             <td>

--- a/app/views/paginable/templates/_publicly_visible.html.erb
+++ b/app/views/paginable/templates/_publicly_visible.html.erb
@@ -37,7 +37,7 @@
             <% end %>
           </td>
           <td><%= template.org.name %></td>
-          <td><%= l(template.updated_at.to_date, formats: :short) %></td>
+          <td><%= l(template.updated_at.localtime.to_date, formats: :short) %></td>
           <td>
             <%= sanitize links_to_a_elements(template.links['funder'], '<br>') %>
           </td>

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -51,12 +51,12 @@
                   <td><%= user.org.name if user.org.present? %></td>
                   <td class="text-center">
                       <% if !user.created_at.nil? %>
-                      <%= l user.created_at.to_date, :formats => :short %>
+                      <%= l user.created_at.localtime.to_date, :formats => :short %>
                       <% end %>
                   </td>
                   <td class="text-center">
                       <% if !user.last_sign_in_at.nil? %>
-                      <%= l user.last_sign_in_at.to_date, :formats => :short %>
+                      <%= l user.last_sign_in_at.localtime.to_date, :formats => :short %>
                       <% end %>
                   </td>
                   <td class="text-center">

--- a/app/views/plans/_overview_details.html.erb
+++ b/app/views/plans/_overview_details.html.erb
@@ -16,7 +16,7 @@
     <p>
         <span class="bold"><%= _('Template version %{template_version}, published on %{published_date}') \
                   %{ :template_version => plan.template.version, \
-                     :published_date =>  l(plan.template.updated_at.to_date, format: :readable) } %>
+                     :published_date =>  l(plan.template.updated_at.localtime.to_date, format: :readable) } %>
         </span>
     </p>
   </div>

--- a/app/views/shared/export/_plan_coversheet.erb
+++ b/app/views/shared/export/_plan_coversheet.erb
@@ -7,7 +7,7 @@
 
   <p><strong><%= _("Creator:") %></strong><%= @hash[:attribution] %></p><br>
 
-  <%# Added contributors to coverage of plans. 
+  <%# Added contributors to coverage of plans.
     # Users will see both roles and contributor names if the role is filled %>
   <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
   <% if @hash[:investigation].present? %>
@@ -48,14 +48,14 @@
   <% end %>
 
   <% if @plan.start_date.present? %>
-    <p><b><%= _("Start date: ") %></b><%=  l(@plan.start_date.to_date, formats: :short) %></p> <br>
+    <p><b><%= _("Start date: ") %></b><%=  l(@plan.start_date.localtime.to_date, formats: :short) %></p> <br>
   <% end %>
 
   <% if @plan.end_date.present? %>
-    <p><b><%= _("End date: ") %></b><%=  l(@plan.end_date.to_date, formats: :short) %></p> <br>
+    <p><b><%= _("End date: ") %></b><%=  l(@plan.end_date.localtime.to_date, formats: :short) %></p> <br>
   <% end %>
 
-  <p><b><%= _("Last modified: ") %></b><%=  l(@plan.updated_at.to_date, formats: :short) %></p> <br>
+  <p><b><%= _("Last modified: ") %></b><%=  l(@plan.updated_at.localtime.to_date, formats: :short) %></p> <br>
 
   <% if @plan.grant.present? %>
     <p><b><%= _("Grant number / URL: ") %></b><%= @plan.grant.value %></p> <br>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -2,7 +2,7 @@
 <%= "----------------------------------------------------------\n" %>
 <% if @show_coversheet %>
 <%= Array(@hash[:attribution]).many? ? _("Creators: ") + Array(@hash[:attribution]).join(", ")  : _('Creator:') + @hash[:attribution] %>
-<%# Added contributors to coverage of plans. 
+<%# Added contributors to coverage of plans.
   # Users will see both roles and contributor names if the role is filled %>
 <%# Roles are ranked by PI -> DM -> PA -> Other (if any) %>
   <% if @hash[:investigation].present? %>
@@ -30,7 +30,7 @@
 <%= _("Project abstract: ") %>
 <%= "\t" + strip_tags(@plan.description) + "\n" %>
   <% end %>
-<%= _("Last modified: ") + l(@plan.updated_at.to_date, formats: :short) %>
+<%= _("Last modified: ") + l(@plan.updated_at.localtime.to_date, formats: :short) %>
 <%= _("Copyright information:") %>
 <%= "\t" + _(" The above plan creator(s) have agreed that others may use as much of the text of this plan as they would like in their own plans, and customise it as necessary. You do not need to credit the creator(s) as the source of the language used, but using any of the plan's text does not imply that the creator(s) endorse, or have any relationship to, your project or proposal") %>
 <%= "----------------------------------------------------------\n" %>


### PR DESCRIPTION
In the event that the database stores date/time entries as UTC, this will ensure that the UI displays the information in Local time.

Most of the dates in the UI that display created_at and updated_at only display the date without time (e.g. 11/15/22, 2022-11-15, etc.) so it's not probably an issue for most users. DMPTool is 8 hours behind UTC though, so when a user does something like creating a plan in the afternoon, the My Dashboard page shows the modification date as in the future.

This PR just adds a conversion to local server time.

**Do not merge this one yet. Lets discuss in the next dev meeting**