### PR TITLE
Fix TinyMCE-Related Console Warnings

### DIFF
--- a/app/javascript/src/superAdmin/notifications/edit.js
+++ b/app/javascript/src/superAdmin/notifications/edit.js
@@ -5,7 +5,7 @@ import { paginableSelector } from '../../utils/paginable';
 import * as notifier from '../../utils/notificationHelper';
 
 $(() => {
-  Tinymce.init({ selector: '#notification_body', forced_root_block: '' });
+  Tinymce.init({ selector: '#notification_body' });
 
   $(paginableSelector).on('click, change', '.enable_notification input[type="checkbox"]', (e) => {
     const form = $(e.target).closest('form');

--- a/app/javascript/src/utils/conditionalFields.js
+++ b/app/javascript/src/utils/conditionalFields.js
@@ -15,14 +15,6 @@ export default function toggleConditionalFields(context, showThem) {
   if (container.length > 0) {
     if (showThem === true) {
       container.find('.toggleable-field').show();
-
-      // Resize any TinyMCE editors
-      container.find('.toggleable-field').find('.tinymce').each((_idx, el) => {
-        const tinymceEditor = Tinymce.findEditorById($(el).attr('id'));
-        if (tinymceEditor) {
-          $(tinymceEditor.iframeElement).height(tinymceEditor.settings.autoresize_min_height);
-        }
-      });
     } else {
       // Clear the contents of any textarea select boxes or input fields
       container.find('.toggleable-field').find('input, textarea, select').val('').change();


### PR DESCRIPTION
Fixes #3424

Changes proposed in this PR:
- Other than preventing specific console warnings from appearing, these changes should not affect the behaviour of the app.
  1. Removed `forced_root_block: ''` from `app/javascript/src/superAdmin/notifications/edit.js`
     -  `The [forced_root_block](https://www.tiny.cloud/docs/tinymce/5/content-filtering/#forced_root_block) option will no-longer accept the false value or an empty string value in TinyMCE 6.0` https://www.tiny.cloud/docs/tinymce/5/6.0-upcoming-changes/
     - Removing this code resolves the console warning, and it doesn't seem to introduce any other changes (documented here: https://github.com/DMPRoadmap/roadmap/issues/3424#issuecomment-2166424160)
   2. Removed "Resize any TinyMCE editors" code  from `app/javascript/src/utils/conditionalFields.js`
      - This code block was attempting to set the height using `tinymceEditor.settings.autoresize_min_height`. However, `tinymceEditor.settings.` was evaluating to `undefined`. In addition, TinyMCE replaced `autoresize_min_height` with `min_height` when it upgraded from v4 to v5 (https://www.tiny.cloud/blog/how-to-migrate-from-tinymce-4-to-tinymce-5/).
      - This code block didn't appear to be affecting anything. Rather, it was being set by the value of `min_height:`, within the the `defaultOptions` object of `app/javascript/src/utils/tinymce.js` (documented here: https://github.com/DMPRoadmap/roadmap/issues/3424#issuecomment-2166552337).