### PR TITLE
Added JS constants to be used in the Research Outputs feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+### Added
+- Added `MORE_INFO` and `LESS_INFO` JS constants (for the Research Outputs feature)
 ## v4.1.0
 
 **Note this upgrade is a migration from Ruby v2.7.6 to v3.0.5.** Note that this could have an impact on any customizations you may have made to your fork of this project. Please see https://www.fastruby.io/blog/ruby/upgrades/upgrade-ruby-from-2.7-to-3.0.html for further information on what to check. In particular, please note the changes to the way [Ruby 3 handles keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -144,7 +144,10 @@
       AUTOCOMPLETE_ARIA_HELPER_EMPTY: _("No results are available for your entry."),
       AUTOCOMPLETE_SEARCHING: _("Searching ..."),
 
-      CURRENT_LOCALE: LocaleService.to_gettext(locale: @current_locale.to_s)
+      CURRENT_LOCALE: LocaleService.to_gettext(locale: @current_locale.to_s),
+
+      MORE_INFO: _("More info"),
+      LESS_INFO: _("Less info")
     }.to_json
     %>
 


### PR DESCRIPTION
Changes proposed in this PR:
- Added two constants `MORE_INFO` and `LESS_INFO` in `application.html.erb` 
