### PR TITLE
Pin `spring` gem to v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add pdf handling in `render_respond_to_format_with_error_message` [#3482](https://github.com/DMPRoadmap/roadmap/pull/3482)
 - Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#3491](https://github.com/DMPRoadmap/roadmap/pull/3491)
 - Bumped dependencies via `bundle update && yarn upgrade` [#3483](https://github.com/DMPRoadmap/roadmap/pull/3483)
+- Pin `spring` gem to v4.2.1 [#3499](https://github.com/DMPRoadmap/roadmap/pull/3499)
 
 ## v4.2.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -304,7 +304,8 @@ group :development do
   gem 'web-console'
   # Spring speeds up development by keeping your application running in the background.
   # Read more: https://github.com/rails/spring
-  gem 'spring'
+  # Pinning Spring to version v4.2.1 due to the following issue: https://github.com/DMPRoadmap/roadmap/issues/3498
+  gem 'spring', '4.2.1'
   gem 'spring-watcher-listen'
 
   # Simple Progress Bar for output to a terminal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -552,7 +552,7 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    spring (4.3.0)
+    spring (4.2.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     spring-watcher-listen (2.1.0)
@@ -681,7 +681,7 @@ DEPENDENCIES
   ruby-progressbar
   selenium-webdriver
   shoulda
-  spring
+  spring (= 4.2.1)
   spring-commands-rspec
   spring-watcher-listen
   sprockets-rails


### PR DESCRIPTION
Fixes # (Workaround for #3498)

Changes proposed in this PR:
- Downgrades spring from v4.3.0 to v4.2.1 as a workaround for issue https://github.com/DMPRoadmap/roadmap/issues/3498.