### PR TITLE
Fix to exclude downloads of public plans with  no user id usually associated with robots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Fix
+- Fix for removing from statistics the count of the download of plans that lack an user id in exported_plans table. Most of such downloads will have been associated with robots harvesting.
+
 ## v5.0.2
 - Bump Ruby to v3.1.4 and use `.ruby-version` in CI
   - [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)

--- a/app/models/stat_exported_plan/create_or_update.rb
+++ b/app/models/stat_exported_plan/create_or_update.rb
@@ -40,9 +40,11 @@ class StatExportedPlan
             .uniq
       end
 
+      # Exclude plans harvested by robots, by excluding plans that have a user_id nil.
       def exported_plans(start_date:, end_date:, org_id:, filtered:)
         ExportedPlan.where(plan_id: org_plan_ids(org_id: org_id, filtered: filtered))
                     .where(created_at: start_date..end_date)
+                    .where.not(user_id: nil)
                     .count
       end
     end


### PR DESCRIPTION
Fix to exclude downloads of public plans with  no user id associated  with download, as most of these downloads are associated with robots.

**Change:**
 - We exclude the count of downloads in export_plans table for which user_id is nil.

**To Test:**

- First, get a snapshot of the monthly download for an org. We are interested in recent stats (when robots seem to start downloading public plans), e,g.,

![BeforeChangeMonthlyDownloads_UOE](https://github.com/user-attachments/assets/5b072016-e059-4797-8928-cec9958f72d1)


- Now we need to delete the data in the stats table before we regenerate it with:

   _**DELETE from stats;**_

- Now run **(this could take 15 - 30 min)**

  _**bundle exec rails stat:build**_

- Now you should be able download the usage monthly stats again for your org and get something with download figures reduced drastically for recent period.

![AfterChangeMonthlyDownloads_UOE](https://github.com/user-attachments/assets/48e24f07-4efd-48f6-910e-967d84675df2)


