### PR TITLE
Change csv file name for statistics from 'Completed' to 'Created'

### DIFF
--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -84,14 +84,14 @@ class UsageController < ApplicationController
     plan_data(args: default_query_args)
     sep = sep_param
     send_data(CSV.generate(col_sep: sep) do |csv|
-      csv << [_('Month'), _('No. Completed Plans')]
+      csv << [_('Month'), _('No. Created Plans')]
       total = 0
       @plans_per_month.each do |data|
         csv << [data.date.strftime('%b-%y'), data.count]
         total += data.count
       end
       csv << [_('Total'), total]
-    end, filename: 'completed_plans.csv')
+    end, filename: 'created_plans.csv')
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/spec/controllers/usage_controller_spec.rb
+++ b/spec/controllers/usage_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe UsageController, type: :controller do
       get :yearly_plans
     end
     it 'assigns the correct csv data' do
-      expected = "Month,No. Completed Plans\n" \
+      expected = "Month,No. Created Plans\n" \
                  "#{@date.strftime('%b-%y')},#{@plan_stat.count}\n" \
                  "Total,#{@plan_stat.count}\n"
       expect(response.content_type).to eq('text/csv')


### PR DESCRIPTION
DMP Assisant users reported being confused by the 'Completed Plan' file name when they downloaded the CSV file from the usage page. A more clarified name should be 'Created Plan'.