### PR TITLE
Match `config.load_defaults` Version to Rails Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Updated app to Rails 7 [#3426](https://github.com/DMPRoadmap/roadmap/pull/3426)
+- Updated app to Rails 7 [#3426](https://github.com/DMPRoadmap/roadmap/pull/3426), [#3496](https://github.com/DMPRoadmap/roadmap/pull/3496)
 - Address Some Bullet Warnings / Optimise Mean Request Times [#3440](https://github.com/DMPRoadmap/roadmap/pull/3440)
 - Fix Flaky Tests / Optimize Checking of `plan.title` Within `spec/features/plans/exports_spec.rb` [#3451](https://github.com/DMPRoadmap/roadmap/pull/3451)
 - Refactor Plan.deep_copy(plan) [#3469](https://github.com/DMPRoadmap/roadmap/pull/3469)

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -28,8 +28,8 @@
 class Condition < ApplicationRecord
   belongs_to :question
   enum action_type: %i[remove add_webhook]
-  serialize :option_list, type: Array
-  serialize :remove_data, type: Array
+  serialize :option_list, type: Array, coder: YAML
+  serialize :remove_data, type: Array, coder: YAML
   serialize :webhook_data, coder: JSON
 
   # Sort order: Number ASC

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User < ApplicationRecord
 
   ##
   # User Notification Preferences
-  serialize :prefs, type: Hash
+  serialize :prefs, type: Hash, coder: YAML
 
   # default user language to the default language
   attribute :language_id, :integer, default: -> { Language.default&.id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,10 +68,6 @@ class User < ApplicationRecord
          :rememberable, :trackable, :validatable, :omniauthable,
          omniauth_providers: %i[shibboleth orcid]
 
-  ##
-  # User Notification Preferences
-  serialize :prefs, type: Hash, coder: YAML
-
   # default user language to the default language
   attribute :language_id, :integer, default: -> { Language.default&.id }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module DMPRoadmap
   # DMPRoadmap application
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Changes proposed in this PR:
- Updated `config.load_defaults` value to `7.1` to match our Rails version.
- Added explicit `coder: YAML` to `serialize` calls to conform with Rails 7.1 changes
  - (Prior to Rails 7.1, `config.active_record.default_column_serializer = YAML` was implicit, so these explicit calls were unnecessary.)
