### PR TITLE
Move Copying of Assets to Precompile Task

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,16 +14,3 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules/@fortawes
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-
-# Bootstrap and TinyMCE expect their files to live in a specific place, so copy them over
-puts "Copying Bootstrap glyphicons to the public directory ..."
-source_dir = Dir.glob(Rails.root.join('node_modules', 'bootstrap', 'fonts', 'glyphicons-halflings-regular.*'))
-destination_dir = Rails.root.join('public', 'fonts', 'bootstrap')
-FileUtils.mkdir_p(destination_dir)
-FileUtils.cp_r(source_dir, destination_dir)
-
-puts "Copying TinyMCE skins to the public directory ..."
-source_dir = Dir.glob(Rails.root.join('node_modules', 'tinymce', 'skins', 'ui', 'oxide'))
-destination_dir = Rails.root.join('public', 'tinymce', 'skins')
-FileUtils.mkdir_p(destination_dir)
-FileUtils.cp_r(source_dir, destination_dir)

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,20 @@
+namespace :assets do
+  desc 'Copy Bootstrap glyphicons and TinyMCE skins to the public directory'
+  task :copy do
+    # Bootstrap and TinyMCE expect their files to live in a specific place, so copy them over
+    puts 'Copying Bootstrap glyphicons to the public directory ...'
+    source_dir = Dir.glob(Rails.root.join('node_modules', 'bootstrap', 'fonts', 'glyphicons-halflings-regular.*'))
+    destination_dir = Rails.root.join('public', 'fonts', 'bootstrap')
+    FileUtils.mkdir_p(destination_dir)
+    FileUtils.cp_r(source_dir, destination_dir)
+
+    puts 'Copying TinyMCE skins to the public directory ...'
+    source_dir = Dir.glob(Rails.root.join('node_modules', 'tinymce', 'skins', 'ui', 'oxide'))
+    destination_dir = Rails.root.join('public', 'tinymce', 'skins')
+    FileUtils.mkdir_p(destination_dir)
+    FileUtils.cp_r(source_dir, destination_dir)
+  end
+
+  # Run the copy task before precompiling assets
+  task precompile: :copy
+end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :assets do
   desc 'Copy Bootstrap glyphicons and TinyMCE skins to the public directory'
   task :copy do


### PR DESCRIPTION
Fixes #3493

Changes proposed in this PR:
- Moved the code for copying Bootstrap glyphicons and TinyMCE skins from the initializer to a custom Rake task.
- Created a new Rake task `assets:copy` to handle the copying of necessary files.
- Ensured that the `assets:copy` task runs before `assets:precompile` by setting it as a prerequisite.
- This change prevents the files from being copied every time the Rails application initializes (e.g., when starting the server or console), and only copies them during the asset precompilation process.