### PR TITLE
The V1 API Docs link in Edit profile > API access tab was broken.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Refactor Plan.deep_copy(plan) [#3469](https://github.com/DMPRoadmap/roadmap/pull/3469)
 - Fixed a bug in the deep copy of plans where the old identifier was being copied into the new plan. We now copy the generated id of the new plan to the identifier field.
 - Fixed bar chart click function in the Usage dashboard (GitHub issue #3443)
+- Fixed broken link for the V1 API documentation.
 
 
 **Note this upgrade is mainly a migration from Bootstrap 3 to Bootstrap 5.** 

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -77,7 +77,7 @@ module DMPRoadmap
     # The link to the API documentation - used in emails about the API
     config.x.application.api_documentation_urls = {
       v0: 'https://github.com/DMPRoadmap/roadmap/wiki/API-V0-Documentation',
-      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-Documentation-V1'
+      v1: 'https://github.com/DMPRoadmap/roadmap/wiki/API-V1-Documentation'
     }
     # The links that appear on the home page. Add any number of links
     config.x.application.welcome_links = [


### PR DESCRIPTION
Updated URL in config.x.application.api_documentation_urls property in config/initializers/_dmproadmap.rb.
![Selection_029](https://github.com/user-attachments/assets/6b6f9c2f-9ea1-4475-bf1d-6f87aab10037)

