### PR TITLE
Fix Paginating, Sorting, and Searching Issues Within "Research Outputs" Tab 

### DIFF
--- a/app/controllers/paginable/research_outputs_controller.rb
+++ b/app/controllers/paginable/research_outputs_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Paginable
+  # Controller for paginating/sorting/searching the research_outputs table
+  class ResearchOutputsController < ApplicationController
+    include Paginable
+
+    after_action :verify_authorized
+
+    # GET /paginable/plans/:plan_id/research_outputs
+    def index
+      @plan = Plan.find_by(id: params[:plan_id])
+      # Same assignment as app/controllers/research_outputs_controller.rb
+      research_outputs = ResearchOutput.includes(:repositories).where(plan_id: @plan.id)
+      # Same authorize handling as app/controllers/research_outputs_controller.rb
+      # `|| ResearchOutput.new(plan_id: @plan.id)` prevents Pundit::NotDefinedError when a direct
+      # GET /paginable/plans/:id/research_outputs request is made on a plan with 0 research_outputs
+      authorize(research_outputs.first || ResearchOutput.new(plan_id: @plan.id))
+      paginable_renderise(
+        partial: 'index',
+        scope: research_outputs,
+        query_params: { sort_field: 'research_outputs.title' },
+        format: :json
+      )
+    end
+  end
+end

--- a/app/models/research_output.rb
+++ b/app/models/research_output.rb
@@ -70,6 +70,15 @@ class ResearchOutput < ApplicationRecord
   # Ensure presence of the :output_type_description if the user selected 'other'
   validates_presence_of :output_type_description, if: -> { other? }, message: PRESENCE_MESSAGE
 
+  # ==========
+  # = Scopes =
+  # ==========
+
+  scope :search, lambda { |term|
+                   search_pattern = "%#{term}%"
+                   where('lower(title) LIKE lower(?)', search_pattern)
+                 }
+
   # ====================
   # = Instance methods =
   # ====================


### PR DESCRIPTION
Fixes the "Create paginable/research_outputs_controller.rb TODO" in https://github.com/DMPRoadmap/roadmap/issues/3464

Changes proposed in this PR:
- Add `scope :search` to `ResearchOutput` model: 8ecced57b5dda5e5b9341b14adf847ae3acaf870
  - Search query is performed by `research_outputs.title` (case-insensitive) 
- Create `app/controllers/paginable/research_outputs_controller.rb` 301231c6ed27d783122e007c1f14e3af89e18458
  - This new controller fixes the following features on the `/plans/:plan_id/research_outputs` page:
    - The clickable pagination options (e.g. View all,1,2,Next,Last)
    - The search box (for `research_outputs.title` matches)
    - The clickable sorting arrows