### PR TITLE
Fix MySQL and PostgreSQL GitHub Actions

### DIFF
--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -27,7 +27,6 @@ jobs:
       with:
         node-version: '16.6.0'
         cache: 'yarn'
-        node-version: 16
 
     # Copy all of the example configs over
     - name: 'Setup the application'

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -46,7 +46,6 @@ jobs:
       with:
         node-version: '16.6.0'
         cache: 'yarn'
-        node-version: 16
 
     # Install the Postgres developer packages
     - name: 'Install Postgresql Packages'

--- a/Gemfile
+++ b/Gemfile
@@ -248,7 +248,7 @@ group :test do
   gem 'capybara'
 
   # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
+  gem 'selenium-webdriver'
 
   # RSpec::CollectionMatchers lets you express expected outcomes on
   # collections of an object in an example.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.16.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -517,10 +517,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -542,6 +538,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -605,6 +602,7 @@ DEPENDENCIES
   rubocop
   rubocop-i18n
   rubocop-performance
+  selenium-webdriver
   shoulda
   spring
   spring-commands-rspec
@@ -613,7 +611,6 @@ DEPENDENCIES
   translation
   turbo-rails
   web-console
-  webdrivers
   webmock
   wicked_pdf
   wkhtmltopdf-binary

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -21,5 +21,6 @@ end
 
 # Throttle attempts to a particular path. 4 POSTs to /users/sign_in every 30 seconds
 Rack::Attack.throttle "logins/ip", limit: 4, period: 30.seconds do |req|
-  req.post? && req.path == "/users/sign_in" && req.ip
+  # Don't apply sign-in rate-limiting to test environment 
+  req.post? && req.path == "/users/sign_in" && req.ip unless Rails.env.test?
 end

--- a/spec/factories/orgs.rb
+++ b/spec/factories/orgs.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
     region { Region.first || create(:region) }
     language { Language.default }
     is_other { false }
-    contact_email { Faker::Internet.safe_email }
+    contact_email { Faker::Internet.email }
     contact_name { Faker::Name.name }
     managed { true }
     trait :institution do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
     language     { Language.default }
     firstname    { Faker::Name.unique.first_name }
     surname      { Faker::Name.unique.last_name }
-    email        { Faker::Internet.unique.safe_email }
+    email        { Faker::Internet.unique.email }
     password     { 'password' }
     accept_terms { true }
 

--- a/spec/features/annotations/annotations_editing_spec.rb
+++ b/spec/features/annotations/annotations_editing_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Annotations::Editing', type: :feature do
       expect { click_button 'Save' }.not_to change { Annotation.count }
     end
     expect(annotation.text).to eql('Foo bar')
-    expect(Annotation.order('created_at').last.text).to eql('Noo bar')
+    expect(Annotation.order('created_at').last.text).to eql('<p>Noo bar</p>')
     expect(page).not_to have_errors
   end
 

--- a/spec/features/templates/templates_editings_spec.rb
+++ b/spec/features/templates/templates_editings_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Templates::Editing', type: :feature do
       click_button 'Save'
     end
     # Make sure annotation has been updated
-    expect(Question.find(template.question_ids.first).annotations.first.text).to eql('Foo bar')
+    expect(Question.find(template.question_ids.first).annotations.first.text).to eql('<p>Foo bar</p>')
     # Make sure blank records are not created for empty annotation form
     expect(Question.find(template.question_ids.first).annotations.count).to eql(1)
     expect(page).not_to have_errors

--- a/spec/features/templates/templates_upgrade_customisations_spec.rb
+++ b/spec/features/templates/templates_upgrade_customisations_spec.rb
@@ -76,8 +76,7 @@ RSpec.feature 'Templates::UpgradeCustomisations', type: :feature do
       end
       expect(page).to have_css('#new_question_new_question')
       within('#new_question_new_question') do
-        expect(find('#new_question_question_text')).to be_present
-        fill_in :new_question_question_text, with: 'Text for this specific question'
+        tinymce_fill_in :new_question_question_text, with: 'Text for this specific question'
         expect { click_button('Save') }.to change { Question.count }.by(1)
       end
     end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -592,7 +592,7 @@ describe Plan do
 
     context 'when org contact_email present' do
       before do
-        org.update!(contact_email: Faker::Internet.safe_email)
+        org.update!(contact_email: Faker::Internet.email)
       end
 
       it 'emails the admins' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,11 +39,9 @@ Dir[Rails.root.join('spec/mixins/*.rb')].each { |f| require f }
 # No need to run this during CI because we build the DB from the schema
 # ActiveRecord::Migration.maintain_test_schema!
 
-# Block all external HTTP requests except to the Google APIs URL so that WebDrivers can fetch
-# the latest Chromedrivers.
+# Block all external HTTP requests
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: %w[chromedriver.storage.googleapis.com]
 )
 
 # Configure RSpec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,17 +111,6 @@ RSpec.configure do |config|
 
   # Enable Capybara webmocks if we are testing a feature
   config.before(:each) do |example|
-    if example.metadata[:type] == :feature
-      # Capybara::Webmock.start
-
-      # Allow Capybara to make localhost requests and also contact the
-      # google api chromedriver store
-      # WebMock.disable_net_connect!(
-      #   allow_localhost: true,
-      #   allow: %w[chromedriver.storage.googleapis.com]
-      # )
-    end
-
     # Ensure that there is always a default Language
     create(:language, abbreviation: 'en', default_language: true) unless Language.default.present?
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require 'webdrivers/chromedriver'
-
-# Cache for one hour
-Webdrivers.cache_time = 3600
-
 # Use Puma as the webserver for feature tests
 Capybara.server = :puma, { Silent: true }
 


### PR DESCRIPTION
Fixes #3347

Changes proposed in this PR:
- Replace webdrivers gem with selenium-webdriver gem (https://github.com/titusfortner/webdrivers states "If you can update to the latest version of Selenium (4.11+), please do so and stop requiring this gem.")
- Disable `rack-attack` from throttling "/users/sign_in" path on Rails test environment
- Address Faker deprecation warning `NOTE: Faker::Internet.safe_email is deprecated; use email instead. It will be removed on or after 2023-10.` (More here: https://github.com/faker-ruby/faker/pull/2733)
- Small changes to enable existing tests to pass (here: https://github.com/DMPRoadmap/roadmap/pull/3375/commits/a5710adda20baa288f5a4451526d9f49de8c37ef)
- Fix `mysql.yml` and `postgres.yml` workflows by removing duplicate `node-version:` statements