### PR TITLE
Strip Outer Spaces Of User Search String and Queried DB Fields

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,17 +138,17 @@ class User < ApplicationRecord
     if date_range?(term: term)
       by_date_range(:created_at, term)
     else
-      search_pattern = "%#{term}%".squish!
+      search_pattern = "%#{term.strip.squish}%"
       # MySQL does not support standard string concatenation and since concat_ws
       # or concat functions do not exist for sqlite, we have to come up with this
       # conditional
       if mysql_db?
-        where("lower(concat_ws(' ', firstname, surname)) LIKE lower(?) OR " \
+        where("lower(concat_ws(' ', trim(firstname), trim(surname))) LIKE lower(?) OR " \
               'lower(email) LIKE lower(?)',
               search_pattern, search_pattern)
       else
         joins(:org)
-          .where("lower(firstname || ' ' || surname) LIKE lower(:search_pattern)
+          .where("lower(trim(firstname) || ' ' || trim(surname)) LIKE lower(:search_pattern)
                     OR lower(email) LIKE lower(:search_pattern)
                     OR lower(orgs.name) LIKE lower (:search_pattern)
                     OR lower(orgs.abbreviation) LIKE lower (:search_pattern) ",


### PR DESCRIPTION
Changes proposed in this PR:
- Addresses the following edge-case: https://github.com/DMPRoadmap/roadmap/pull/3407#issuecomment-2192201540
- In addition to applying `.squish` to the user-inputted search term, `.strip` is applied as well. For example, if `" x "` was typed by the user, then a query would be made for `"x"`.
- Similarly, `trim()` is applied to the db values for for `User.firstname` and `User.surname`. For example, if the value for one of these fields was `" x "`, then it would be trimmed to `"x"`.

Additional Notes:
- There is still another edge-case. That is, it is possible for a `User.firstname` or `User.lastname` value to exist in the db having multiple spaces in-between non-space characters. In fact, there are two currently in the production db of DMP Assistant:
-  ```sql
   SELECT firstname, lastname
   FROM users
   WHERE trim(firstname) LIKE '%  %' -- 
   OR trim(surname) LIKE '%  %';
   ```

- It would be great to expand the concept of #3407 to other search bars within the app, but the following issue should probably be addressed first: https://github.com/DMPRoadmap/roadmap/issues/3432