### PR TITLE
Fix `hidden_field_tag` Nested Attributes Format For Rails 7 Upgrade and Add Test Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixed a bug in the deep copy of plans where the old identifier was being copied into the new plan. We now copy the generated id of the new plan to the identifier field.
 - Fixed bar chart click function in the Usage dashboard (GitHub issue #3443)
 - Fixed broken link for the V1 API documentation.
+- Fix `hidden_field_tag` Nested Attributes Format For Rails 7 Upgrade and Add Test Coverage [#3479](https://github.com/DMPRoadmap/roadmap/pull/3479)
 
 
 **Note this upgrade is mainly a migration from Bootstrap 3 to Bootstrap 5.** 

--- a/app/views/research_outputs/metadata_standards/_search_result.html.erb
+++ b/app/views/research_outputs/metadata_standards/_search_result.html.erb
@@ -1,7 +1,7 @@
 <%# locals: result %>
 
 <% if result.present? %>
-  <%= hidden_field_tag "research_output[metadata_standards_attributes[#{result.id}][id]]", result.id %>
+  <%= hidden_field_tag "research_output[metadata_standards_attributes][#{result.id}][id]", result.id %>
 
   <p><%= sanitize(result.description) %></p>
 

--- a/app/views/research_outputs/repositories/_search_result.html.erb
+++ b/app/views/research_outputs/repositories/_search_result.html.erb
@@ -3,7 +3,7 @@
 %>
 
 <% if result.present? %>
-  <%= hidden_field_tag "research_output[repositories_attributes[#{result.id}][id]]", result.id %>
+  <%= hidden_field_tag "research_output[repositories_attributes][#{result.id}][id]", result.id %>
 
   <p><%= result.description %></p>
 

--- a/spec/features/modal_search_spec.rb
+++ b/spec/features/modal_search_spec.rb
@@ -49,4 +49,35 @@ RSpec.feature 'ModalSearchDialog', type: :feature do
     click_link 'Remove'
     expect(page).not_to have_text(@model.description)
   end
+
+  it 'saves research output and selected repository association', :js do
+    # Fill in required fields
+    fill_in 'Title', with: 'Test Output'
+    select 'Audiovisual', from: 'research_output_output_type'
+
+    # Open the modal and select repository
+    click_button 'Add a repository'
+    within('#modal-search-repositories') do
+      fill_in 'research_output_search_term', with: @model.name
+      click_button 'Apply filter(s)'
+      click_link 'Select'
+      modal_close_button = find('.modal-header button.btn-close')
+      execute_script('arguments[0].click();', modal_close_button)
+    end
+
+    click_button 'Save'
+
+    # Verify UI changes
+    expect(page).to have_css('.fas.fa-circle-check + span + span',
+                             text: 'Successfully added the researchoutput.')
+    expect(page).to have_content('Test Output')
+    expect(page).to have_content(@model.name)
+
+    # Verify DB changes
+    research_output = ResearchOutput.last
+    expect(research_output.title).to eq('Test Output')
+    expect(research_output.output_type).to eq('audiovisual')
+    expect(research_output.repositories).to include(@model)
+    expect(research_output.plan).to eq(@plan)
+  end
 end

--- a/spec/features/modal_search_spec.rb
+++ b/spec/features/modal_search_spec.rb
@@ -61,8 +61,8 @@ RSpec.feature 'ModalSearchDialog', type: :feature do
       fill_in 'research_output_search_term', with: @model.name
       click_button 'Apply filter(s)'
       click_link 'Select'
-      modal_close_button = find('.modal-header button.btn-close')
-      execute_script('arguments[0].click();', modal_close_button)
+      # (execute_script('arguments[0].click();', modal_close_button) works locally here, but not as GitHub Action)
+      find('[data-bs-dismiss="modal"]').click
     end
 
     click_button 'Save'


### PR DESCRIPTION
Fixes #3478

Changes proposed in this PR:
- Update `hidden_field_tag` nested attributes format for Rails 7 compatibility b417f28e634ad91b1207261bc3885d62a868273d
  - This re-enables the saving of `repositories` and `metadata_standards` associations when creating or updating a `research_output` (See #3478 for more info).
- Add feature test to have coverage for any future breaking changes 434074af017bac2d1541be60ee76626b0a125d14
  - NOTE: This test fails without commit  b417f28e634ad91b1207261bc3885d62a868273d