### PR TITLE
Override `Rails.configuration.x.ror.active` During RSpec Tests

### DIFF
--- a/spec/services/external_apis/ror_service_spec.rb
+++ b/spec/services/external_apis/ror_service_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ExternalApis::RorService do
+  Rails.configuration.x.ror.active = true # Override actual config value for duration of tests
   describe '#ping' do
     before(:each) do
       @headers = described_class.headers


### PR DESCRIPTION
Changes proposed in this PR:

- This PR overrides the value of `Rails.configuration.x.ror.active` to true for the duration of the `spec/services/external_apis/ror_service_spec.rb` tests.

- Prior to this commit, when setting `Rails.configuration.x.ror.active = false` in `config/initializers/external_apis/ror.rb`, the following errors were encountered after executing `bundle exec rspec spec/services/external_apis/ror_service_spec.rb`:

```ruby
Finished in 1.03 seconds (files took 1.2 seconds to load)
37 examples, 5 failures

Failed examples:

rspec ./spec/services/external_apis/ror_service_spec.rb:45 # ExternalApis::RorService#search ROR did not return a 200 status logs the response as an error
rspec ./spec/services/external_apis/ror_service_spec.rb:117 # ExternalApis::RorService#search Successful response from API includes the country in the name (if no website is available)
rspec ./spec/services/external_apis/ror_service_spec.rb:105 # ExternalApis::RorService#search Successful response from API returns both results
rspec ./spec/services/external_apis/ror_service_spec.rb:109 # ExternalApis::RorService#search Successful response from API includes the website in the name (if available)
rspec ./spec/services/external_apis/ror_service_spec.rb:16 # ExternalApis::RorService#ping returns false if an HTTP 200 is NOT returned
```
