### PR TITLE
Address Bullet Warnings

### DIFF
--- a/app/controllers/guidances_controller.rb
+++ b/app/controllers/guidances_controller.rb
@@ -17,8 +17,7 @@ class GuidancesController < ApplicationController
     @guidances = Guidance.includes(:guidance_group, :themes)
                          .by_org(current_user.org).page(1)
     ensure_default_group(current_user.org)
-    @guidance_groups = GuidanceGroup.includes(:org)
-                                    .by_org(current_user.org).page(1)
+    @guidance_groups = GuidanceGroup.by_org(current_user.org).page(1)
   end
 
   # GET /org/admin/guidance/:id/admin_new

--- a/app/controllers/org_admin/phases_controller.rb
+++ b/app/controllers/org_admin/phases_controller.rb
@@ -57,7 +57,7 @@ module OrgAdmin
                  template: phase.template,
                  phase: phase,
                  prefix_section: phase.prefix_section,
-                 sections: phase.sections.order(:number)
+                 sections: phase.sections.includes(:template).order(:number)
                                          .select(:id, :title, :modifiable, :phase_id),
                  suffix_sections: phase.suffix_sections.order(:number),
                  current_section: Section.find_by(id: params[:section], phase_id: phase.id)

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -17,7 +17,7 @@ module OrgAdmin
 
       @super_admin = current_user.can_super_admin?
       @clicked_through = params[:click_through].present?
-      @plans = @super_admin ? Plan.all.page(1) : current_user.org.org_admin_plans.page(1)
+      @plans = @super_admin ? Plan.all.page(1).includes(:template, roles: { user: :org }) : current_user.org.org_admin_plans.page(1).includes(roles: { user: :org })
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/app/controllers/org_admin/plans_controller.rb
+++ b/app/controllers/org_admin/plans_controller.rb
@@ -17,7 +17,11 @@ module OrgAdmin
 
       @super_admin = current_user.can_super_admin?
       @clicked_through = params[:click_through].present?
-      @plans = @super_admin ? Plan.all.page(1).includes(:template, roles: { user: :org }) : current_user.org.org_admin_plans.page(1).includes(roles: { user: :org })
+      @plans = if @super_admin
+                 Plan.all.page(1).includes(:template, roles: { user: :org })
+               else
+                 current_user.org.org_admin_plans.page(1).includes(roles: { user: :org })
+               end
     end
     # rubocop:enable Metrics/AbcSize
 

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -2,7 +2,6 @@
 
 module OrgAdmin
   # Controller that handles templates
-  # rubocop:disable Metrics/ClassLength
   class TemplatesController < ApplicationController
     include Paginable
     include Versionable
@@ -33,7 +32,7 @@ module OrgAdmin
     # A version of index that displays only templates that belong to the user's org
     # GET /org_admin/templates/organisational
     # -----------------------------------------------------
-    # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize
     def organisational
       authorize Template
       templates = Template.latest_version_per_org(current_user.org.id).includes(:org)
@@ -54,13 +53,12 @@ module OrgAdmin
       @unpublished_count = @all_count - @published_count
       render :index
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize
 
     # A version of index that displays only templates that are customizable
     # GET /org_admin/templates/customisable
     # -----------------------------------------------------
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize
     def customisable
       authorize Template
       funder_templates = Template.latest_customizable.includes(:org)
@@ -87,9 +85,8 @@ module OrgAdmin
 
       render :index
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
+    # rubocop:enable Metrics/AbcSize
     # GET /org_admin/templates/[:id]
     def show
       template = Template.find(params[:id])
@@ -405,5 +402,4 @@ module OrgAdmin
       end
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -16,7 +16,8 @@ module OrgAdmin
     def index
       authorize Template
       templates = Template.latest_version.where(customization_of: nil)
-      published = templates.count { |t| t.published? || t.draft? }
+      published_family_ids = Template.published.select(:family_id)
+      published = templates.count { |t| t.published? || published_family_ids.include?(t.family_id) }
 
       @orgs              = Org.includes(identifiers: :identifier_scheme).managed
       @title             = _('All Templates')
@@ -41,7 +42,8 @@ module OrgAdmin
       authorize Template
       templates = Template.latest_version_per_org(current_user.org.id)
                           .where(customization_of: nil, org_id: current_user.org.id)
-      published = templates.count { |t| t.published? || t.draft? }
+      published_family_ids = Template.published.select(:family_id)
+      published = templates.count { |t| t.published? || published_family_ids.include?(t.family_id) }
 
       @orgs  = current_user.can_super_admin? ? Org.includes(identifiers: :identifier_scheme).all : nil
       @title = if current_user.can_super_admin?
@@ -79,7 +81,8 @@ module OrgAdmin
       customizations = customizations.select do |t|
         funder_template_families.include?(t.customization_of)
       end
-      published = customizations.count { |t| t.published? || t.draft? }
+      published_family_ids = Template.published.select(:family_id)
+      published = customizations.count { |t| t.published? || published_family_ids.include?(t.family_id) }
 
       @orgs = current_user.can_super_admin? ? Org.includes(identifiers: :identifier_scheme).all : []
       @title = _('Customizable Templates')

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -18,7 +18,7 @@ module OrgAdmin
       templates = Template.latest_version.where(customization_of: nil)
       published = templates.count { |t| t.published? || t.draft? }
 
-      @orgs              = Org.includes(:identifiers).managed
+      @orgs              = Org.includes(identifiers: :identifier_scheme).managed
       @title             = _('All Templates')
       @templates         = templates.includes(:org).page(1)
       @query_params      = { sort_field: 'templates.title', sort_direction: 'asc' }
@@ -43,7 +43,7 @@ module OrgAdmin
                           .where(customization_of: nil, org_id: current_user.org.id)
       published = templates.count { |t| t.published? || t.draft? }
 
-      @orgs  = current_user.can_super_admin? ? Org.includes(:identifiers).all : nil
+      @orgs  = current_user.can_super_admin? ? Org.includes(identifiers: :identifier_scheme).all : nil
       @title = if current_user.can_super_admin?
                  format(_('%{org_name} Templates'), org_name: current_user.org.name)
                else
@@ -81,7 +81,7 @@ module OrgAdmin
       end
       published = customizations.count { |t| t.published? || t.draft? }
 
-      @orgs = current_user.can_super_admin? ? Org.includes(:identifiers).all : []
+      @orgs = current_user.can_super_admin? ? Org.includes(identifiers: :identifier_scheme).all : []
       @title = _('Customizable Templates')
       @templates = funder_templates
       @customizations = customizations

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -25,11 +25,7 @@ module OrgAdmin
       @query_params      = { sort_field: 'templates.title', sort_direction: 'asc' }
       @all_count         = templates.size
       @published_count   = published.present? ? published : 0
-      @unpublished_count = if published.present?
-                             (@all_count - published)
-                           else
-                             @all_count
-                           end
+      @unpublished_count = @all_count - @published_count
       render :index
     end
     # rubocop:enable Metrics/AbcSize
@@ -55,11 +51,7 @@ module OrgAdmin
       @query_params = { sort_field: 'templates.title', sort_direction: 'asc' }
       @all_count = templates.size
       @published_count = published.present? ? published : 0
-      @unpublished_count = if published.present?
-                             @all_count - published
-                           else
-                             @all_count
-                           end
+      @unpublished_count = @all_count - @published_count
       render :index
     end
     # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
@@ -90,11 +82,7 @@ module OrgAdmin
       @query_params = { sort_field: 'templates.title', sort_direction: 'asc' }
       @all_count = funder_templates.size
       @published_count = published.present? ? published : 0
-      @unpublished_count = if published.present?
-                             (customizations_count - published)
-                           else
-                             customizations_count
-                           end
+      @unpublished_count = customizations_count - @published_count
       @not_customized_count = @all_count - customizations_count
 
       render :index

--- a/app/controllers/paginable/guidance_groups_controller.rb
+++ b/app/controllers/paginable/guidance_groups_controller.rb
@@ -10,7 +10,7 @@ module Paginable
       authorize(Guidance)
       paginable_renderise(
         partial: 'index',
-        scope: GuidanceGroup.includes(:org).by_org(current_user.org),
+        scope: GuidanceGroup.by_org(current_user.org),
         query_params: { sort_field: 'guidance_groups.name', sort_direction: :asc },
         format: :json
       )

--- a/app/controllers/paginable/orgs_controller.rb
+++ b/app/controllers/paginable/orgs_controller.rb
@@ -10,7 +10,7 @@ module Paginable
       authorize(Org)
       paginable_renderise(
         partial: 'index',
-        scope: Org.with_template_and_user_counts,
+        scope: Org.with_template_count_and_associations_check,
         query_params: { sort_field: 'orgs.name', sort_direction: :asc },
         format: :json
       )

--- a/app/controllers/public_pages_controller.rb
+++ b/app/controllers/public_pages_controller.rb
@@ -85,7 +85,7 @@ class PublicPagesController < ApplicationController
   # GET /plans_index
   # ------------------------------------------------------------------------------------
   def plan_index
-    @plans = Plan.publicly_visible.includes(:template)
+    @plans = Plan.publicly_visible.includes(:template, roles: { user: :org })
     render 'plan_index', locals: {
       query_params: {
         page: paginable_params.fetch(:page, 1),

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -11,7 +11,7 @@ module SuperAdmin
     def index
       authorize Org
       render 'index', locals: {
-        orgs: Org.with_template_and_user_counts.page(1).includes(:contributors, :plans)
+        orgs: Org.with_template_and_user_counts.page(1)
       }
     end
 

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -11,7 +11,7 @@ module SuperAdmin
     def index
       authorize Org
       render 'index', locals: {
-        orgs: Org.with_template_and_user_counts.page(1)
+        orgs: Org.with_template_count_and_associations_check.page(1)
       }
     end
 

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -11,7 +11,7 @@ module SuperAdmin
     def index
       authorize Org
       render 'index', locals: {
-        orgs: Org.with_template_and_user_counts.page(1)
+        orgs: Org.with_template_and_user_counts.page(1).includes(:contributors, :plans)
       }
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,10 +21,10 @@ class UsersController < ApplicationController
         @filter_admin = false
 
         @users = if current_user.can_super_admin?
-                   User.includes(:department, :org, :perms, :roles, :identifiers).page(1)
+                   User.includes(:department, :org, :perms, :roles, identifiers: :identifier_scheme).page(1)
                  else
                    current_user.org.users
-                               .includes(:department, :org, :perms, :roles, :identifiers)
+                               .includes(:department, :perms, :roles, identifiers: :identifier_scheme)
                                .page(1)
                  end
       end

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -201,9 +201,9 @@ class Org < ApplicationRecord
       .group('orgs.id')
       .select("orgs.*,
               count(distinct templates.family_id) as template_count,
-              EXISTS (SELECT 1 FROM users WHERE users.org_id = orgs.id) AS has_users,
-              EXISTS (SELECT 1 FROM contributors WHERE contributors.org_id = orgs.id) AS has_contributors,
-              EXISTS (SELECT 1 FROM plans WHERE plans.org_id = orgs.id) as has_plans")
+              EXISTS (SELECT 1 FROM users WHERE users.org_id = orgs.id) OR
+              EXISTS (SELECT 1 FROM contributors WHERE contributors.org_id = orgs.id) OR
+              EXISTS (SELECT 1 FROM plans WHERE plans.org_id = orgs.id) as has_associations")
   }
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -198,11 +198,12 @@ class Org < ApplicationRecord
   # Scope used in several controllers
   scope :with_template_and_user_counts, lambda {
     joins('LEFT OUTER JOIN templates ON orgs.id = templates.org_id')
-      .joins('LEFT OUTER JOIN users ON orgs.id = users.org_id')
       .group('orgs.id')
       .select("orgs.*,
               count(distinct templates.family_id) as template_count,
-              count(users.id) as user_count")
+              EXISTS (SELECT 1 FROM users WHERE users.org_id = orgs.id) AS has_users,
+              EXISTS (SELECT 1 FROM contributors WHERE contributors.org_id = orgs.id) AS has_contributors,
+              EXISTS (SELECT 1 FROM plans WHERE plans.org_id = orgs.id) as has_plans")
   }
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -196,8 +196,8 @@ class Org < ApplicationRecord
   }
 
   # Scope used in several controllers
-  scope :with_template_and_user_counts, lambda {
-    joins('LEFT OUTER JOIN templates ON orgs.id = templates.org_id')
+  scope :with_template_count_and_associations_check, lambda {
+    left_outer_joins(:templates)
       .group('orgs.id')
       .select("orgs.*,
               count(distinct templates.family_id) as template_count,

--- a/app/views/org_admin/plans/index.html.erb
+++ b/app/views/org_admin/plans/index.html.erb
@@ -34,7 +34,7 @@
         </div>
       </div>
     <% end %>
-    <% if @plans.length > 0  %>
+    <% if @plans.any? %>
       <% unless @super_admin %>
         <%= link_to sanitize(_('Download plans <em class="sr-only">(new window)</em><span class="new-window-popup-info">%{open_in_new_window_text}</span>') %
                            { open_in_new_window_text: _('Opens in new window') },

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -31,7 +31,7 @@
               </button>
               <ul class="dropdown-menu" aria-labelledby="org-<%= org.id %>-actions">
                 <li class="nav-item"><%= link_to _('Edit'), admin_edit_org_path(org), class:'dropdown-item px-3' %></li>
-                <% unless org.user_count > 0 || org.template_count > 0 || org.contributors.length > 0 || org.plans.length > 0 %>
+                <% unless org.has_users || org.template_count > 0 || org.has_contributors || org.has_plans %>
                   <li class="nav-item"><%= link_to _('Remove'), super_admin_org_path(org), data: {confirm: _("You are about to delete '%{org_name}'. Are you sure?") % { org_name: org.name}}, method: :delete, class:'dropdown-item px-3' %></li>
                 <% end %>
               </ul>

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -31,7 +31,7 @@
               </button>
               <ul class="dropdown-menu" aria-labelledby="org-<%= org.id %>-actions">
                 <li class="nav-item"><%= link_to _('Edit'), admin_edit_org_path(org), class:'dropdown-item px-3' %></li>
-                <% unless org.has_users || org.template_count > 0 || org.has_contributors || org.has_plans %>
+                <% unless org.template_count > 0 || org.has_associations? %>
                   <li class="nav-item"><%= link_to _('Remove'), super_admin_org_path(org), data: {confirm: _("You are about to delete '%{org_name}'. Are you sure?") % { org_name: org.name}}, method: :delete, class:'dropdown-item px-3' %></li>
                 <% end %>
               </ul>

--- a/app/views/paginable/users/_index.html.erb
+++ b/app/views/paginable/users/_index.html.erb
@@ -93,8 +93,7 @@
                     <% end %>
                   </td>
                   <td class="text-center">
-                    <% presenter = IdentifierPresenter.new(identifiable: user) %>
-                    <% presenter.identifiers.each do |identifier| %>
+                    <% user.identifiers.each do |identifier| %>
                       <p><%= identifier.identifier_scheme.name %></p>
                     <% end %>
                   </td>

--- a/app/views/super_admin/api_clients/_form.html.erb
+++ b/app/views/super_admin/api_clients/_form.html.erb
@@ -1,7 +1,7 @@
 <%
 url = @api_client.new_record? ? super_admin_api_clients_path : super_admin_api_client_path(@api_client)
 method = @api_client.new_record? ? :post : :put
-orgs = Org.where(is_other: false)
+orgs = Org.includes(identifiers: :identifier_scheme).where(is_other: false)
 %>
 
 <%= form_for @api_client, url: url, method: method,

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -22,5 +22,6 @@ if defined?(Bullet)
     # config.slack = {
     #   webhook_url: 'http://some.slack.url', channel: '#default', username: 'notifier'
     # }
+    config.add_safelist type: :unused_eager_loading, class_name: 'User', association: :perms_users
   end
 end


### PR DESCRIPTION
Changes proposed in this PR:
- This PR addresses some of the Bullet warnings that are triggered when using the app in development mode.
- Various ActiveRecord `.includes()` args have been added or removed to address these warnings.
- Some calls to `.length` have been changed to `.size` or `.any?` to address these warnings (which are sometimes false-positives).
  - `.length` brings the records into memory.
  - `.size` and `.any?` will only operate on the memory level if the records are already in memory. Otherwise, they will operate on the db level.
- `app/controllers/org_admin/templates_controller.rb` has been re-factored. In particular, the refactoring prevents N+1 queries related to the calls to `Template.published`.
- More details are documented within the individual commits of this PR.
- None of the actual returned results from these queries should be affected by this PR.

The following table compares the `development` branch to `aaron/bullet-fixes` by making requests to the various paths affected by this PR. The benchmarking was performed via ab - Apache HTTP server benchmarking tool alongside a recent (May 2024) db dump from the production environment of DMP Assistant. In both cases, 100 consecutive requests were performed to each path and the recorded result is the mean request time (ms).

Example request:
```
$ ab -n 100 -k -C "_dmp_roadmap_session=COOKIE_VALUE" -l http://127.0.0.1:3000/PATH/TO/PAGE
```


Path | mean request time (ms) before | mean request time (ms) now | % change
-- | -- | -- | --
/org_admin/plans (as org_admin type user) | 504.502 | 440.714 | -12.64%
/org_admin/plans (as super_admin type user) | 165.98 | 130.816 | -21.19%
/org_admin/templates | 328.156 | 162.383 | -50.52%
/org_admin/templates/organisational | 1022.935 | 969.703 | -5.20%
/org_admin/templates/customisable | 815.51 | 725.64 | -11.02%
/org_admin/templates/3925/phases/3994/edit | 83.591 | 85.359 | +2.12%
/org/admin/guidance/8/admin_index | 56.504 | 53.465 | -5.38%
/org/admin/users/admin_index | 144.602 | 139.837 | -3.30%
/paginable/guidance_groups/index/ALL | 14.816 | 12.931 | -12.72%
/public_plans | 135.203 | 99.571 | -26.35%
/super_admin/api_clients/new | 1625.653 | 653.083 | -59.83%
/super_admin/orgs | 1101.719 | 62.133 | -94.36%
/paginable/orgs/index/ALL | 3316.224 | 331.831 | -90%