### PR TITLE
Add pdf handling in render_respond_to_format_with_error_message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -188,7 +188,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       # Redirect use to the path and display the error message
-      format.html { redirect_to url_or_path, alert: msg }
+      format.any(:html, :pdf) { redirect_to url_or_path, alert: msg }
       # Render the JSON error message (using API V1)
       format.json do
         @payload = { errors: [msg] }


### PR DESCRIPTION
Fixes #3414
- #3414

Changes proposed in this PR:
- `render_respond_to_format_with_error_message` is called both when rescuing from Pundit::NotAuthorizedError and ActiveRecord::RecordNotFound. The method works properly with .html format, but prior to this change, ActionController::UnknownFormat was thrown for .pdf format.