### PR TITLE
Added missing translation for email that lists new user permissions

### DIFF
--- a/app/helpers/perms_helper.rb
+++ b/app/helpers/perms_helper.rb
@@ -14,7 +14,7 @@ module PermsHelper
       use_api: _('API rights'),
       change_org_details: _('Manage organisation details'),
       grant_api_to_orgs: _('Grant API to organisations'),
-      review_org_plans: _('')
+      review_org_plans: _('Review organisational plans')
     }
   end
 end


### PR DESCRIPTION
The email that gets sent to users when their permissions have changed includes a Translation.io error message. This PR sets a value/label for the `review_org_plans` permission.
