### PR TITLE
Refactor `org_admin/conditions/_form.html.erb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Lower PostgreSQL GitHub Action Chrome Version to Address Breaking Changes Between Latest Chrome Version (134) and `/features` Tests [#3491](https://github.com/DMPRoadmap/roadmap/pull/3491)
 - Bumped dependencies via `bundle update && yarn upgrade` [#3483](https://github.com/DMPRoadmap/roadmap/pull/3483)
 - Fixed issues with Conditional Question serialization offered by @briri from PR https://github.com/CDLUC3/dmptool/pull/667 for DMPTool. There is a migration file with code for MySQL and Postgres to update the Conditions table to convert JSON Arrays in string format records in the conditions table so that they are JSON Arrays.
+- Refactor `org_admin/conditions/_form.html.erb` [#3502](https://github.com/DMPRoadmap/roadmap/pull/3502)
 
 ## v4.2.0
 

--- a/app/views/org_admin/conditions/_existing_condition_display.erb
+++ b/app/views/org_admin/conditions/_existing_condition_display.erb
@@ -1,0 +1,38 @@
+    <%
+    qopt = condition[:question_option_id].any? ? QuestionOption.find_by(id: condition[:question_option_id].first): nil
+    rquesArray = condition[:remove_question_id].any? ? Question.where(id: condition[:remove_question_id]) : nil
+    %>
+    <div class="col-md-3 pe-2">
+      <%= qopt[:text]&.slice(0, 25) %>
+      <%= hidden_field_tag(name_start + "[question_option][]", condition[:question_option_id]) %>
+    </div>
+    <div class="col-md-3 pe-2">
+      <%= condition[:action_type] == 'remove' ? 'Remove' : 'Email' %>
+      <%= hidden_field_tag(name_start + "[action_type]", condition[:action_type]) %>
+    </div>
+    <div class="col-md-3 pe-2">
+      <% if !rquesArray.nil? %>
+        <% rquesArray.each do |rques| %>
+           Question <%= rques[:number] %>: <%= rques.text.gsub(%r{</?p>}, '').slice(0, 50) %>
+           <%= '...' if rques.text.gsub(%r{</?p>}, '').length > 50 %>
+           <br>
+        <% end %>
+        <%= hidden_field_tag(name_start + "[remove_question_id][]", condition[:remove_question_id]) %>
+      <% else %>
+        <%
+        hook_tip = "Name: #{condition[:webhook_data]['name']}\nEmail: #{condition[:webhook_data]['email']}\n"
+        hook_tip += "Subject: #{condition[:webhook_data]['subject']}\nMessage: #{condition[:webhook_data]['message']}"
+        %>
+        <span title="<%= hook_tip %>"><%= condition[:webhook_data]['email'] %></span>
+        <br>(<%= view_email_content_info %>)
+
+        <%= hidden_field_tag(name_start + "[webhook-email]", condition[:webhook_data]['email']) %>
+        <%= hidden_field_tag(name_start + "[webhook-name]", condition[:webhook_data]['name']) %>
+        <%= hidden_field_tag(name_start + "[webhook-subject]", condition[:webhook_data]['subject']) %>
+        <%= hidden_field_tag(name_start + "[webhook-message]", condition[:webhook_data]['message']) %>
+      <% end %>
+      <%= hidden_field_tag(name_start + "[number]", condition_no) %>
+    </div>
+    <div class="col-md-3">
+      <a href="#anotherurl" class="delete-condition"><%= _('Remove') %></a>
+    </div>

--- a/app/views/org_admin/conditions/_existing_condition_display.erb
+++ b/app/views/org_admin/conditions/_existing_condition_display.erb
@@ -1,6 +1,7 @@
     <%
     qopt = condition[:question_option_id].any? ? QuestionOption.find_by(id: condition[:question_option_id].first): nil
     rquesArray = condition[:remove_question_id].any? ? Question.where(id: condition[:remove_question_id]) : nil
+    view_email_content_info = _("Hover over the email address to view email content. To change email details you need to remove and add the condition again.")
     %>
     <div class="col-md-3 pe-2">
       <%= qopt[:text]&.slice(0, 25) %>

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -10,9 +10,7 @@
     action_type_arr = [["removes", :remove], ["adds notification", :add_webhook]]
     name_start = "conditions[#{condition_no.to_s}]"
     remove_question_collection = later_question_list(question)
-    remove_question_group = condition.present? ?
-      grouped_options_for_select(remove_question_collection, condition[:remove_question_id]) :
-      grouped_options_for_select(remove_question_collection)
+    remove_question_group = grouped_options_for_select(remove_question_collection)
     view_email_content_info = _("Hover over the email address to view email content. To change email details you need to remove and add the condition again.")
   %>
   

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -3,40 +3,29 @@
     - app/views/org_admin/conditions/_container.html.erb
     %>
 
-<% condition ||= nil %>
-
 <div class="row condition-partial mb-3">
   <%
-    action_type_arr = [["removes", :remove], ["adds notification", :add_webhook]]
+    condition ||= nil
     name_start = "conditions[#{condition_no.to_s}]"
-    remove_question_collection = later_question_list(question)
-    remove_question_group = grouped_options_for_select(remove_question_collection)
-    view_email_content_info = _("Hover over the email address to view email content. To change email details you need to remove and add the condition again.")
   %>
   
   <%# If this is a new condition then display the interactive controls. otherwise just display the logic %>
   <% if condition.nil? %>
     <%= render partial: 'org_admin/conditions/new_condition_form',
-                locals: { action_type_arr: action_type_arr,
-                          condition_no: condition_no,
-                          question: question,
+                locals: { condition_no: condition_no,
                           name_start: name_start,
-                          remove_question_group: remove_question_group,
-                          view_email_content_info: view_email_content_info
+                          question: question
                         }
       %>
 
   <% else %>
-  <%= render partial: 'org_admin/conditions/existing_condition_display',
-              locals: { action_type_arr: action_type_arr,
-                        condition: condition,
-                        condition_no: condition_no,
-                        name_start: name_start,
-                        question: question,
-                        remove_question_group: remove_question_group,
-                        view_email_content_info: view_email_content_info
-                      }
-    %>
+    <%= render partial: 'org_admin/conditions/existing_condition_display',
+                locals: { condition: condition,
+                          condition_no: condition_no,
+                          name_start: name_start,
+                          question: question
+                        }
+      %>
 
   <% end %>
 </div>

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -16,72 +16,27 @@
   
   <%# If this is a new condition then display the interactive controls. otherwise just display the logic %>
   <% if condition.nil? %>
-  <div class="form-label bold">Add condition</div>
-  <div class="row  mb-3">
-    <div class="col-md-9 pe-2">
-      <div class="form-label bold"><%= _('Option') %></div>
-      <%= select_tag(:question_option, options_from_collection_for_select(question.question_options.sort_by(&:number), "id", "text",
-          question.question_options.sort_by(&:number)[0]), {class: 'form-select regular', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3', name: name_start + "[question_option][]"}) %>
-    </div>
-    <div class="col-md-3 pe-2">
-      <div class="form-label bold"><%= _('Action') %></div>
-      <%= select_tag(:action_type, options_for_select(action_type_arr, :remove), {name: name_start + "[action_type]", class: 'action-type form-select narrow', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3'}) %>
-    </div>
-  </div>
-  <div class="row d-flex mb-3">
-    <div class="col-md-10 pe-2">
-      <div class="form-label bold display-if-action-remove"><%= _('Target') %></div>
-      <div class="remove-dropdown">
-        <%= select_tag(:remove_question_id, remove_question_group, {name: name_start + "[remove_question_id][]", class: 'form-select regular', multiple: true, 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3'}) %>
-      </div>
-      <div class="webhook-replacement display-off my-auto text-center">
-        <%= link_to _('Edit email'), '#' %>
-      </div>
-      <%= hidden_field_tag(name_start + "[number]", condition_no) %>
-    </div>
-    <div class="col-md-2 align-self-center">
-      <a href="#anotherurl" class="delete-condition btn btn-primary"><%= _('Remove') %></a>
-    </div>
-    <%= render partial: 'org_admin/conditions/webhook_form', locals: {name_start: name_start, condition_no: condition_no} %>
-  </div>
-  <% else %>
-    <%
-    qopt = condition[:question_option_id].any? ? QuestionOption.find_by(id: condition[:question_option_id].first): nil
-    rquesArray = condition[:remove_question_id].any? ? Question.where(id: condition[:remove_question_id]) : nil
-    %>
-    <div class="col-md-3 pe-2">
-      <%= qopt[:text]&.slice(0, 25) %>
-      <%= hidden_field_tag(name_start + "[question_option][]", condition[:question_option_id]) %>
-    </div>
-    <div class="col-md-3 pe-2">
-      <%= condition[:action_type] == 'remove' ? 'Remove' : 'Email' %>
-      <%= hidden_field_tag(name_start + "[action_type]", condition[:action_type]) %>
-    </div>
-    <div class="col-md-3 pe-2">
-      <% if !rquesArray.nil? %>
-        <% rquesArray.each do |rques| %>
-           Question <%= rques[:number] %>: <%= rques.text.gsub(%r{</?p>}, '').slice(0, 50) %>
-           <%= '...' if rques.text.gsub(%r{</?p>}, '').length > 50 %>
-           <br>
-        <% end %>
-        <%= hidden_field_tag(name_start + "[remove_question_id][]", condition[:remove_question_id]) %>
-      <% else %>
-        <%
-        hook_tip = "Name: #{condition[:webhook_data]['name']}\nEmail: #{condition[:webhook_data]['email']}\n"
-        hook_tip += "Subject: #{condition[:webhook_data]['subject']}\nMessage: #{condition[:webhook_data]['message']}"
-        %>
-        <span title="<%= hook_tip %>"><%= condition[:webhook_data]['email'] %></span>
-        <br>(<%= view_email_content_info %>)
+    <%= render partial: 'org_admin/conditions/new_condition_form',
+                locals: { action_type_arr: action_type_arr,
+                          condition_no: condition_no,
+                          question: question,
+                          name_start: name_start,
+                          remove_question_group: remove_question_group,
+                          view_email_content_info: view_email_content_info
+                        }
+      %>
 
-        <%= hidden_field_tag(name_start + "[webhook-email]", condition[:webhook_data]['email']) %>
-        <%= hidden_field_tag(name_start + "[webhook-name]", condition[:webhook_data]['name']) %>
-        <%= hidden_field_tag(name_start + "[webhook-subject]", condition[:webhook_data]['subject']) %>
-        <%= hidden_field_tag(name_start + "[webhook-message]", condition[:webhook_data]['message']) %>
-      <% end %>
-      <%= hidden_field_tag(name_start + "[number]", condition_no) %>
-    </div>
-    <div class="col-md-3">
-      <a href="#anotherurl" class="delete-condition"><%= _('Remove') %></a>
-    </div>
+  <% else %>
+  <%= render partial: 'org_admin/conditions/existing_condition_display',
+              locals: { action_type_arr: action_type_arr,
+                        condition: condition,
+                        condition_no: condition_no,
+                        name_start: name_start,
+                        question: question,
+                        remove_question_group: remove_question_group,
+                        view_email_content_info: view_email_content_info
+                      }
+    %>
+
   <% end %>
 </div>

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -23,7 +23,7 @@
     <div class="col-md-9 pe-2">
       <div class="form-label bold"><%= _('Option') %></div>
       <%= select_tag(:question_option, options_from_collection_for_select(question.question_options.sort_by(&:number), "id", "text",
-          condition.present? ? condition[:question_option_id] : question.question_options.sort_by(&:number)[0]), {class: 'form-select regular', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3', name: name_start + "[question_option][]"}) %>
+          question.question_options.sort_by(&:number)[0]), {class: 'form-select regular', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3', name: name_start + "[question_option][]"}) %>
     </div>
     <div class="col-md-3 pe-2">
       <div class="form-label bold"><%= _('Action') %></div>

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -1,3 +1,8 @@
+<%# This partial is called from the following files:
+    - app/controllers/org_admin/conditions_controller.rb
+    - app/views/org_admin/conditions/_container.html.erb
+    %>
+
 <% condition ||= nil %>
 
 <div class="row condition-partial mb-3">

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -10,9 +10,8 @@
     action_type_arr = [["removes", :remove], ["adds notification", :add_webhook]]
     name_start = "conditions[#{condition_no.to_s}]"
     remove_question_collection = later_question_list(question)
-    condition_exists = local_assigns.has_key? :condition
-    type_default = condition_exists ? (condition[:action_type] == "remove" ? :remove : :add_webhook) : :remove
-    remove_question_group = condition_exists ?
+    type_default = condition.present? ? (condition[:action_type] == "remove" ? :remove : :add_webhook) : :remove
+    remove_question_group = condition.present? ?
       grouped_options_for_select(remove_question_collection, condition[:remove_question_id]) :
       grouped_options_for_select(remove_question_collection)
     view_email_content_info = _("Hover over the email address to view email content. To change email details you need to remove and add the condition again.")
@@ -25,7 +24,7 @@
     <div class="col-md-9 pe-2">
       <div class="form-label bold"><%= _('Option') %></div>
       <%= select_tag(:question_option, options_from_collection_for_select(question.question_options.sort_by(&:number), "id", "text",
-          condition_exists ? condition[:question_option_id] : question.question_options.sort_by(&:number)[0]), {class: 'form-select regular', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3', name: name_start + "[question_option][]"}) %>
+          condition.present? ? condition[:question_option_id] : question.question_options.sort_by(&:number)[0]), {class: 'form-select regular', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3', name: name_start + "[question_option][]"}) %>
     </div>
     <div class="col-md-3 pe-2">
       <div class="form-label bold"><%= _('Action') %></div>

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -10,7 +10,6 @@
     action_type_arr = [["removes", :remove], ["adds notification", :add_webhook]]
     name_start = "conditions[#{condition_no.to_s}]"
     remove_question_collection = later_question_list(question)
-    type_default = condition.present? ? (condition[:action_type] == "remove" ? :remove : :add_webhook) : :remove
     remove_question_group = condition.present? ?
       grouped_options_for_select(remove_question_collection, condition[:remove_question_id]) :
       grouped_options_for_select(remove_question_collection)
@@ -28,7 +27,7 @@
     </div>
     <div class="col-md-3 pe-2">
       <div class="form-label bold"><%= _('Action') %></div>
-      <%= select_tag(:action_type, options_for_select(action_type_arr, type_default), {name: name_start + "[action_type]", class: 'action-type form-select narrow', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3'}) %>
+      <%= select_tag(:action_type, options_for_select(action_type_arr, :remove), {name: name_start + "[action_type]", class: 'action-type form-select narrow', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3'}) %>
     </div>
   </div>
   <div class="row d-flex mb-3">

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -15,7 +15,6 @@
     remove_question_group = condition_exists ?
       grouped_options_for_select(remove_question_collection, condition[:remove_question_id]) :
       grouped_options_for_select(remove_question_collection)
-    multiple = (question.question_format.multiselectbox? || question.question_format.checkbox?)
     view_email_content_info = _("Hover over the email address to view email content. To change email details you need to remove and add the condition again.")
   %>
   

--- a/app/views/org_admin/conditions/_form.html.erb
+++ b/app/views/org_admin/conditions/_form.html.erb
@@ -8,7 +8,6 @@
 <div class="row condition-partial mb-3">
   <%
     action_type_arr = [["removes", :remove], ["adds notification", :add_webhook]]
-    # name_start = "conditions[]condition_" + condition_no.to_s
     name_start = "conditions[#{condition_no.to_s}]"
     remove_question_collection = later_question_list(question)
     condition_exists = local_assigns.has_key? :condition

--- a/app/views/org_admin/conditions/_new_condition_form.erb
+++ b/app/views/org_admin/conditions/_new_condition_form.erb
@@ -1,0 +1,28 @@
+  <div class="form-label bold">Add condition</div>
+  <div class="row  mb-3">
+    <div class="col-md-9 pe-2">
+      <div class="form-label bold"><%= _('Option') %></div>
+      <%= select_tag(:question_option, options_from_collection_for_select(question.question_options.sort_by(&:number), "id", "text",
+          question.question_options.sort_by(&:number)[0]), {class: 'form-select regular', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3', name: name_start + "[question_option][]"}) %>
+    </div>
+    <div class="col-md-3 pe-2">
+      <div class="form-label bold"><%= _('Action') %></div>
+      <%= select_tag(:action_type, options_for_select(action_type_arr, :remove), {name: name_start + "[action_type]", class: 'action-type form-select narrow', 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3'}) %>
+    </div>
+  </div>
+  <div class="row d-flex mb-3">
+    <div class="col-md-10 pe-2">
+      <div class="form-label bold display-if-action-remove"><%= _('Target') %></div>
+      <div class="remove-dropdown">
+        <%= select_tag(:remove_question_id, remove_question_group, {name: name_start + "[remove_question_id][]", class: 'form-select regular', multiple: true, 'data-bs-style': 'dropdown-toggle bg-white px-4 py-3'}) %>
+      </div>
+      <div class="webhook-replacement display-off my-auto text-center">
+        <%= link_to _('Edit email'), '#' %>
+      </div>
+      <%= hidden_field_tag(name_start + "[number]", condition_no) %>
+    </div>
+    <div class="col-md-2 align-self-center">
+      <a href="#anotherurl" class="delete-condition btn btn-primary"><%= _('Remove') %></a>
+    </div>
+    <%= render partial: 'org_admin/conditions/webhook_form', locals: {name_start: name_start, condition_no: condition_no} %>
+  </div>

--- a/app/views/org_admin/conditions/_new_condition_form.erb
+++ b/app/views/org_admin/conditions/_new_condition_form.erb
@@ -1,3 +1,9 @@
+  <%
+    action_type_arr = [["removes", :remove], ["adds notification", :add_webhook]]
+    remove_question_collection = later_question_list(question)
+    remove_question_group = grouped_options_for_select(remove_question_collection)
+  %>
+
   <div class="form-label bold">Add condition</div>
   <div class="row  mb-3">
     <div class="col-md-9 pe-2">


### PR DESCRIPTION
Changes proposed in this PR:
- These changes are intended to refactor `app/views/org_admin/conditions/_form.html.erb`.
  - Commit 3a1106770b13f10502486f5cdf15bc79fb2b12db creates the files `app/views/org_admin/conditions/_new_condition_form.erb` and `app/views/org_admin/conditions/_existing_condition_display.erb` which now handle the logic for new conditions vs existing conditions respectively. This change was largely performed via a simple copy/paste. Commit 4724bc7e499878208a99cc3dafa53329b457fe6b further refines this change.
- Individual descriptions are provided for most of the remaining commits. 