### PR TITLE
Fix KeywordArgs issue in Paginable concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 - Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
 - Added validation with custom error message in research_output.rb to ensure a user does not enter a very large value as 'Anticipated file size'. [#3161](https://github.com/DMPRoadmap/roadmap/issues/3161)
-- Added popover for org profile page and added explanation for public plan 
+- Added popover for org profile page and added explanation for public plan
 ### Fixed
 
 - Updated JS that used to call the TinyMCE `setMode()` function so that it now calls `mode.set()` because the former is now deprecated.
+- Fixed an issue with the Rails 6 keyword arguments change that was causing the `paginable_sort_link` to fail
 
 ### Changed
 

--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -200,7 +200,7 @@ module Paginable
                                     end
     base_url = paginable_base_url(query_params[:page])
     sort_url = URI(base_url)
-    sort_url.query = stringify_query_params(query_params)
+    sort_url.query = stringify_query_params(**query_params)
     sort_url.to_s
     "#{sort_url}&#{stringify_nonpagination_query_params}"
   end


### PR DESCRIPTION
I just pulled down the latest development branch and ran into a keyword args error: `expected 1 but got 0` in the `pagionable_sort_link` calls for the tables on the my dashboard page.

I thought this had been fixed earlier 🤷🏻‍♂️ 
