### PR TITLE
Add Changelog.md and Danger Github action to code review process

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,32 @@
+name: Danger
+
+on: [push, pull_request]
+
+jobs:
+  danger:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: 'Determine Ruby and Bundler Versions from Gemfile.lock'
+      run: |
+        echo "RUBY_VERSION=`cat ./Gemfile.lock | grep -A 1 'RUBY VERSION' | grep 'ruby' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
+        echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
+
+    # Install Ruby - using the version found in the Gemfile.lock
+    - name: 'Install Ruby'
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ env.RUBY_VERSION }}
+
+    - name: 'Bundle Install'
+      run: |
+        gem install bundler -v ${{ env.BUNDLER_VERSION }}
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3 --without pgsql rollbar aws
+
+    - name: 'Run Danger'
+      env:
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: bundle exec danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+### Added 
+
+- Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
+
+### Fixed
+
+### Changed

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,27 @@
+# Make sure non-trivial amounts of code changes come with corresponding tests
+has_app_changes = !git.modified_files.grep(/lib/).empty? || !git.modified_files.grep(/app/).empty?
+has_test_changes = !git.modified_files.grep(/test/).empty?
+
+if  git.lines_of_code > 50 && has_app_changes && !has_test_changes
+  warn('There are code changes, but no corresponding tests. '\
+         'Please include tests if this PR introduces any modifications in '\
+         'behavior.',
+       sticky: false)
+end
+
+# Mainly to encourage writing up some reasoning about the PR, rather than
+# just leaving a title
+warn('Please add a detailed summary in the description.') if github.pr_body.length < 3
+
+# Warn when there is a big PR
+warn('This PR is too big! Consider breaking it down into smaller PRs.') if git.lines_of_code > 1000
+
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
+
+# Let people say that this isn't worth a CHANGELOG entry in the PR if they choose
+declared_trivial = (github.pr_title + github.pr_body).include?("#trivial") || !has_app_changes
+
+if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
+  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/DMPRoadmap/roadmap/blob/main/CHANGELOG.md).", sticky: false)
+end

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 # Make sure non-trivial amounts of code changes come with corresponding tests
 has_app_changes = !git.modified_files.grep(/lib/).empty? || !git.modified_files.grep(/app/).empty?
 has_test_changes = !git.modified_files.grep(/test/).empty?
 
-if  git.lines_of_code > 50 && has_app_changes && !has_test_changes
-  warn('There are code changes, but no corresponding tests. '\
-         'Please include tests if this PR introduces any modifications in '\
-         'behavior.',
+if git.lines_of_code > 50 && has_app_changes && !has_test_changes
+  warn('There are code changes, but no corresponding tests. ' \
+       'Please include tests if this PR introduces any modifications in ' \
+       'behavior.',
        sticky: false)
 end
 
@@ -17,11 +19,15 @@ warn('Please add a detailed summary in the description.') if github.pr_body.leng
 warn('This PR is too big! Consider breaking it down into smaller PRs.') if git.lines_of_code > 1000
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
+warn('PR is classed as Work in Progress') if github.pr_title.include? '[WIP]'
 
 # Let people say that this isn't worth a CHANGELOG entry in the PR if they choose
-declared_trivial = (github.pr_title + github.pr_body).include?("#trivial") || !has_app_changes
+declared_trivial = (github.pr_title + github.pr_body).include?('#trivial') || !has_app_changes
 
-if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
-  fail("Please include a CHANGELOG entry. \nYou can find it at [CHANGELOG.md](https://github.com/DMPRoadmap/roadmap/blob/main/CHANGELOG.md).", sticky: false)
+if !git.modified_files.include?('CHANGELOG.md') && !declared_trivial
+  raise(
+    "Please include a CHANGELOG entry. \n
+    You can find it at [CHANGELOG.md](https://github.com/DMPRoadmap/roadmap/blob/main/CHANGELOG.md).",
+    sticky: false
+  )
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,7 +2,7 @@
 
 # Make sure non-trivial amounts of code changes come with corresponding tests
 has_app_changes = !git.modified_files.grep(/lib/).empty? || !git.modified_files.grep(/app/).empty?
-has_test_changes = !git.modified_files.grep(/test/).empty?
+has_test_changes = !git.modified_files.grep(/spec/).empty?
 
 if git.lines_of_code > 50 && has_app_changes && !has_test_changes
   warn('There are code changes, but no corresponding tests. ' \

--- a/Gemfile
+++ b/Gemfile
@@ -294,7 +294,7 @@ group :test do
   gem 'rails-controller-testing'
 
   # automating code review
-  gem "danger", '~> 9.0', require: false 
+  gem 'danger', '~> 9.0', require: false
 end
 
 group :ci, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -292,6 +292,9 @@ group :test do
   # This gem brings back assigns to your controller tests as well as assert_template
   # to both controller and integration tests.
   gem 'rails-controller-testing'
+
+  # automating code review
+  gem "danger", '~> 9.0', require: false 
 end
 
 group :ci, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,13 +106,34 @@ GEM
       xpath (~> 3.2)
     capybara-webmock (0.1.0)
     childprocess (4.1.0)
+    claide (1.1.0)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
     coderay (1.1.3)
+    colored2 (3.1.2)
     concurrent-ruby (1.1.10)
     contact_us (1.2.0)
       rails (>= 4.2.0)
+    cork (0.3.0)
+      colored2 (~> 3.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    danger (9.1.0)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (>= 0.9.0, < 2.0)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.7)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      no_proxy_fix
+      octokit (~> 5.0)
+      terminal-table (>= 1, < 4)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
     database_cleaner-active_record (2.0.1)
@@ -153,10 +174,11 @@ GEM
       railties (>= 5.0.0)
     faker (3.0.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.7.1)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (1.2.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-http-cache (2.4.1)
+      faraday (>= 0.8)
     ffi (1.15.5)
     flag_shih_tzu (0.3.23)
     fog-aws (3.15.0)
@@ -186,6 +208,9 @@ GEM
       locale (>= 2.0.5)
       prime
       text (>= 1.3.0)
+    git (1.12.0)
+      addressable (~> 2.8)
+      rchardet (~> 1.8)
     globalid (1.0.0)
       activesupport (>= 5.0)
     guard (2.18.0)
@@ -232,6 +257,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     ledermann-rails-settings (2.5.0)
       activerecord (>= 4.2)
     listen (3.7.1)
@@ -260,9 +289,12 @@ GEM
     msgpack (1.6.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
+    multipart-post (2.2.3)
     mysql2 (0.5.4)
+    nap (1.1.0)
     nenv (0.3.0)
     nio4r (2.5.8)
+    no_proxy_fix (0.1.2)
     nokogiri (1.13.9-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
@@ -277,6 +309,9 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    octokit (5.6.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     omniauth (2.1.0)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -292,6 +327,7 @@ GEM
       omniauth (~> 2.0)
     omniauth-shibboleth (1.3.0)
       omniauth (>= 1.0.0)
+    open4 (1.3.4)
     options (2.3.2)
     orm_adapter (0.5.0)
     parallel (1.22.1)
@@ -359,6 +395,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rchardet (1.8.0)
     recaptcha (5.12.3)
       json
     regexp_parser (2.6.1)
@@ -414,6 +451,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
     selenium-webdriver (4.6.1)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -444,6 +484,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     text (1.3.1)
     thor (1.2.1)
     tilt (2.0.11)
@@ -517,6 +559,7 @@ DEPENDENCIES
   capybara
   capybara-webmock
   contact_us
+  danger (~> 9.0)
   database_cleaner
   devise
   devise_invitable


### PR DESCRIPTION
Fixes #3257 

### 1. Add Danger gem and Github action to the roadmap

Note that Danger is for reference. We can discuss changing the Danger configuration. Currently, the suggestion/reminder is:

1) PR prefers <= 1000 lines
2) If PR change >= 50, suggest adding a test
3) Remind to update CHANGELOG
4) `[WIP]` in the title will make this PR to be a draft pr
5) `#trivial` means no changelog is needed

An example:
<img width="802" alt="Screenshot 2022-12-06 at 4 06 56 PM" src="https://user-images.githubusercontent.com/92752107/206023043-f4fac0b8-eb93-4499-95dd-4af6f9dd6c61.png">

### 2. CHANGELOG.md is ready for use

The workflow would be to add the description and link to the issue (if any) to the CHANGELOG every time a PR is submitted. I created the 'Changed', 'Added' and 'Fixed' sections for categorization purposes, but we are feeling to change to other formats. 
The person who's gonna do the release will add the release version as the header to the CHANGELOG. Later, developers will pull the CHANGELOG and continue to build above it.

Example:
<img width="1053" alt="Screenshot 2022-12-06 at 5 08 35 PM" src="https://user-images.githubusercontent.com/92752107/206033942-f6ab6e68-d902-4a4c-b607-850ed9b1f06e.png">

By doing this, we will have a good record of the process, and whoever doing the release can use CHANGELOG as part of the release note. 

We can also consider adding this step to the contribution guide.
