### PR TITLE
Fix issue with combining named and unnamed function args

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -55,7 +55,7 @@ class RolesController < ApplicationController
           if @role.save
             if registered
               deliver_if(recipients: user, key: 'users.added_as_coowner') do |r|
-                UserMailer.sharing_notification(@role, r, inviter: current_user)
+                UserMailer.sharing_notification(@role, r, current_user)
                           .deliver_now
               end
             end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -48,7 +48,7 @@ class UserMailer < ActionMailer::Base
   end
   # rubocop:enable Metrics/AbcSize
 
-  def sharing_notification(role, user, inviter:)
+  def sharing_notification(role, user, inviter)
     @role       = role
     @user       = user
     @user_email = @user.email


### PR DESCRIPTION
We recently upgraded our Ruby version and the emails that get sent out to collaborators stopped working. This is due to the fact that the arguments to the mailer function use both named and unnamed arguments.