### PR TITLE
Address Deprecation Warnings

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -28,9 +28,9 @@
 class Condition < ApplicationRecord
   belongs_to :question
   enum action_type: %i[remove add_webhook]
-  serialize :option_list, Array
-  serialize :remove_data, Array
-  serialize :webhook_data, JSON
+  serialize :option_list, type: Array
+  serialize :remove_data, type: Array
+  serialize :webhook_data, coder: JSON
 
   # Sort order: Number ASC
   default_scope { order(number: :asc) }

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -54,7 +54,7 @@ class Org < ApplicationRecord
   # The links are validated against custom validator allocated at
   # validators/template_links_validator.rb
   attribute :links, :text, default: { org: [] }
-  serialize :links, JSON
+  serialize :links, coder: JSON
 
   # ================
   # = Associations =

--- a/app/models/pref.rb
+++ b/app/models/pref.rb
@@ -13,7 +13,7 @@
 class Pref < ApplicationRecord
   ##
   # Serialize prefs to JSON
-  serialize :settings, JSON
+  serialize :settings, coder: JSON
 
   # ================
   # = Associations =

--- a/app/models/stat_created_plan.rb
+++ b/app/models/stat_created_plan.rb
@@ -19,7 +19,7 @@ require 'set'
 
 # Object that represents a Nbr of Plans created usage statistic
 class StatCreatedPlan < Stat
-  serialize :details, JSON
+  serialize :details, coder: JSON
 
   def by_template
     parse_details.fetch('by_template', [])

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -53,7 +53,7 @@ class Template < ApplicationRecord
   # The links is validated against custom validator allocated at
   # validators/template_links_validator.rb
   attribute :links, :text, default: { funder: [], sample_plan: [] }
-  serialize :links, JSON
+  serialize :links, coder: JSON
 
   attribute :published, :boolean, default: false
   attribute :archived, :boolean, default: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ApplicationRecord
 
   ##
   # User Notification Preferences
-  serialize :prefs, Hash
+  serialize :prefs, type: Hash
 
   # default user language to the default language
   attribute :language_id, :integer, default: -> { Language.default&.id }

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
This PR addresses the following deprecation warnings (the warnings were encountered when executing `bundle exec rspec`):

1. ```
    DEPRECATION WARNING: Setting action_dispatch.show_exceptions to false is deprecated. Set to :none instead. 
    (called from rescue in call at /usr/share/rvm/gems/ruby-3.0.5@upstream/gems/actionpack- 
    7.1.3.4/lib/action_dispatch/middleware/debug_exceptions.rb:43)
    ```
2.  Added `coder:` and `type:` keywords in various places

     Example warning (before adding `type: ` keyword in `app/models/user.rb`:
     ```
     Please pass the class as a keyword argument:

     serialize :prefs, type: Hash
     (called from <class:User> at /path/to/app/models/user.rb:73)
     DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 
     7.2.
     ```
  
