### PR TITLE
Update all workflows to `runs-on: ubuntu-24.04` and Consolidate Capybara Config

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   brakeman:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   brakeman:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   danger:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,8 +11,8 @@ jobs:
 
     - name: 'Determine Ruby and Bundler Versions from Gemfile.lock'
       run: |
-        echo "RUBY_VERSION=`cat ./Gemfile.lock | grep -A 1 'RUBY VERSION' | grep 'ruby' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
-        echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]\.[0-9]'`" >> $GITHUB_ENV
+        echo "RUBY_VERSION=`cat ./Gemfile.lock | grep -A 1 'RUBY VERSION' | grep 'ruby' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`" >> $GITHUB_ENV
+        echo "BUNDLER_VERSION=`cat ./Gemfile.lock | grep -A 1 'BUNDLED WITH' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`" >> $GITHUB_ENV
 
     # Install Ruby - using the version found in the Gemfile.lock
     - name: 'Install Ruby'

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,7 +16,7 @@ jobs:
 
     # Install Ruby - using the version found in the Gemfile.lock
     - name: 'Install Ruby'
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
 

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   danger:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   eslint:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     # Checkout the repo

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   eslint:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     # Checkout the repo

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   mysql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Define environment variables for MySQL and Rails
     env:

--- a/.github/workflows/mysql.yml
+++ b/.github/workflows/mysql.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   mysql:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # Define environment variables for MySQL and Rails
     env:

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -52,6 +52,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libpq-dev
+    
+    # Install ImageMagick (for `identify` command)
+    - name: 'Install ImageMagick'
+      run: |
+        sudo apt-get install -y imagemagick
 
     # Copy all of the example configs over
     - name: 'Setup Default Configuration'

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   postgresql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       # Postgres installation

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   postgresql:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       # Postgres installation

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   rubocop:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     # Checkout the repo

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   rubocop:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     # Checkout the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed bar chart click function in the Usage dashboard (GitHub issue #3443)
 - Fixed broken link for the V1 API documentation.
 - Fix `hidden_field_tag` Nested Attributes Format For Rails 7 Upgrade and Add Test Coverage [#3479](https://github.com/DMPRoadmap/roadmap/pull/3479)
-
+- Update all workflows to `runs-on: ubuntu-22.04` [#3487](https://github.com/DMPRoadmap/roadmap/pull/3487)
 
 **Note this upgrade is mainly a migration from Bootstrap 3 to Bootstrap 5.** 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed bar chart click function in the Usage dashboard (GitHub issue #3443)
 - Fixed broken link for the V1 API documentation.
 - Fix `hidden_field_tag` Nested Attributes Format For Rails 7 Upgrade and Add Test Coverage [#3479](https://github.com/DMPRoadmap/roadmap/pull/3479)
-- Update all workflows to `runs-on: ubuntu-24.04` [#3487](https://github.com/DMPRoadmap/roadmap/pull/3487)
+- Update all workflows to `runs-on: ubuntu-24.04` and Consolidate Capybara Config [#3487](https://github.com/DMPRoadmap/roadmap/pull/3487)
 - Add pdf handling in `render_respond_to_format_with_error_message` [#3482](https://github.com/DMPRoadmap/roadmap/pull/3482)
 - Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#3491](https://github.com/DMPRoadmap/roadmap/pull/3491)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed bar chart click function in the Usage dashboard (GitHub issue #3443)
 - Fixed broken link for the V1 API documentation.
 - Fix `hidden_field_tag` Nested Attributes Format For Rails 7 Upgrade and Add Test Coverage [#3479](https://github.com/DMPRoadmap/roadmap/pull/3479)
-- Update all workflows to `runs-on: ubuntu-22.04` [#3487](https://github.com/DMPRoadmap/roadmap/pull/3487)
+- Update all workflows to `runs-on: ubuntu-24.04` [#3487](https://github.com/DMPRoadmap/roadmap/pull/3487)
 - Add pdf handling in `render_respond_to_format_with_error_message` [#3482](https://github.com/DMPRoadmap/roadmap/pull/3482)
 - Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#3491](https://github.com/DMPRoadmap/roadmap/pull/3491)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,21 +80,3 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Pundit::Matchers, type: :policy
 end
-
-Capybara.register_driver :headless_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument('--headless')
-  options.add_argument('--no-sandbox')
-  options.add_argument('--disable-dev-shm-usage')
-
-  Capybara::Selenium::Driver.new(
-    app,
-    browser: :chrome,
-    options: options
-  )
-end
-
-Capybara.javascript_driver = :headless_chrome
-Capybara.default_driver = :headless_chrome
-# Configure Capybara to wait longer for elements to appear
-Capybara.default_max_wait_time = 20

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,18 +3,22 @@
 # Use Puma as the webserver for feature tests
 Capybara.server = :puma, { Silent: true }
 
-# Use the fast rack_test driver for non-feature tests by default
-Capybara.default_driver = :rack_test
-
 # Create a custom driver based on Capybara's :selenium_chrome_headless driver
-# This resolves a ElementClickInterceptedError when executing `click_button 'Sign in'` with DMP Assistant
-Capybara.register_driver :selenium_chrome_headless_add_window_size do |app|
+Capybara.register_driver :selenium_chrome_headless_custom do |app|
   # Get a copy of the default options for Capybara's :selenium_chrome_headless driver
   options = Capybara.drivers[:selenium_chrome_headless].call.options[:options].dup
-  options.add_argument('--window-size=1920,1080') # default window-size is only (800x600)
+  # Resolves ElementClickInterceptedError (default window-size is only (800x600))
+  options.add_argument('--window-size=1920,1080')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
   # Create a new Selenium driver with the customised options
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
+
+# Use the fast rack_test driver for non-feature tests by default
+Capybara.default_driver = :rack_test
+Capybara.javascript_driver = :selenium_chrome_headless_custom
+Capybara.default_max_wait_time = 20
 
 RSpec.configure do |config|
   config.before(:each, type: :feature, js: false) do
@@ -23,6 +27,6 @@ RSpec.configure do |config|
 
   # Use the Selenium headless Chrome driver for feature tests
   config.before(:each, type: :feature, js: true) do
-    Capybara.current_driver = :selenium_chrome_headless_add_window_size
+    Capybara.current_driver = :selenium_chrome_headless_custom
   end
 end


### PR DESCRIPTION
Fixes #3484

### Changes proposed in this PR:
- Updates from `runs-on: ubuntu-20.04` to `runs-on: ubuntu-24.04` within all `.github/workflows` files
  - This change addresses the following deprecation/brownout warning: https://github.com/actions/runner-images/issues/11101

- Prior to the `ubuntu-24.04` update, all of the workflows were bumped to `ubuntu-22.04`. The `22.04` update resulted in the Danger GitHub Action failing with the following output:
   ```
   Run actions/setup-ruby@v1
     with:
       ruby-version: 3.0
     env:
       RUBY_VERSION: 3.0
       BUNDLER_VERSION: [2](https://github.com/DMPRoadmap/roadmap/actions/runs/13906666949/job/38911245234? 
  pr=3487#step:4:2).4
   ------------------------
   NOTE: This action is deprecated and is no longer maintained.
   Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
   ------------------------
   Error: Version [3](https://github.com/DMPRoadmap/roadmap/actions/runs/13906666949/job/38911245234? 
  pr=3487#step:4:3).0 not found
   ```
  - To address this, the deprecated `actions/setup-ruby@v1` has been replaced with  `ruby/setup-ruby@v1`. Additionally, the regex has been modified to capture the full Ruby and Bundler versions.

- Bumping the Postgres workflow from `runs-on: ubuntu-22.04` to  `runs-on: ubuntu-22.04` required the following extra steps:
  - https://github.com/DMPRoadmap/roadmap/pull/3487/commits/027fa4a3fb04e0f35a062c23d367772c7f2d38b0: `imagemagick` is required for some of the tests but is not packaged with `ubuntu-24.04` by default
  - https://github.com/DMPRoadmap/roadmap/pull/3487/commits/c7b9b483e8edf6575ac33e8acec4c7d8674281fc: The Capybara config existed in two files and consolidating them into one resolved the following failing `/features` tests: https://github.com/DMPRoadmap/roadmap/actions/runs/14041753874/job/39313346863
