### PR TITLE
Prevent Duplicate Options in 'Select Guidance'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,14 @@ We sometimes use the button native Dom element to programmatically click, as the
 - Fixed rubocop errors after Bootstrap upgrade 
 - Fixed RSpec tests after Bootstrap upgrade  
 - Fix "undefined" Tooltip Messages [#3364](https://github.com/DMPRoadmap/roadmap/pull/3364)
+- Fixed rubocop errors after V4.1.1 release
+- Fixed MySQL and PostgreSQL GitHub Actions [PR #3376](https://github.com/DMPRoadmap/roadmap/pull/3376)
+  - Removed duplicate `node-version:` statements from the `mysql.yml` and `postgres.yml` workflows
+  - Replaced `webdrivers` gem with `selenium-webdriver` gem
+  - Disabled `rack-attack` gem from throttling `/users/sign_in` path in Rails test environment
+  - Addressed `Faker` deprecation warnings
+  - Made some small changes to fix some existing tests
+- Prevent Duplicate Options in 'Select Guidance' [PR #3365](https://github.com/DMPRoadmap/roadmap/pull/3365)
 
 ## V4.1.1
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -193,7 +193,9 @@ class PlansController < ApplicationController
     @default_orgs = Org.default_orgs
     @all_ggs_grouped_by_org.each do |org, ggs|
       # @default_orgs and already selected guidance groups are important.
-      @important_ggs << [org, ggs] if (@default_orgs.include?(org) || !(ggs & @selected_guidance_groups).empty?) && !@important_ggs.include?([org, ggs])
+      if (@default_orgs.include?(org) || (ggs & @selected_guidance_groups).any?) && !@important_ggs.include?([org, ggs])
+        @important_ggs << [org, ggs]
+      end
     end
 
     # Sort the rest by org name for the accordion

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -192,10 +192,8 @@ class PlansController < ApplicationController
     end
     @default_orgs = Org.default_orgs
     @all_ggs_grouped_by_org.each do |org, ggs|
-      @important_ggs << [org, ggs] if @default_orgs.include?(org)
-
-      # If this is one of the already selected guidance groups its important!
-      @important_ggs << [org, ggs] if !(ggs & @selected_guidance_groups).empty? && !@important_ggs.include?([org, ggs])
+      # @default_orgs and already selected guidance groups are important.
+      @important_ggs << [org, ggs] if (@default_orgs.include?(org) || !(ggs & @selected_guidance_groups).empty?) && !@important_ggs.include?([org, ggs])
     end
 
     # Sort the rest by org name for the accordion


### PR DESCRIPTION
Fixes #3343
- #3343

Changes proposed in this PR:
- This PR addresses the bug where duplicate guidance options were displayed for some plans.
- Some minor refactoring is done in this PR as well.

**Reasoning Behind Changes**
- Prior to this PR, if `current_user.org` was also a `@default_org`, then `@important_ggs` would contain duplicate `[org, ggs]`.
  - commit 4b27071618a96982c3befc7696f845e43b2539c9 fixes this issue.
  - commit c6f73c9b3bb6cf5317c211397cbe6f8f570fae0b addresses a rubocop offence due to the line being too long. Also,  `!(ggs & @selected_guidance_groups).empty?` is changed to `(ggs & @selected_guidance_groups).any?` (the two statements should evaluate identically in this context).