### PR TITLE
Bug 3221 - Fix for docx export of plans sometimes fails when Html tags - WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-### Added 
+### Added
 
 - Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
 
 ### Fixed
+- Fix for docx export of plans sometimes fails when Html tags
+present in phase questions. [#3221] (https://github.com/DMPRoadmap/roadmap/issues/3221)
 
 ### Changed

--- a/app/scrubbers/html_free_scrubber.rb
+++ b/app/scrubbers/html_free_scrubber.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Logic that ensures that all HTML tags stripped from TinyMCE editor results
+class HtmlFreeScrubber < Rails::Html::PermitScrubber
+  def initialize
+    super
+    self.tags = []
+  end
+end

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -41,8 +41,9 @@
                   <% options = answer.present? ? answer.question_options : [] %>
                   <% if @show_unanswered %>
                     <%# Hack: for DOCX export - otherwise, bold highlighting of question inconsistent. %>
+                    <%# Strip all HTML tags for DOCX - as it sometimes result in broken files. %>
                     <% if local_assigns[:export_format] && export_format == 'docx' %>
-                      <strong><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></strong>
+                      <strong><%=  sanitize question[:text].to_s, scrubber: HtmlFreeScrubber.new %></strong>
                     <% else %>
                      <div class="bold"><%=  sanitize question[:text].to_s, scrubber: TableFreeScrubber.new %></div>
                     <% end %>


### PR DESCRIPTION
present in phase questions.

Fixes # 3221.

Followed a suggestion by @nicolasfranck to remove html markup for questions as they cause issue.

Changes proposed in this PR:
 - Created HtmlFreeScrubber a scrubber to strip html tags.
 - This scrupper is used in app/views/shared/export/_plan.erb only for rendering questions only for docx export.

**FOR DISCUSSION IF THIS IS SUITABLE.**

**Example with Table**

**Question and Answer with HTML including table**
![Selection_043](https://user-images.githubusercontent.com/8876215/210773998-94a1f515-ec2c-42fc-83d6-fcbab05a65ac.png)

**DOCX version of Question and Answer:**
![Selection_045](https://user-images.githubusercontent.com/8876215/210774740-59c13529-4012-481c-9822-3b3ef9439062.png)

**Unchanged PDF version of  Question and Answer:**
![Selection_046](https://user-images.githubusercontent.com/8876215/210775485-27df8c57-ce9b-4004-a581-2254ad0fe533.png)


**Simple Example:**

**Question with list:**
![Selection_047](https://user-images.githubusercontent.com/8876215/210776475-3e4658e7-646f-4e8c-984c-91f052728a77.png)

**DOCX version** 
![Selection_048](https://user-images.githubusercontent.com/8876215/210776775-edf59853-8bd1-44ca-8fee-0fd5a351fdbc.png)

**Unchanged PDF version**
![Selection_049](https://user-images.githubusercontent.com/8876215/210777017-1a7f2436-6ded-4c24-ad82-b21434b74c4f.png)

