### PR TITLE
Optimise and Refactor `Org.with_template_and_user_counts`

### DIFF
--- a/app/controllers/paginable/orgs_controller.rb
+++ b/app/controllers/paginable/orgs_controller.rb
@@ -10,7 +10,7 @@ module Paginable
       authorize(Org)
       paginable_renderise(
         partial: 'index',
-        scope: Org.with_template_and_user_counts,
+        scope: Org.with_template_count_and_associations_check,
         query_params: { sort_field: 'orgs.name', sort_direction: :asc },
         format: :json
       )

--- a/app/controllers/super_admin/orgs_controller.rb
+++ b/app/controllers/super_admin/orgs_controller.rb
@@ -11,7 +11,7 @@ module SuperAdmin
     def index
       authorize Org
       render 'index', locals: {
-        orgs: Org.with_template_and_user_counts.page(1)
+        orgs: Org.with_template_count_and_associations_check.page(1)
       }
     end
 

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -201,9 +201,9 @@ class Org < ApplicationRecord
       .group('orgs.id')
       .select("orgs.*,
               count(distinct templates.family_id) as template_count,
-              EXISTS (SELECT 1 FROM users WHERE users.org_id = orgs.id) AS has_users,
-              EXISTS (SELECT 1 FROM contributors WHERE contributors.org_id = orgs.id) AS has_contributors,
-              EXISTS (SELECT 1 FROM plans WHERE plans.org_id = orgs.id) as has_plans")
+              EXISTS (SELECT 1 FROM users WHERE users.org_id = orgs.id) OR
+              EXISTS (SELECT 1 FROM contributors WHERE contributors.org_id = orgs.id) OR
+              EXISTS (SELECT 1 FROM plans WHERE plans.org_id = orgs.id) as has_associations")
   }
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -198,11 +198,12 @@ class Org < ApplicationRecord
   # Scope used in several controllers
   scope :with_template_and_user_counts, lambda {
     joins('LEFT OUTER JOIN templates ON orgs.id = templates.org_id')
-      .joins('LEFT OUTER JOIN users ON orgs.id = users.org_id')
       .group('orgs.id')
       .select("orgs.*,
               count(distinct templates.family_id) as template_count,
-              count(users.id) as user_count")
+              EXISTS (SELECT 1 FROM users WHERE users.org_id = orgs.id) AS has_users,
+              EXISTS (SELECT 1 FROM contributors WHERE contributors.org_id = orgs.id) AS has_contributors,
+              EXISTS (SELECT 1 FROM plans WHERE plans.org_id = orgs.id) as has_plans")
   }
 
   # EVALUATE CLASS AND INSTANCE METHODS BELOW

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -196,8 +196,8 @@ class Org < ApplicationRecord
   }
 
   # Scope used in several controllers
-  scope :with_template_and_user_counts, lambda {
-    joins('LEFT OUTER JOIN templates ON orgs.id = templates.org_id')
+  scope :with_template_count_and_associations_check, lambda {
+    left_outer_joins(:templates)
       .group('orgs.id')
       .select("orgs.*,
               count(distinct templates.family_id) as template_count,

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -31,7 +31,7 @@
               </button>
               <ul class="dropdown-menu" aria-labelledby="org-<%= org.id %>-actions">
                 <li class="nav-item"><%= link_to _('Edit'), admin_edit_org_path(org), class:'dropdown-item px-3' %></li>
-                <% unless org.user_count > 0 || org.template_count > 0 || org.contributors.length > 0 || org.plans.length > 0 %>
+                <% unless org.has_users || org.template_count > 0 || org.has_contributors || org.has_plans %>
                   <li class="nav-item"><%= link_to _('Remove'), super_admin_org_path(org), data: {confirm: _("You are about to delete '%{org_name}'. Are you sure?") % { org_name: org.name}}, method: :delete, class:'dropdown-item px-3' %></li>
                 <% end %>
               </ul>

--- a/app/views/paginable/orgs/_index.html.erb
+++ b/app/views/paginable/orgs/_index.html.erb
@@ -31,7 +31,7 @@
               </button>
               <ul class="dropdown-menu" aria-labelledby="org-<%= org.id %>-actions">
                 <li class="nav-item"><%= link_to _('Edit'), admin_edit_org_path(org), class:'dropdown-item px-3' %></li>
-                <% unless org.has_users || org.template_count > 0 || org.has_contributors || org.has_plans %>
+                <% unless org.template_count > 0 || org.has_associations? %>
                   <li class="nav-item"><%= link_to _('Remove'), super_admin_org_path(org), data: {confirm: _("You are about to delete '%{org_name}'. Are you sure?") % { org_name: org.name}}, method: :delete, class:'dropdown-item px-3' %></li>
                 <% end %>
               </ul>


### PR DESCRIPTION
Changes proposed in this PR:

- `app/models/org.rb`
  - Updated the query logic for `scope :with_template_and_user_counts`. It is now significantly faster (see table at bottom of description).

- `app/views/paginable/orgs/_index.html.erb`
  - Updated the code to correspond with the changes made in `app/models/org.rb`.
  - The code updated in this file is for determining whether or not a listed Org should have the `delete` option enabled. These PR changes should result in the same exact Orgs having the `delete` option enabled as before.

- Refactoring:
- To reflect these changes, `scope: Org.with_template_and_user_counts` has been renamed to `scope: Org.with_template_count_and_associations_check` throughout the codebase.
- In `app/models/org.rb`, `joins('LEFT OUTER JOIN templates ON orgs.id = templates.org_id')` has been replaced with the equivalent `left_outer_joins(:templates)`


- The following table compares the `development` branch to `aaron/optimize-scope-with_template_and_user_counts` by making requests to the various paths affected by this PR. The benchmarking was performed via ab - Apache HTTP server benchmarking tool alongside a recent (May 2024) db dump from the production environment of DMP Assistant. In both cases, 100 consecutive requests were performed to each path and the recorded result is the mean request time (ms).

Path | mean request time (ms) before | mean request time (ms) now | % change
-- | -- | -- | --
/super_admin/orgs | 1090.878 | 61.887 | -94.33%
/paginable/orgs/index/ALL | 3322.034 | 328.263 | -90.12%