### PR TITLE
Template visibility changed to organizationally_visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 - Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
 - Added validation with custom error message in research_output.rb to ensure a user does not enter a very large value as 'Anticipated file size'. [#3161](https://github.com/DMPRoadmap/roadmap/issues/3161)
-- Added popover for org profile page and added explanation for public plan 
+- Added popover for org profile page and added explanation for public plan
 ### Fixed
 
 - Updated JS that used to call the TinyMCE `setMode()` function so that it now calls `mode.set()` because the former is now deprecated.
+- Patched an issue that was causing a template's visibility to change to 'organizationally_visible' when saving on the template details page.
 
 ### Changed
 

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -385,9 +385,11 @@ module OrgAdmin
       # If nil and the org is not a funder, we default to organisational
       # If present, we parse to retrieve the value
       if args[:visibility].nil?
-        org.funder? ? 'publicly_visible' : 'organisationally_visible'
+        org.funder? ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
+      elsif args.fetch(:visibility, '0') == '1'
+        Template.visibilities[:organisationally_visible]
       else
-        args.fetch(:visibility, '0') == '1' ? 'organisationally_visible' : 'publicly_visible'
+        Template.visibilities[:publicly_visible]
       end
     end
 

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -386,7 +386,7 @@ module OrgAdmin
       # If present, we parse to retrieve the value
       if args[:visibility].nil?
         org.funder? ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
-      elsif args.fetch(:visibility, '0') == '1'
+      elsif ['0', 'organisationally_visible'].include?(args.fetch(:visibility, 'publicly_visible'))
         Template.visibilities[:organisationally_visible]
       else
         Template.visibilities[:publicly_visible]

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -386,7 +386,7 @@ module OrgAdmin
       # If present, we parse to retrieve the value
       if args[:visibility].nil?
         org.funder? ? Template.visibilities[:publicly_visible] : Template.visibilities[:organisationally_visible]
-      elsif ['0', 'organisationally_visible'].include?(args.fetch(:visibility, 'publicly_visible'))
+      elsif %w[0 organisationally_visible].include?(args.fetch(:visibility, 'publicly_visible'))
         Template.visibilities[:organisationally_visible]
       else
         Template.visibilities[:publicly_visible]


### PR DESCRIPTION
Found an issue that is setting the `templates.visibility = 'organizationally_visible'` even when the Org is a funder. The issue was due to using a string to represent the value. I'm not 100% sure why this fails for this and not in other places. 
