### PR TITLE
Fix Ampersand Issue When Rendering Plan.title

### DIFF
--- a/app/views/contributors/edit.html.erb
+++ b/app/views/contributors/edit.html.erb
@@ -1,9 +1,9 @@
-<% title "#{@plan.title} - edit contributor" %>
+<% title sanitize("#{@plan.title} - edit contributor") %>
 
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -1,9 +1,9 @@
-<% title "#{@plan.title} - contributors" %>
+<% title sanitize("#{@plan.title} - contributors") %>
 
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/contributors/new.html.erb
+++ b/app/views/contributors/new.html.erb
@@ -1,9 +1,9 @@
-<% title "#{@plan.title} - add contributor" %>
+<% title sanitize("#{@plan.title} - add contributor") %>
 
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/org_admin/plans/index.html.erb
+++ b/app/views/org_admin/plans/index.html.erb
@@ -23,7 +23,7 @@
                 <!-- Using the plan owner as the requestor even though it could have been issued by a co-owner -->
                 <!-- TODO: correct this behavior once the notification table is in place -->
                 <tr>
-                  <td><%= link_to notice.name, plan_path(notice) %></td>
+                  <td><%= link_to sanitize(notice.name), plan_path(notice) %></td>
                   <td><%= notice.owner&.name(false) %></td>
                   <td><%= _('Feedback requested') %></td>
                   <td><%= link_to _('Complete'), feedback_complete_org_admin_plan_path(notice), 'data-toggle': 'tooltip', title: _('Notify the plan owner that I have finished providing feedback') %></td>

--- a/app/views/paginable/plans/_index.html.erb
+++ b/app/views/paginable/plans/_index.html.erb
@@ -15,9 +15,9 @@
         <tr>
           <td>
             <% if plan.readable_by?(current_user.id) %>
-              <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
+              <%= link_to sanitize("#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}"), plan_path(plan) %>
             <% else %>
-              <%= plan.title.truncate(60) %>
+              <%= sanitize plan.title.truncate(60) %>
             <% end %>
           </td>
           <td><%= plan.template.title %></td>

--- a/app/views/paginable/plans/_org_admin.html.erb
+++ b/app/views/paginable/plans/_org_admin.html.erb
@@ -29,9 +29,9 @@
         <tr>
           <td>
             <% if plan.readable_by?(current_user.id) %>
-              <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}", plan_path(plan) %>
+              <%= link_to sanitize("#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}"), plan_path(plan) %>
             <% else %>
-              <%= plan.title.truncate(60) %>
+              <%= sanitize plan.title.truncate(60) %>
             <% end %>
           </td>
           <td><%= plan.template.title %></td>

--- a/app/views/paginable/plans/_privately_visible.html.erb
+++ b/app/views/paginable/plans/_privately_visible.html.erb
@@ -19,7 +19,7 @@
         <% my_plan_roles = plan.roles.select(&:active).select { |r| r.user_id == current_user.id } %>
         <tr id="<%= dom_id(plan) %>">
           <td>
-            <%= link_to "#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}",
+            <%= link_to sanitize("#{plan.title.length > 60 ? "#{plan.title[0..59]} ..." : plan.title}"),
                 plan_path(plan) %>
           </td>
           <td><%= plan.template.title %></td>

--- a/app/views/paginable/plans/_publicly_visible.html.erb
+++ b/app/views/paginable/plans/_publicly_visible.html.erb
@@ -12,7 +12,7 @@
     <tbody>
       <% scope.each do |plan| %>
         <tr class="table-data">
-          <td><%= plan.title %></td>
+          <td><%= sanitize plan.title %></td>
           <td><%= plan.template.title %></td>
           <td><%= (plan.owner.nil? || plan.owner.org.nil? ? _('Not Applicable') : plan.owner.org.name) %></td>
           <td><%= (plan.owner.nil? ? _('Unknown') : plan.owner.name(false)) %></td>

--- a/app/views/phases/edit.html.erb
+++ b/app/views/phases/edit.html.erb
@@ -1,7 +1,7 @@
-<% title "#{plan.title} - Write plan" %>
+<% title sanitize("#{plan.title} - Write plan") %>
 <div class="row">
   <div class="col-md-12">
-    <h1><%= plan.title %></h1>
+    <h1><%= sanitize plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -17,7 +17,8 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
     <em class="sr-only"><%= project_title_tooltip %></em>
     <%= form.text_field(:title, class: "form-control", "aria-required": true,
                                 'data-toggle': 'tooltip', spellcheck: true,
-                                title: project_title_tooltip) %>
+                                title: project_title_tooltip,
+                                value: sanitize(plan.title)) %>
   </div>
   <div class="col-md-8">
     <div class="checkbox">

--- a/app/views/plans/_show_details.html.erb
+++ b/app/views/plans/_show_details.html.erb
@@ -2,7 +2,7 @@
 
 <dl class="dl-horizontal">
   <dt><%= _('Project Title') %></dt>
-  <dd><%= plan.title %></dd>
+  <dd><%= sanitize plan.title %></dd>
   <dt><%= _('Project Abstract') %></dt>
   <dd><%= sanitize plan.description %></dd>
   <dt><%= _('Start and End Dates') %></dt>

--- a/app/views/plans/download.html.erb
+++ b/app/views/plans/download.html.erb
@@ -1,8 +1,8 @@
-<% title "#{@plan.title} - Download" %>
+<% title sanitize("#{@plan.title} - Download") %>
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/plans/overview.html.erb
+++ b/app/views/plans/overview.html.erb
@@ -1,9 +1,9 @@
 <%# locals: { plan } %>
 
-<% title "#{plan.title}" %>
+<% title sanitize("#{plan.title}") %>
 <div class="row">
   <div class="col-md-12">
-    <h1><%= plan.title %></h1>
+    <h1><%= sanitize plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/plans/request_feedback.html.erb
+++ b/app/views/plans/request_feedback.html.erb
@@ -1,8 +1,8 @@
-<% title _("#{@plan.title} - Request feedback") %>
+<% title sanitize(_("#{@plan.title} - Request feedback")) %>
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/plans/share.html.erb
+++ b/app/views/plans/share.html.erb
@@ -1,8 +1,8 @@
-<% title "#{@plan.title} - Share" %>
+<% title sanitize("#{@plan.title} - Share") %>
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,8 +1,8 @@
-<% title "#{@plan.title}" %>
+<% title sanitize("#{@plan.title}") %>
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/research_outputs/edit.html.erb
+++ b/app/views/research_outputs/edit.html.erb
@@ -1,9 +1,9 @@
-<% title "#{@plan.title} - edit research output" %>
+<% title sanitize("#{@plan.title} - edit research output") %>
 
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/research_outputs/index.html.erb
+++ b/app/views/research_outputs/index.html.erb
@@ -1,9 +1,9 @@
-<% title "#{@plan.title} - research outputs" %>
+<% title sanitize("#{@plan.title} - research outputs") %>
 
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/research_outputs/new.html.erb
+++ b/app/views/research_outputs/new.html.erb
@@ -1,4 +1,4 @@
-<% title sanitize("#{@plan.title} - add contributor") %>
+<% title sanitize("#{@plan.title} - add research output") %>
 
 <div class="row">
   <div class="col-md-12">

--- a/app/views/research_outputs/new.html.erb
+++ b/app/views/research_outputs/new.html.erb
@@ -1,9 +1,9 @@
-<% title "#{@plan.title} - add contributor" %>
+<% title sanitize("#{@plan.title} - add contributor") %>
 
 <div class="row">
   <div class="col-md-12">
     <!-- render the project title -->
-    <h1><%= @plan.title %></h1>
+    <h1><%= sanitize @plan.title %></h1>
   </div>
 </div>
 

--- a/app/views/shared/export/_plan.erb
+++ b/app/views/shared/export/_plan.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-    <title><%= @plan.title %></title>
+    <title><%= sanitize @plan.title %></title>
 
     <%= render partial: 'shared/export/plan_styling',
                locals: {
@@ -21,7 +21,7 @@
       <% if @hash[:all_phases] || (@selected_phase.present? && phase[:title] == @selected_phase.title) %>
         <%# Page break before each phase %>
         <div style="page-break-before:always;"></div>
-        <h1><%= download_plan_page_title(@plan, phase, @hash) %></h1>
+        <h1><%= sanitize download_plan_page_title(@plan, phase, @hash) %></h1>
         <hr />
         <% phase[:sections].each do |section| %>
           <% if display_section?(@hash[:customization], section, @show_custom_sections) && num_section_questions(@plan, section, phase) > 0 %>

--- a/app/views/shared/export/_plan_txt.erb
+++ b/app/views/shared/export/_plan_txt.erb
@@ -1,4 +1,4 @@
-<%= "#{@plan.title}" %>
+<%= "#{@plan.title}".gsub(/&amp;/,'&') %>
 <%= "----------------------------------------------------------\n" %>
 <% if @show_coversheet %>
 <%= Array(@hash[:attribution]).many? ? _("Creators: ") + Array(@hash[:attribution]).join(", ")  : _('Creator:') + @hash[:attribution] %>
@@ -28,7 +28,7 @@
   <% end %>
   <% if @plan.description.present? %>
 <%= _("Project abstract: ") %>
-<%= "\t" + strip_tags(@plan.description) + "\n" %>
+<%= "\t" + strip_tags(@plan.description).gsub(/&amp;/,'&') + "\n" %>
   <% end %>
 <%= _("Last modified: ") + l(@plan.updated_at.to_date, formats: :short) %>
 <%= _("Copyright information:") %>

--- a/app/views/user_mailer/plan_access_removed.html.erb
+++ b/app/views/user_mailer/plan_access_removed.html.erb
@@ -2,7 +2,7 @@
   <%= _('Hello ') %><%= @user.email %>,
 </p>
 <p>
-  <%= _('Your access to ') %>"<%= @plan.title %>"<%= _(' has been removed by ') %><%= "#{@current_user.name(false)}"%>.
+  <%= _('Your access to ') %>"<%= sanitize @plan.title %>"<%= _(' has been removed by ') %><%= "#{@current_user.name(false)}"%>.
 </p>
 
 <%= render partial: 'email_signature' %>


### PR DESCRIPTION
Fixes https://github.com/DMPRoadmap/roadmap/issues/3348
- https://github.com/DMPRoadmap/roadmap/issues/3348

Changes proposed in this PR:
- Use `sanitize()` on `Plan.title` to enable proper rendering of ampersands
- Use `.gsub(/&amp;/,'&')` on `Plan.title` to enable proper rendering of ampersands in downloaded .txt files of plans
- Change `'- add contributor'` to `'- add research output'` for appended browser tab title in `app/views/research_outputs/new.html.erb`
