### PR TITLE
Add pdf handling in `render_respond_to_format_with_error_message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed bar chart click function in the Usage dashboard (GitHub issue #3443)
 - Fixed broken link for the V1 API documentation.
 - Fix `hidden_field_tag` Nested Attributes Format For Rails 7 Upgrade and Add Test Coverage [#3479](https://github.com/DMPRoadmap/roadmap/pull/3479)
+- Add pdf handling in `render_respond_to_format_with_error_message` [#3482](https://github.com/DMPRoadmap/roadmap/pull/3482)
 
 
 **Note this upgrade is mainly a migration from Bootstrap 3 to Bootstrap 5.** 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -188,7 +188,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       # Redirect use to the path and display the error message
-      format.html { redirect_to url_or_path, alert: msg }
+      format.any(:html, :pdf) { redirect_to url_or_path, alert: msg }
       # Render the JSON error message (using API V1)
       format.json do
         @payload = { errors: [msg] }


### PR DESCRIPTION
Fixes #3414
- #3414

Changes proposed in this PR:
- `render_respond_to_format_with_error_message` is called both when rescuing from Pundit::NotAuthorizedError and ActiveRecord::RecordNotFound. The method works properly with .html format, but prior to this change, ActionController::UnknownFormat was thrown for .pdf format.