### PR TITLE
Retain Filter Setting When Applying Search or "View All" On `/org_admin/templates/` Page

### DIFF
--- a/app/controllers/concerns/paginable.rb
+++ b/app/controllers/concerns/paginable.rb
@@ -99,6 +99,8 @@ module Paginable
       action: @args[:action],
       page: page
     )
+    # Retain :f if paginable/templates controller is using it to filter templates
+    url_params[:f] = @args[:f] if @args[:f].present? && @args[:controller] == 'paginable/templates'
     url_for(url_params)
   end
 

--- a/app/controllers/paginable/templates_controller.rb
+++ b/app/controllers/paginable/templates_controller.rb
@@ -25,7 +25,7 @@ module Paginable
       paginable_renderise(
         partial: 'index',
         scope: templates,
-        query_params: { sort_field: 'templates.title', sort_direction: :asc },
+        query_params: { sort_field: 'templates.title', sort_direction: :asc, f: params[:f] },
         locals: { action: 'index' },
         format: :json
       )
@@ -50,7 +50,7 @@ module Paginable
       paginable_renderise(
         partial: 'organisational',
         scope: templates,
-        query_params: { sort_field: 'templates.title', sort_direction: :asc },
+        query_params: { sort_field: 'templates.title', sort_direction: :asc, f: params[:f] },
         locals: { action: 'organisational' },
         format: :json
       )
@@ -78,7 +78,7 @@ module Paginable
       paginable_renderise(
         partial: 'customisable',
         scope: templates.joins(:org).includes(:org),
-        query_params: { sort_field: 'templates.title', sort_direction: :asc },
+        query_params: { sort_field: 'templates.title', sort_direction: :asc, f: params[:f] },
         locals: { action: 'customisable', customizations: customizations },
         format: :json
       )

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -17,6 +17,8 @@
         <%= label_tag(:filter_admin, _('Only Show Admins'), class: 'form-check-label') %>
       </div>
     <% end %>
+    <%# :f corresponds to the "Published" vs "Unpublished" etc. filters defined on the org_admin/templates pages %>
+    <%= hidden_field_tag :f, params[:f] if params[:f].present? %>
       <%= submit_tag(_('Search'), class: 'btn btn-secondary ms-2') %>
     </div>
   </div>


### PR DESCRIPTION
Changes proposed in this PR:
- Retain `:f` filter on `/org_admin/templates/` Search c0a0dbf02ab6af91750f671bbc5a803ff367bbd5
  - This change retains the selected 'Published', 'Unpublished', or 'Not customized' filter when using the search on the paths `/org_admin/templates`, `org_admin/templates/organisational`, and `org_admin/templates/customisable`. Previously, the search would ignore the filter and return all templates.

 - Retain `:f` filter on `/org_admin/templates/` "View All" c0a0dbf02ab6af91750f671bbc5a803ff367bbd5
   - This change retains the selected 'Published', 'Unpublished', or 'Not customized' filter when using the "Select All" pagination option on the paths `/org_admin/templates`, `org_admin/templates/organisational`, and `org_admin/templates/customisable`. Previously, clicking "Select All" would ignore the filter and return all templates.