### PR TITLE
Use `I18n.default_locale` in faker config

### DIFF
--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -2,14 +2,10 @@
 
 require 'faker'
 
-# Keep this as :en. Faker doesn't have :en-GB
-LOCALE = 'en'
-
 RSpec.configure do |config|
   config.before(:each) do
-    I18n.locale = LOCALE
-    Faker::Config.locale = LOCALE
-    I18n.default_locale = LOCALE
+    I18n.locale = I18n.default_locale
+    Faker::Config.locale = I18n.default_locale
   end
 
   config.after(:each) do


### PR DESCRIPTION
The previous configuration had a hardcoded 'en' locale with a comment stating "Keep this as :en. Faker doesn't have :en-GB". However, testing confirms that Faker now works properly with :"en-GB".

This change should allow for more accurate testing by using the application's specified locale.

Fixes # .

Changes proposed in this PR:
-
