### PR TITLE
update to allow the research_outputs.byte_size field to be blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - Added CHANGELOG.md and Danger Github Action [#3257](https://github.com/DMPRoadmap/roadmap/issues/3257)
 - Added validation with custom error message in research_output.rb to ensure a user does not enter a very large value as 'Anticipated file size'. [#3161](https://github.com/DMPRoadmap/roadmap/issues/3161)
 - Added popover for org profile page and added explanation for public plan
+
 ### Fixed
 
+- Fixed an issue that was preventing uses from leaving the research output byte_size field blank
 - Froze mail gem version [#3254](https://github.com/DMPRoadmap/roadmap/issues/3254)
 - Updated the CSV export so that it now includes research outputs
 - Updated sans-serif font used in PDF downloads to Roboto since Google API no longer offers Helvetica

--- a/app/models/research_output.rb
+++ b/app/models/research_output.rb
@@ -65,6 +65,7 @@ class ResearchOutput < ApplicationRecord
                                            message: UNIQUENESS_MESSAGE }
 
   validates_numericality_of :byte_size, greater_than: 0, less_than_or_equal_to: 2**63,
+                                        allow_blank: true,
                                         message: '(Anticipated file size) is too large. Please enter a smaller value.'
   # Ensure presence of the :output_type_description if the user selected 'other'
   validates_presence_of :output_type_description, if: -> { other? }, message: PRESENCE_MESSAGE


### PR DESCRIPTION
- fixes an issue related to #3161 so that you can now leave the `byte_size` field blank and output types that do not have a byte size can be saved (e.g. collection and physical object)