### PR TITLE
Fix rendering of `confirm_merge` partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - Fix failing eslint workflow / upgrade `actions/checkout` & `actions/setup-node` to v3 [#3503](https://github.com/DMPRoadmap/roadmap/pull/3503)
+- Fix rendering of `confirm_merge` partial [#3515](https://github.com/DMPRoadmap/roadmap/pull/3515)
 
 ## v5.0.0
 

--- a/app/controllers/super_admin/users_controller.rb
+++ b/app/controllers/super_admin/users_controller.rb
@@ -91,7 +91,7 @@ module SuperAdmin
       # WHAT TO RETURN!?!?!
       if @users.present? # found a user, or Users, submit for merge
         render json: {
-          form: render_to_string(partial: 'super_admin/users/confirm_merge.html.erb')
+          form: render_to_string(partial: 'confirm_merge')
         }
       else # NO USER, re-render w/error?
         flash.now[:alert] = 'Unable to find user'


### PR DESCRIPTION
Changes proposed in this PR:

- This change simplifies the partial naming by taking advantage of Rails' naming conventions and resolves the following error / Rails 7 breaking change:
```
ActionView::MissingTemplate - Missing partial super_admin/users/_confirm_merge.html.erb with {:locale=>[:"en-CA", :en, :"en-GB"], :formats=>[:js, :html, :text, :css, :ics, :csv, :vcf, :vtt, :png, :jpeg, :gif, :bmp, :tiff, :svg, :webp, :mpeg, :mp3, :ogg, :m4a, :webm, :mp4, :otf, :ttf, :woff, :woff2, :xml, :rss, :atom, :yaml, :multipart_form, :url_encoded_form, :json, :pdf, :zip, :gzip, :docx, :turbo_stream], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}.
...
  app/controllers/super_admin/users_controller.rb:94:in `search'
```

- The prior `'super_admin/users/confirm_merge.html.erb'` code works with release`v4.2`, which uses Rails 6. However, it generates the following deprecation warning:
```
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: super_admin/users/_confirm_merge.html.erb (called from search at /home/aaron/Documents/GitHub/roadmap_upstream/app/controllers/super_admin/users_controller.rb:94)
```


