### PR TITLE
Patch issue causing template visibility to get set to organizationally visible

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -11,6 +11,8 @@ jobs:
       DB_ADAPTER: mysql2
       MYSQL_PWD: root
       RAILS_ENV: test
+      # Added to handle issue compiling assets that was causing OpenSSL to throw: ERR_OSSL_EVP_UNSUPPORTED
+      NODE_OPTIONS: --openssl-legacy-provider
 
     steps:
     # Checkout the repo

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     # Checkout the repo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Install Ruby and run bundler
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -25,6 +25,7 @@ jobs:
     # Install Node
     - uses: actions/setup-node@v3
       with:
+        node-version: '19.6.0'
         cache: 'yarn'
 
     # Copy all of the example configs over

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -11,8 +11,6 @@ jobs:
       DB_ADAPTER: mysql2
       MYSQL_PWD: root
       RAILS_ENV: test
-      # Added to handle issue compiling assets that was causing OpenSSL to throw: ERR_OSSL_EVP_UNSUPPORTED
-      NODE_OPTIONS: --openssl-legacy-provider
 
     steps:
     # Checkout the repo
@@ -27,7 +25,7 @@ jobs:
     # Install Node
     - uses: actions/setup-node@v3
       with:
-        node-version: '19.6.0'
+        node-version: '16.6.0'
         cache: 'yarn'
 
     # Copy all of the example configs over

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -23,7 +23,7 @@ jobs:
         bundler-cache: true
 
     # Install Node
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         cache: 'yarn'
 

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     # Checkout the repo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Install Ruby and run bundler
     - uses: ruby/setup-ruby@v1
@@ -39,8 +39,9 @@ jobs:
         bundler-cache: true
 
     # Install Node
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
+        node-version: '16.6.0'
         cache: 'yarn'
 
     # Install the Postgres developer packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added popover for org profile page and added explanation for public plan
 ### Fixed
 
+- Patched issue that was causing template visibility to default to organizationally visible after saving
 - Froze mail gem version [#3254](https://github.com/DMPRoadmap/roadmap/issues/3254)
 - Updated the CSV export so that it now includes research outputs
 - Updated sans-serif font used in PDF downloads to Roboto since Google API no longer offers Helvetica

--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -26,6 +26,12 @@
       <% end %>
     </div>
   </div>
+<% else %>
+  <%
+  visibility = f.object.visibility
+  visibility = f.object.funder? ? 'publicly_visible' : 'organisationally_visible' if visibility.nil?
+  %>
+  <%= f.hidden_field :visibility, value: visibility %>
 <% end %>
 
 <div class="form-group col-xs-8">


### PR DESCRIPTION
When an admin saves changes to their template on the template details page, the visibility os getting automatically set to 'organizationally_visible' this patch carries forward whatever the current value is.