### PR TITLE
Updated Rack Attack configuration to address vulnerabilities in password updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Updated Rack Attack configuration to address vulnerabilities in password updates.
+
 ## v4.2.0
 
 **Note this upgrade is mainly a migration from Bootstrap 3 to Bootstrap 5.** 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -16,11 +16,17 @@ end
 
 # Throttle attempts to a particular path. 2 POSTs to /users/password every 30 seconds
 Rack::Attack.throttle "password_resets/ip", limit: 2, period: 30.seconds do |req|
-  req.post? && req.path == "/users/password" && req.ip
+  req.ip if req.post? && req.path == "/users/password"
 end
 
 # Throttle attempts to a particular path. 4 POSTs to /users/sign_in every 30 seconds
 Rack::Attack.throttle "logins/ip", limit: 4, period: 30.seconds do |req|
   # Don't apply sign-in rate-limiting to test environment
-  req.post? && req.path == "/users/sign_in" && req.ip unless Rails.env.test?
+  (req.ip if req.post? && req.path == "/users/sign_in") unless Rails.env.test?
+end
+
+# Throttle attempts to a particular path. 2 POST or PUTS to /users every 30 seconds
+# This includes password updates.
+Rack::Attack.throttle "profile_updates/ip", limit: 2, period: 30.seconds do |req|
+  req.ip if (req.put? || req.post?) && req.path == "/users"
 end


### PR DESCRIPTION


Changes:
    The fix involves adding a new Rack Attack rule "profile_updates/ip" and
    rewriting the body of the rules "password_resets/ip" and "logins/ip" so
    the the request ip is returned if the rule is triggered.

To Test:

- Make 4+  Forgot Password requests in less than 30 secs.
![Selection_219](https://github.com/user-attachments/assets/da40de22-91f0-4627-84f8-c4926efbb1fd)


- Make 4+ Password updates using the User Profile in 30 secs.

![Selection_218](https://github.com/user-attachments/assets/04fdac00-843b-4f63-85f7-de39fc7add21)

You should get the following message with each test above.
![Selection_217](https://github.com/user-attachments/assets/411c5520-4304-49a3-8acf-12683e370ce7)
