### PR TITLE
Switched Google font used in PDFs from Helvetica to Roboto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-### Added 
+### Added
 
 - Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
 
 ### Fixed
+
+- Updated sans-serif font used in PDF downloads to Roboto since Google API no longer offers Helvetica
 
 ### Changed

--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -10,7 +10,7 @@ module ExportsHelper
   }.freeze
 
   def font_face
-    @formatting[:font_face].presence || 'Arial, Helvetica, Sans-Serif'
+    @formatting[:font_face].presence || 'Roboto, Arial, Sans-Serif'
   end
 
   def font_size

--- a/app/models/settings/template.rb
+++ b/app/models/settings/template.rb
@@ -18,7 +18,7 @@ module Settings
   class Template < RailsSettings::SettingObject
     VALID_FONT_FACES = [
       '"Times New Roman", Times, Serif',
-      'Arial, Helvetica, Sans-Serif'
+      'Roboto, Arial, Sans-Serif'
     ].freeze
 
     VALID_FONT_SIZE_RANGE = (8..14).freeze

--- a/app/views/shared/export/_plan_styling.erb
+++ b/app/views/shared/export/_plan_styling.erb
@@ -1,5 +1,5 @@
 <style>
-  @import 'https://fonts.googleapis.com/css?family=<%= font_face.downcase.include?('times') ? 'Times' : 'Helvetica' %>';
+  @import 'https://fonts.googleapis.com/css?family=<%= font_face.downcase.include?('times') ? 'Times' : 'Roboto' %>';
 
   body {
     font-family: <%= font_face %>;
@@ -58,5 +58,5 @@
     }
     .bold {
       font-weight: bold;
-    }  
+    }
 </style>


### PR DESCRIPTION
Fixes #3272

Changes proposed in this PR:
- Switch PDF CSS styling to fetch Roboto from the Google API since it no longer supports Helvetica
- Updated the select box on the download page to display 'Roboto' so users know what to expect
