### PR TITLE
Fix handling of template.visibility

### DIFF
--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -20,7 +20,11 @@
                          placement: 'right' }%>
     <div class="form-check">
       <%= f.label(:visibility) do %>
-        <%= f.check_box(:visibility, checked: f.object.visibility == 'organisationally_visible') %>
+        <%= f.check_box(:visibility,
+                        {},
+                        f.object.class.visibilities[:organisationally_visible],
+                        f.object.class.visibilities[:publicly_visible])
+                        %>
 
         <%= _('for internal %{org_name} use only') % { org_name: f.object.org.name } %>
       <% end %>

--- a/app/views/org_admin/templates/_show.html.erb
+++ b/app/views/org_admin/templates/_show.html.erb
@@ -31,7 +31,7 @@
     <!-- If the Org is a funder and another org type then allow then to set the visibility -->
     <dt><%= _('Visibility') %></dt>
     <dd>
-      <% if template.visibility == 'organisationally_visible' %>
+      <% if template.organisationally_visible? %>
         <%= _('for internal %{org_name} use only') % {org_name: template.org.name} %>
       <% else %>
         <%=  _('available to the public') + (template.published? ? '' : ' (once published)') %>


### PR DESCRIPTION
Fixes #3419

Changes proposed in this PR:
- app/views/org_admin/templates/_show.html.erb
  - Prior to this commit, `if template.visibility == 'organisationally_visible'`, would always evaluate to false. This is because `template.visibility` returns an integer value.

- app/views/org_admin/templates/_form.html.erb
  - `f.object.visibility == 'organisationally_visible'` always evaluates to false. Thus, prior to this commit, the checkbox would always initially render as unchecked.
  - Also, prior to this commit, the default checked/unchecked values were used (i.e. "1" would be returned when checked, and "0" would be returned when unchecked), and the box is meant to be checked when selecting 'organisationally_visible' ('for internal %{org_name} use only'), which makes the default checked/unchecked values opposite to the mapping of our enums (i.e. `{"organisationally_visible"=>0, "publicly_visible"=>1}`).
