### PR TITLE
Minor fix to sort out 500 Internal Server error for API V0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+### Fixed
+- Fixed an issue with API V0 that was causing a 500 Internal Server error
 ## v4.1.0
 
 **Note this upgrade is a migration from Ruby v2.7.6 to v3.0.5.** Note that this could have an impact on any customizations you may have made to your fork of this project. Please see https://www.fastruby.io/blog/ruby/upgrades/upgrade-ruby-from-2.7-to-3.0.html for further information on what to check. In particular, please note the changes to the way [Ruby 3 handles keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

--- a/app/controllers/api/v0/plans_controller.rb
+++ b/app/controllers/api/v0/plans_controller.rb
@@ -101,7 +101,7 @@ module Api
         max_per_page = Rails.configuration.x.application.api_max_page_size
         page = params.fetch('page', 1).to_i
         per_page = params.fetch('per_page', max_per_page).to_i
-        per_page = max_per_page if @per_page > max_per_page
+        per_page = max_per_page if per_page > max_per_page
         @args = { per_page: per_page, page: page }
         @plans = refine_query(@plans)
         respond_with @plans


### PR DESCRIPTION
Changes proposed in this PR:
- replaced `@per_page` with `per_page` (line 104)
