### PR TITLE
Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -75,6 +75,18 @@ jobs:
     - name: 'Yarn Install'
       run: |
         yarn install
+    
+    # TEMPORARY WORKAROUND FOR THE FOLLOWING ISSUE: https://github.com/DMPRoadmap/roadmap/issues/3485
+    # Remove this once our tests are compatible with the new version of Chrome
+    # Source: https://github.com/teamcapybara/capybara/issues/2800#issuecomment-2731100953
+    - name: Remove image-bundled Chrome
+      run: sudo apt-get purge google-chrome-stable
+    - name: Setup stable Chrome
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: 128
+        install-chromedriver: true
+        install-dependencies: true
 
     # Initialize the DB
     - name: 'Setup Test DB'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fixed bar chart click function in the Usage dashboard (GitHub issue #3443)
 - Fixed broken link for the V1 API documentation.
 - Fix `hidden_field_tag` Nested Attributes Format For Rails 7 Upgrade and Add Test Coverage [#3479](https://github.com/DMPRoadmap/roadmap/pull/3479)
-
+- Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#3491](https://github.com/DMPRoadmap/roadmap/pull/3491)
 
 **Note this upgrade is mainly a migration from Bootstrap 3 to Bootstrap 5.** 
 

--- a/spec/features/modal_search_spec.rb
+++ b/spec/features/modal_search_spec.rb
@@ -56,26 +56,37 @@ RSpec.feature 'ModalSearchDialog', type: :feature do
 
   # handles opening + closing of the modal, as well as the actions performed within the modal
   def perform_modal_actions
-    # Open the modal
-    click_button 'Add a repository'
-    expect(page).to have_text('Repository search')
+    open_modal
 
     within('#modal-search-repositories') do
-      # Search for the Repository
-      fill_in 'research_output_search_term',	with: @model.name
-      click_button 'Apply filter(s)'
-      expect(page).to have_text(@model.description)
-      # Select the repository and make sure it no longer appears in the search results
-      click_link 'Select'
-      expect(page).not_to have_text(@model.description)
-
-      # Using JS to click on button, as click_button '.modal-header button.btn-close' did not work.
-      modal_close_button = find('.modal-header button.btn-close')
-      # Close the modal
-      execute_script('arguments[0].click();', modal_close_button)
+      search_and_select_repository_within_modal
+      close_modal
     end
     # Verify that the selection was added to the main page's dom
     expect(page).not_to have_text('Repository search')
     expect(page).to have_text(@model.description)
+  end
+
+  def open_modal
+    # Open the modal
+    click_button 'Add a repository'
+    expect(page).to have_text('Repository search')
+  end
+
+  def search_and_select_repository_within_modal
+    # Search for the Repository
+    fill_in 'research_output_search_term',	with: @model.name
+    click_button 'Apply filter(s)'
+    expect(page).to have_text(@model.description)
+    # Select the repository and make sure it no longer appears in the search results
+    click_link 'Select'
+    expect(page).not_to have_text(@model.description)
+  end
+
+  def close_modal
+    # Using JS to click on button, as click_button '.modal-header button.btn-close' did not work.
+    modal_close_button = find('.modal-header button.btn-close')
+    # Close the modal
+    execute_script('arguments[0].click();', modal_close_button)
   end
 end


### PR DESCRIPTION
Fixes # (Only a temporary fix for #3485)

Changes proposed in this PR:
- Replace image-bundled Chrome version with Chrome version 128
  - This change addresses the breaking changes encountered between Chrome version 134 and our `/features` tests
  - NOTE: This change should be reverted once are `/features` tests are working with the latest Chrome version
- Refactored `spec/features/modal_search_spec.rb` to allow both tests within the file to share the same modal logic
  - This solved an issue where one of the two tests was repeatedly failing to close the modal: https://github.com/DMPRoadmap/roadmap/actions/runs/13977354846/job/39134312551
  - Performed some additional refactoring as well to avoid any Rubocop offences.