### PR TITLE
Fix failing eslint workflow / upgrade `actions/checkout` & `actions/setup-node` to v3

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     # Checkout the repo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Install Node
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         cache: 'yarn'
         node-version: 18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix failing eslint workflow / upgrade `actions/checkout` & `actions/setup-node` to v3 [#3503](https://github.com/DMPRoadmap/roadmap/pull/3503)
+
 ## v5.0.0
 
 - Updated app to Rails 7 [#3426](https://github.com/DMPRoadmap/roadmap/pull/3426), [#3496](https://github.com/DMPRoadmap/roadmap/pull/3496)


### PR DESCRIPTION
Changes proposed in this PR:
- This change is intended to fix the following GitHub Action failure: https://github.com/DMPRoadmap/roadmap/actions/runs/14087197077
- Upgraded upgrade actions/checkout & actions/setup-node to v3