### PR TITLE
updated JS that interacts with TinyMCE so that it stops using depreca…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-### Added 
+### Added
 
 - Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
 
 ### Fixed
+
+- Updated JS that used to call the TinyMCE `setMode()` function so that it now calls `mode.set()` because the former is now deprecated.
 
 ### Changed

--- a/app/javascript/src/answers/edit.js
+++ b/app/javascript/src/answers/edit.js
@@ -180,7 +180,7 @@ $(() => {
   } else {
     // Sets the editor mode for each editor to readonly
     Tinymce.findEditorsByClassName(editorClass).forEach((editor) => {
-      editor.setMode('readonly');
+      editor.mode.set('readonly');
     });
   }
 

--- a/app/javascript/src/orgs/adminEdit.js
+++ b/app/javascript/src/orgs/adminEdit.js
@@ -10,9 +10,9 @@ $(() => {
     const editor = Tinymce.findEditorById('org_feedback_msg');
     if (isObject(editor)) {
       if ($('#org_feedback_enabled_true').is(':checked')) {
-        editor.setMode('code');
+        editor.mode.set('design');
       } else {
-        editor.setMode('readonly');
+        editor.mode.set('readonly');
       }
     }
   };


### PR DESCRIPTION
We are calling the TinyMCE `setMode()` function in several places and this has been deprecated as of TinyMCE 5.0 https://www.tiny.cloud/docs/api/tinymce/tinymce.editor/#setmode

This PR updates the codebase to use `mode.set()` instead. It also uses the `design` mode instead of `code` since that option is no longer available.
