### PR TITLE
Fix issue 3247: change ubuntu version in Github Actions to ubuntu-20.04

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   brakeman:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   eslint:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     # Checkout the repo

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   mysql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Define environment variables for MySQL and Rails
     env:

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   postgresql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       # Postgres installation

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   rubocop:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     # Checkout the repo


### PR DESCRIPTION
Fixes #3247 .

Changes proposed in this PR:
- set ubuntu-20.04 in all Github actions to get the latest version of wkhtmltopdf-binary(0.12.6.5) running again.
