### PR TITLE
Additional `form-control` to `form-select` changes & styling changes to "Download settings" subheadings

### DIFF
--- a/app/views/guidances/new_edit.html.erb
+++ b/app/views/guidances/new_edit.html.erb
@@ -34,7 +34,7 @@ end
         <%= f.label _('Guidance group'), for: :guidance_group_id, class: 'form-label' %>
         <%= f.collection_select(:guidance_group_id,
                 GuidanceGroup.where(org_id: current_user.org_id).order("name ASC"),
-                :id, :name, {prompt: false}, {multiple: false, 'data-toggle': 'tooltip', title: _('Select which group this guidance relates to.'), class: 'form-control', 'aria-required': true})%>
+                :id, :name, {prompt: false}, {multiple: false, 'data-toggle': 'tooltip', title: _('Select which group this guidance relates to.'), class: 'form-select', 'aria-required': true})%>
       </div>
       <div class="form-check">
         <%= f.label :published do %>

--- a/app/views/org_admin/questions/_form.html.erb
+++ b/app/views/org_admin/questions/_form.html.erb
@@ -32,7 +32,7 @@
           :title,
           question.question_format_id),
           {},
-          class: "form-control question_format",
+          class: "form-select question_format",
           'data-toggle': 'tooltip',
           'data-html': true,
           title: _("You can choose from:<ul><li>- text area (large box for paragraphs);</li> <li>- text field (for a short answer);</li> <li>- checkboxes where options are presented in a list and multiple values can be selected;</li> <li>- radio buttons where options are presented in a list but only one can be selected;</li> <li>- dropdown like this box - only one option can be selected;</li> <li>- multiple select box allows users to select several options from a scrollable list, using the CTRL key;</li></ul>")

--- a/app/views/plans/_download_form.html.erb
+++ b/app/views/plans/_download_form.html.erb
@@ -16,9 +16,9 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-sm-12 col-lg-6">
+      <div class="form-control col-sm-12 col-lg-6">
         <fieldset>
-          <legend><%= _("Optional plan components") %></legend>
+          <%= label_tag('', _("Optional plan components"), class: 'form-label') %>
           <div class="form-check">
             <%= label_tag 'export[project_details]', class:'form-check-label' do %>
               <%= check_box_tag 'export[project_details]', true, download_coversheet_tickbox_checked %>

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -50,7 +50,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
                               include_blank: _("- Please select one -"),
                               selected: form.object.research_domain_id
                             },
-                            { class: "form-control" } %>
+                            { class: "form-select" } %>
     </div>
   </div>
 <% end %>
@@ -171,7 +171,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
                               include_blank: _("- Please select one -"),
                               selected: form.object.funding_status
                             },
-                            { class: "form-control" } %>
+                            { class: "form-select" } %>
     </div>
     <%= form.fields_for :grant, plan.grant do |grant_fields| %>
       <div class="col-lg-12">

--- a/app/views/research_outputs/_form.html.erb
+++ b/app/views/research_outputs/_form.html.erb
@@ -23,7 +23,7 @@ repository_tooltip = _("Repositories preserve, manage, and provide access to man
                        include_blank: _("- Please select one -"),
                        selected: (research_output.output_type.present? ? research_output.output_type : "" )
                      }, {
-                       class: "form-control",
+                       class: "form-select",
                        aria: { required: true, label: _("Research output type") },
                        data: { remote: true, url: plan_output_type_selection_path(plan), method: :get }
                      } %>
@@ -140,7 +140,7 @@ repository_tooltip = _("Repositories preserve, manage, and provide access to man
         <%= f.label(:access, _("Initial access level"), class: "form-label") %>
         <%= f.select :access, options_for_select(presenter.selectable_access_types, f.object.access),
                               { selected: f.object.access },
-                              { class: "form-control" } %>
+                              { class: "form-select" } %>
       </span>
     </div>
   </div>

--- a/app/views/super_admin/notifications/_form.html.erb
+++ b/app/views/super_admin/notifications/_form.html.erb
@@ -16,7 +16,7 @@
       <%= f.select :level,
           Notification.levels.keys.map { |l| [l.humanize, l] },
           { value: @notification.level },
-          { class: 'form-control',
+          { class: 'form-select',
             data: { toggle: 'tooltip', html: true }, title: _('<strong>Info:</strong> Simple information message, displayed in blue.<br/><strong>Warning:</strong> warning message, for signaling something unusual, displayed in orange.<br/><strong>Danger:</strong> error message, for anything critical, displayed in red') } %>
     </div>
   </div>


### PR DESCRIPTION
Changes proposed in this PR:
- This changes expand upon commit 87ddbb0ddb62073beadf3256115988d09e0a8b09
- Commit 225b93ba85c39f88e90fef375ee6512e11bf923d is a little OCD, but it does seem to improve the styling consistency between the "Optional plan components" and "Select phase to download" headings.
  - Prior to this change, the font sizes and vertical alignment were slightly mismatched between the two.
