### PR TITLE
Refactor `Plan.deep_copy(plan)`

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -259,8 +259,7 @@ class Plan < ApplicationRecord
     plan_copy.identifier = plan_copy.id.to_s
     plan.answers.each do |answer|
       answer_copy = Answer.deep_copy(answer)
-      answer_copy.plan_id = plan_copy.id
-      answer_copy.save!
+      plan_copy.answers << answer_copy
     end
     plan.guidance_groups.each do |guidance_group|
       plan_copy.guidance_groups << guidance_group if guidance_group.present?

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -257,7 +257,6 @@ class Plan < ApplicationRecord
     plan_copy.save!
     # Copy newly generated Id to the identifier
     plan_copy.identifier = plan_copy.id.to_s
-    plan.save!
     plan.answers.each do |answer|
       answer_copy = Answer.deep_copy(answer)
       answer_copy.plan_id = plan_copy.id

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -398,6 +398,10 @@ describe Plan do
       expect(subject.title).to include(plan.title)
     end
 
+    it "copies the new plan's id to its identifer" do
+      expect(subject.identifier).to eql(subject.id.to_s)
+    end
+
     it 'persists the record' do
       expect(subject).to be_persisted
     end


### PR DESCRIPTION
Changes proposed in this PR:
- Remove redundant `plan.save!` (line 260) 4b25e4adc0f09fec80b2816797d12a7b683ca38e
   - Considering that the removed line occurred immediately after `plan_copy.identifier = plan_copy.id.to_s`, I believe this was meant to be `plan_copy.save!`. However, rather than correcting the variable, I think the line can be removed completely .
      The earlier execution of `plan_copy.save!` (line 257) is necessary because we need to generate a pk for `plan_copy`. However, the `duplicate` action within `PlansController` appears to be the only thing calling `Plan.deep_copy`, and the action is performing its own save on the copied plan returned from `deep_copy` (see below):
    ```ruby
    def duplicate
    plan = Plan.find(params[:id])
    authorize plan
    @plan = Plan.deep_copy(plan)
    respond_to do |format|
    if @plan.save
    ...
    ```
- Refactor / use ActiveRecord association operator d8f897880a7fc3cc70b8aa84ef21d9ed7fdbde47
    - Using `<<` here replaces manual foreign key assignment as well as the explicit save call.
  
- Add test for plan identifier copying 521ba8ef76b7ead4b769137358a8be1729872c52