### PR TITLE
fix to properly use max per page settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-### Added 
+### Added
 
 - Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
 
 ### Fixed
+
+- Fixed discrepencies with default/max per_page values for API and UI pagination
 
 ### Changed

--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -6,7 +6,6 @@ module Api
     class BaseController < ApplicationController
       protect_from_forgery with: :null_session
       before_action :define_resource, only: %i[destroy show update]
-      before_action :pagination_params, only: %i[index]
       respond_to :json
 
       # POST /api/{plural_resource_name}

--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -6,6 +6,7 @@ module Api
     class BaseController < ApplicationController
       protect_from_forgery with: :null_session
       before_action :define_resource, only: %i[destroy show update]
+      before_action :pagination_params, only: %i[index]
       respond_to :json
 
       # POST /api/{plural_resource_name}

--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -98,7 +98,11 @@ module Api
         plan_ids = extract_param_list(params, 'plan')
         @plans = @plans.where(id: plan_ids) if plan_ids.present?
         # apply pagination after filtering
-        @args = { per_page: params[:per_page], page: params[:page] }
+        max_per_page = Rails.configuration.x.application.api_max_page_size
+        page = params.fetch('page', 1).to_i
+        per_page = params.fetch('per_page', max_per_page).to_i
+        per_page = max_per_page if @per_page > max_per_page
+        @args = { per_page: per_page, page: page }
         @plans = refine_query(@plans)
         respond_with @plans
       end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -60,9 +60,10 @@ module Api
       # Retrieve the requested pagination params or use defaults
       # only allow 100 per page as the max
       def pagination_params
+        max_per_page = Rails.configuration.x.application.api_max_page_size
         @page = params.fetch('page', 1).to_i
-        @per_page = params.fetch('per_page', 20).to_i
-        @per_page = 100 if @per_page > 100
+        @per_page = params.fetch('per_page', max_per_page).to_i
+        @per_page = max_per_page if @per_page > max_per_page
       end
 
       # Parse the body of the incoming request

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -156,7 +156,7 @@ module Paginable
     if @args[:page] != 'ALL'
       # Can raise error if page is not a number
       scope = scope.page(@args[:page])
-                   .per(@args.fetch(:per_page, Rails.configuration.x.application.api_max_page_size))
+                   .per(@args.fetch(:per_page, Rails.configuration.x.results_per_page))
     end
     scope
   end


### PR DESCRIPTION
- Update API v1 to obey they `api_max_page_size` configuration param
- Update `paginable.rb` to use `results_per_page` instead of `api_max_page_size`