### PR TITLE
Make a Plan's "Add a Contributor" Button Only Render For User's With Sufficient Permissions

### DIFF
--- a/app/views/contributors/index.html.erb
+++ b/app/views/contributors/index.html.erb
@@ -29,8 +29,10 @@
         <p><%= _("No contributors have been defined.") %></p>
       <% end %>
 
-      <%= link_to _("Add a contributor"), new_plan_contributor_path(@plan),
-                                          class: "btn btn-primary" %>
+      <% if @plan.editable_by?(current_user.id) %>
+        <%= link_to _("Add a contributor"), new_plan_contributor_path(@plan),
+                                            class: "btn btn-primary" %>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes #3439

Changes proposed in this PR:
- This PR adds a conditional to the plan's "Add a contributor" button.
  - Adding the `if @plan.editable_by?(current_user.id)` permission check prevents users with "Read only" access from accessing the button.