### PR TITLE
Refactor `Question.save_condition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#3491](https://github.com/DMPRoadmap/roadmap/pull/3491)
 - Bumped dependencies via `bundle update && yarn upgrade` [#3483](https://github.com/DMPRoadmap/roadmap/pull/3483)
 - Fixed issues with Conditional Question serialization offered by @briri from PR https://github.com/CDLUC3/dmptool/pull/667 for DMPTool. There is a migration file with code for MySQL and Postgres to update the Conditions table to convert JSON Arrays in string format records in the conditions table so that they are JSON Arrays.
+- Refactor `Question.save_condition` [#3501](https://github.com/DMPRoadmap/roadmap/pull/3501)
 
 ## v4.2.0
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -221,24 +221,11 @@ class Question < ApplicationRecord
     c.number = value['number']
     # question options may have changed so rewrite them
     c.option_list = value['question_option']
-
-    if opt_map.present?
-      new_question_options = []
-      c.option_list.map do |qopt|
-        new_question_options << opt_map[qopt]
-      end
-      c.option_list = new_question_options
-    end
+    c.option_list = c.option_list.map { |qopt| opt_map[qopt] } if opt_map.present?
 
     if value['action_type'] == 'remove'
       c.remove_data = value['remove_question_id']
-      if question_id_map.present?
-        new_question_ids = []
-        c.remove_data.map do |qid|
-          new_question_ids << question_id_map[qid]
-        end
-        c.remove_data = new_question_ids
-      end
+      c.remove_data = c.remove_data.map { |qid| question_id_map[qid] } if question_id_map.present?
 
       # Do not save the condition if the option_list or remove_data is empty
       if c.option_list.empty? || c.remove_data.empty?

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -222,21 +222,24 @@ class Question < ApplicationRecord
     # question options may have changed so rewrite them
     c.option_list = value['question_option']
     c.option_list = c.option_list.map { |qopt| opt_map[qopt] } if opt_map.present?
+    # Do not save the condition if the option_list is empty
+    if c.option_list.empty?
+      c.destroy
+      return
+    end
 
     if value['action_type'] == 'remove'
       c.remove_data = value['remove_question_id']
       c.remove_data = c.remove_data.map { |qid| question_id_map[qid] } if question_id_map.present?
-
-      # Do not save the condition if the option_list or remove_data is empty
-      if c.option_list.empty? || c.remove_data.empty?
+      # Do not save the condition if remove_data is empty
+      if c.remove_data.empty?
         c.destroy
         return
       end
     else
       c.webhook_data = handle_webhook_data(value)
-
-      # Do not save the condition if the option_list is empty or webhook_data is nil
-      if c.option_list.empty? || c.webhook_data.nil?
+      # Do not save the condition if webhook_data is nil
+      if c.webhook_data.nil?
         c.destroy
         return
       end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -213,7 +213,7 @@ class Question < ApplicationRecord
     end
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def save_condition(value, opt_map, question_id_map)
     c = conditions.build
@@ -233,19 +233,10 @@ class Question < ApplicationRecord
         return
       end
     else
-      c.webhook_data = {
-        name: value['webhook-name'],
-        email: value['webhook-email'],
-        subject: value['webhook-subject'],
-        message: value['webhook-message']
-      }
+      c.webhook_data = handle_webhook_data(value)
 
-      # Do not save the condition if the option_list or if any webhook_data fields is empty
-      if c.option_list.empty? ||
-         c.webhook_data['name'].blank? ||
-         c.webhook_data['email'].blank? ||
-         c.webhook_data['subject'].blank? ||
-         c.webhook_data['message'].blank?
+      # Do not save the condition if the option_list is empty or webhook_data is nil
+      if c.option_list.empty? || c.webhook_data.nil?
         c.destroy
         return
       end
@@ -253,7 +244,7 @@ class Question < ApplicationRecord
     c.save
   end
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
 
   private
 
@@ -280,4 +271,17 @@ class Question < ApplicationRecord
     end
   end
   # rubocop:enable Metrics/AbcSize
+
+  def handle_webhook_data(value)
+    # return nil if any of the webhook fields are blank
+    return if %w[webhook-name webhook-email webhook-subject webhook-message].any? { |key| value[key].blank? }
+
+    # else return the constructed webhook_data hash
+    {
+      name: value['webhook-name'],
+      email: value['webhook-email'],
+      subject: value['webhook-subject'],
+      message: value['webhook-message']
+    }
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -213,7 +213,7 @@ class Question < ApplicationRecord
     end
   end
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def save_condition(value, opt_map, question_id_map)
     c = conditions.build
     c.action_type = value['action_type']
@@ -244,7 +244,7 @@ class Question < ApplicationRecord
     end
     c.save
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   private
 


### PR DESCRIPTION
Changes proposed in this PR:
- This PR refactors `Question.save_condition` via the following changes:
  - [Refactor mapping of remove_data & option_list](https://github.com/DMPRoadmap/roadmap/commit/739aad0e1e51b2031d67984d30a084468ecff191)
    - This change uses `.map` to refactor/simplify the mapping of `option_list` and `remove_data`. It also removes the need for temporary arrays.
  - [Refactor webhook_data validation and construction](https://github.com/DMPRoadmap/roadmap/commit/f6a232b47f2c8ff3ee594a3670130377652597ee)
    - This change adds the `handle_webhook_data` helper method
      - Helper method returns nil if any of the required `webhook_data` fields are absent. Else, it constructs and returns the `webhook_data` hash
    - Returning nil when any fields are absent enables us to simplify the if check that immediately follows (now line 240)
   - [Refactor handling of c.option_list.empty?](https://github.com/DMPRoadmap/roadmap/commit/82984e25bdd039246a8dfebb8d0ab78b57fe4f17)
     - Moved `c.option_list.empty?` immediately after `c.option_list` assignment to streamline logic.
     - This change reduces unnecessary processing of `c.remove_data` and `c.webhook_data`.
     - Isolating the `c.option_list.empty?` check also simplifies subsequent checks for `c.remove_data.empty?` and `c.webhook_data.nil?` later in the code. 
   - [Refactor option_list and remove_data handling](https://github.com/DMPRoadmap/roadmap/commit/49b9f7d4408c68d77594a59ae57de18c6a5e1d31)
     - Moved logic for handling `option_list` and `remove_data` into separate helper methods (`handle_option_list` and `handle_remove_data`).
     - This simplifies our `save_condition` method and resolves some previously disabled rubocop offenses.