### PR TITLE
Add Functionality Allowing Super Admins to Confirm/Unconfirm User Emails

### DIFF
--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -143,8 +143,8 @@ module SuperAdmin
       # if an unconfirmed email is now being confirmed
       if !@user.confirmed? && attrs[:confirmed_at] == '1'
         attrs[:confirmed_at] = Time.current
-      # elsif a confirmed email is now being unconfirmed
-      elsif @user.confirmed? && attrs[:confirmed_at] == '0'
+      # elsif a confirmed email is now being unconfirmed and the user is not a super admin
+      elsif @user.confirmed? && attrs[:confirmed_at] == '0' && !@user.can_super_admin?
         attrs[:confirmed_at] = nil
       else
         # else delete the param

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -38,6 +38,7 @@ module SuperAdmin
 
       # Remove the extraneous Org Selector hidden fields
       attrs = remove_org_selection_params(params_in: attrs)
+      attrs = handle_confirmed_at_param(attrs)
 
       if @user.update(attrs)
         # If its a new Org create it
@@ -125,7 +126,8 @@ module SuperAdmin
                                    :org_id, :org_name, :org_crosswalk,
                                    :department_id,
                                    :language_id,
-                                   :other_organisation)
+                                   :other_organisation,
+                                   :confirmed_at)
     end
 
     def merge_accounts
@@ -135,6 +137,21 @@ module SuperAdmin
       else
         flash.now[:alert] = failure_message(@user, _('merge'))
       end
+    end
+
+    def handle_confirmed_at_param(attrs)
+      # if an unconfirmed email is now being confirmed
+      if !@user.confirmed? && attrs[:confirmed_at] == '1'
+        attrs[:confirmed_at] = Time.current
+      # elsif a confirmed email is now being unconfirmed
+      elsif @user.confirmed? && attrs[:confirmed_at] == '0'
+        attrs[:confirmed_at] = nil
+      else
+        # else delete the param
+        # (keeps value nil for unconfirmed user and maintains previous Time value for confirmed user)
+        attrs.delete(:confirmed_at)
+      end
+      attrs
     end
   end
 end

--- a/app/views/super_admin/users/_email_confirmation_status.html.erb
+++ b/app/views/super_admin/users/_email_confirmation_status.html.erb
@@ -1,9 +1,11 @@
 <div class="form-group col-xs-12">
     <%= f.label(:confirmed_at, _('Email Confirmation Status'), class: 'control-label') %>
     <br>
-    <%= f.check_box(:confirmed_at, { checked: @user.confirmed?, 
+    <% is_checkbox_disabled = @user.can_super_admin? && @user.confirmed_at.present? %>
+    <%= f.check_box(:confirmed_at, { checked: @user.confirmed?,
+                                     disabled: is_checkbox_disabled,             
                                      style: 'vertical-align: middle;
                                              margin-top: -2px;' }) %>
     <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
-    <small><%= _("(Use checkbox to change status.)") %></small>
+    <%= content_tag(:small, _("(Use checkbox to change status.)")) unless is_checkbox_disabled %>
 </div>

--- a/app/views/super_admin/users/_email_confirmation_status.html.erb
+++ b/app/views/super_admin/users/_email_confirmation_status.html.erb
@@ -1,7 +1,9 @@
 <div class="form-group col-xs-12">
     <%= f.label(:confirmed_at, _('Email Confirmation Status'), class: 'control-label') %>
     <br>
-    <%= f.check_box(:confirmed_at, checked: @user.confirmed? ) %>
+    <%= f.check_box(:confirmed_at, { checked: @user.confirmed?, 
+                                     style: 'vertical-align: middle;
+                                             margin-top: -2px;' }) %>
     <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
     <small><%= _("(Use checkbox to change status.)") %></small>
 </div>

--- a/app/views/super_admin/users/_email_confirmation_status.html.erb
+++ b/app/views/super_admin/users/_email_confirmation_status.html.erb
@@ -1,0 +1,7 @@
+<div class="form-group col-xs-12">
+    <%= f.label(:confirmed_at, _('Email Confirmation Status'), class: 'control-label') %>
+    <br>
+    <%= f.check_box(:confirmed_at, checked: @user.confirmed? ) %>
+    <%= @user.confirmed? ? _("Confirmed.") : _("Unconfirmed.") %>
+    <small><%= _("(Use checkbox to change status.)") %></small>
+</div>

--- a/app/views/super_admin/users/edit.html.erb
+++ b/app/views/super_admin/users/edit.html.erb
@@ -57,6 +57,8 @@
         </div>
       <% end %>
 
+      <%= render 'email_confirmation_status', f: f %>
+
       <div class="form-control mb-3 col-xs-12">
         <%= f.button(_('Save'), class: 'btn btn-secondary', type: "submit", id: "personal_details_registration_form_submit") %>
 

--- a/spec/controllers/super_admin/users_controller_spec.rb
+++ b/spec/controllers/super_admin/users_controller_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SuperAdmin::UsersController, type: :controller do
+  let(:super_admin) { create(:user, :super_admin) }
+  let(:user) { create(:user, confirmed_at: nil) }
+
+  before do
+    sign_in super_admin
+  end
+
+  describe 'PUT #update' do
+    context 'when confirming an unconfirmed user' do
+      it 'sets confirmed_at to the current time' do
+        put :update, params: { id: user.id, user: { confirmed_at: '1' } }
+        user.reload
+        expect(user.confirmed_at).to be_a(Time)
+      end
+    end
+
+    context 'when unconfirming a confirmed user' do
+      before do
+        user.update(confirmed_at: Time.current)
+      end
+
+      it 'sets confirmed_at to nil' do
+        put :update, params: { id: user.id, user: { confirmed_at: '0' } }
+        user.reload
+        expect(user.confirmed_at).to be_nil
+      end
+    end
+
+    context 'when update will not affect confirmation status' do
+      it 'does not update confirmed_at value for an already confirmed user' do
+        # (usec: 0) removes mircoseconds to better enable comparison
+        user.update(confirmed_at: Time.current.change(usec: 0))
+        original_confirmed_at = user.confirmed_at
+        patch :update, params: { id: user.id, user: { firstname: 'NewName', confirmed_at: '1' } }
+        user.reload
+        expect(user.confirmed_at).to eq(original_confirmed_at)
+      end
+    end
+  end
+end

--- a/spec/controllers/super_admin/users_controller_spec.rb
+++ b/spec/controllers/super_admin/users_controller_spec.rb
@@ -36,9 +36,17 @@ RSpec.describe SuperAdmin::UsersController, type: :controller do
         # (usec: 0) removes mircoseconds to better enable comparison
         user.update(confirmed_at: Time.current.change(usec: 0))
         original_confirmed_at = user.confirmed_at
-        patch :update, params: { id: user.id, user: { firstname: 'NewName', confirmed_at: '1' } }
+        put :update, params: { id: user.id, user: { firstname: 'NewName', confirmed_at: '1' } }
         user.reload
         expect(user.confirmed_at).to eq(original_confirmed_at)
+      end
+    end
+
+    context 'when attempting to set a super_admin to unconfirmed' do
+      it 'does not update confirmed_at value to nil' do
+        put :update, params: { id: super_admin.id, user: { confirmed_at: '0' } }
+        super_admin.reload
+        expect(super_admin.confirmed_at).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
**NOTE: This PR should not be merged or tested until the app re-implements email confirmation via Devise's `:confirmable` module.**

Fixes (Issue exists downstream: https://github.com/portagenetwork/roadmap/issues/1006)

Changes proposed in this PR:
- Include email confirmation status as an editable attribute on the `/super_admin/users/:id` path.
![Screenshot from 2025-04-14 15-06-35](https://github.com/user-attachments/assets/585f76f7-6a68-448c-91db-f54475940c53)
  - The added logic includes special handling for superadmins. Specifically, it prevents the un-confirming of any already confirmed super admin email.
- This added feature helps address an encountered issue (https://github.com/portagenetwork/roadmap/issues/1005) where some institutions were blocking emails from `@portagenetwork.ca`, and as a result, preventing users from receiving email confirmation instructions.