### PR TITLE
fix typo, probably introduced by v1 code

### DIFF
--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -101,7 +101,7 @@ module Api
         max_per_page = Rails.configuration.x.application.api_max_page_size
         page = params.fetch('page', 1).to_i
         per_page = params.fetch('per_page', max_per_page).to_i
-        per_page = max_per_page if @per_page > max_per_page
+        per_page = max_per_page if per_page > max_per_page
         @args = { per_page: per_page, page: page }
         @plans = refine_query(@plans)
         respond_with @plans


### PR DESCRIPTION
fix typo, probably introduced by v1 code

`@per_page` attribute does not exists here, so returns an internal server error containing

```
[6689aad6-1f63-4bfc-aae0-3f331d464dc1] NoMethodError (undefined method `>' for nil:NilClass):
[6689aad6-1f63-4bfc-aae0-3f331d464dc1]   
[6689aad6-1f63-4bfc-aae0-3f331d464dc1] app/controllers/api/v0/plans_controller.rb:104:in `index'
```