### PR TITLE
Prevent '%{org_title} Plans' Section From Displaying Plans Created by Users From Other Organisations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -188,7 +188,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       # Redirect use to the path and display the error message
-      format.html { redirect_to url_or_path, alert: msg }
+      format.any(:html, :pdf) { redirect_to url_or_path, alert: msg }
       # Render the JSON error message (using API V1)
       format.json do
         @payload = { errors: [msg] }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,8 +22,6 @@ class ApplicationController < ActionController::Base
   # When we are in production reroute Record Not Found errors to the branded 404 page
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
-  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-
   private
 
   def current_org

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -301,6 +301,10 @@ class Org < ApplicationRecord
   end
   # rubocop:enable Metrics/AbcSize
 
+  def owned_plans
+    Plan.where(id: owned_plan_ids)
+  end
+
   def grant_api!(token_permission_type)
     token_permission_types << token_permission_type unless
       token_permission_types.include? token_permission_type
@@ -411,6 +415,13 @@ class Org < ApplicationRecord
     Rails.cache.fetch("org[#{id}].plans", expires_in: 2.seconds) do
       Role.administrator.where(user_id: users.pluck(:id), active: true)
           .pluck(:plan_id).uniq
+    end
+  end
+
+  def owned_plan_ids
+    Rails.cache.fetch("org[#{id}].owned_plans", expires_in: 2.seconds) do
+      Role.creator.where(user_id: users.pluck(:id), active: true)
+          .pluck(:plan_id)
     end
   end
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -170,15 +170,16 @@ class Plan < ApplicationRecord
   # Retrieves any plan organisationally or publicly visible for a given org id
   scope :organisationally_or_publicly_visible, lambda { |user|
     user.org.owned_plans
-    .includes(:template, roles: :user)
-      .where(complete: true, visibility: [
-               visibilities[:organisationally_visible],
-               visibilities[:publicly_visible]
-             ])
-      .where(
-        'NOT EXISTS (SELECT 1 FROM roles WHERE plan_id = plans.id AND user_id = ?)',
-        user.id
-      ).distinct
+        .includes(:template, roles: :user)
+        .where(complete: true,
+               visibility: [
+                 visibilities[:organisationally_visible],
+                 visibilities[:publicly_visible]
+               ])
+        .where(
+          'NOT EXISTS (SELECT 1 FROM roles WHERE plan_id = plans.id AND user_id = ?)',
+          user.id
+        ).distinct
   }
 
   scope :search, lambda { |term|

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -169,7 +169,7 @@ class Plan < ApplicationRecord
 
   # Retrieves any plan organisationally or publicly visible for a given org id
   scope :organisationally_or_publicly_visible, lambda { |user|
-    plan_ids = user.org.org_admin_plans.where(complete: true).pluck(:id).uniq
+    plan_ids = user.org.owned_plans.where(complete: true).pluck(:id).uniq
     includes(:template, roles: :user)
       .where(id: plan_ids, visibility: [
                visibilities[:organisationally_visible],

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -169,16 +169,16 @@ class Plan < ApplicationRecord
 
   # Retrieves any plan organisationally or publicly visible for a given org id
   scope :organisationally_or_publicly_visible, lambda { |user|
-    plan_ids = user.org.owned_plans.where(complete: true).pluck(:id).uniq
-    includes(:template, roles: :user)
-      .where(id: plan_ids, visibility: [
+    user.org.owned_plans
+    .includes(:template, roles: :user)
+      .where(complete: true, visibility: [
                visibilities[:organisationally_visible],
                visibilities[:publicly_visible]
              ])
       .where(
         'NOT EXISTS (SELECT 1 FROM roles WHERE plan_id = plans.id AND user_id = ?)',
         user.id
-      )
+      ).distinct
   }
 
   scope :search, lambda { |term|


### PR DESCRIPTION
Fixes #3345 
Fixes #3414

Changes proposed in this PR:
- `app/controllers/application_controller.rb`
  - Add pdf handling in `render_respond_to_format_with_error_message`
    - `render_respond_to_format_with_error_message` is called both when rescuing from Pundit::NotAuthorizedError and ActiveRecord::RecordNotFound. The method works properly with .html format, but prior to this change, ActionController::UnknownFormat was thrown for .pdf format.

- Edit `scope :organisationally_or_publicly_visible`
  - Within this scope, replace `Org.org_admin_plans` with newly created `Org.owned_plans`.
    - `Org.org_admin_plans` would return any plan where `plan.org_id = Org.id`. In addition, it would return any plan where a user with user.org_id = Org.id had Administrator access on the plan.
    - `Org.owned_plans` only returns plans where the Creator access for the plan belongs to a user with user.org_id = Org.id


