### PR TITLE
Refactor Conditional Questions Tests

### DIFF
--- a/spec/controllers/answers_controller_with_conditional_questions_spec.rb
+++ b/spec/controllers/answers_controller_with_conditional_questions_spec.rb
@@ -11,63 +11,61 @@ RSpec.describe AnswersController, type: :controller do
     @section1, @section2, @section3 = template.sections
 
     # Different types of questions (than can have conditional options)
-    @checkbox_conditional_question = create(:question, :checkbox, section: @section1, options: 5)
-    @radiobutton_conditional_question = create(:question, :radiobuttons, section: @section2, options: 5)
-    @dropdown_conditional_question = create(:question, :dropdown, section: @section3, options: 5)
-
-    @conditional_questions = [@checkbox_conditional_question, @radiobutton_conditional_question,
-                              @dropdown_conditional_question]
+    @conditional_questions = {
+      checkbox: create(:question, :checkbox, section: @section1, options: 5),
+      radiobutton: create(:question, :radiobuttons, section: @section2, options: 5),
+      dropdown: create(:question, :dropdown, section: @section3, options: 5)
+    }
 
     # Questions that do not have conditional options for adding or removing
-    @textarea_questions = create_list(:question, 7, :textarea, section: @section1)
-    @textfield_questions = create_list(:question, 7, :textfield, section: @section2)
-    @date_questions = create_list(:question, 7, :date, section: @section3)
-    @rda_metadata_questions = create_list(:question, 7, :rda_metadata, section: @section1, options: 3)
-    @checkbox_questions = create_list(:question, 7, :checkbox, section: @section2, options: 3)
-    @radiobuttons_questions = create_list(:question, 7, :radiobuttons, section: @section3, options: 3)
-    @dropdown_questions = create_list(:question, 7, :dropdown, section: @section1, options: 3)
-    @multiselectbox_questions = create_list(:question, 7, :multiselectbox, section: @section2, options: 3)
+    @non_conditional_questions = {
+      textarea: create_list(:question, 7, :textarea, section: @section1),
+      textfield: create_list(:question, 7, :textfield, section: @section2),
+      date: create_list(:question, 7, :date, section: @section3),
+      rda_metadata: create_list(:question, 7, :rda_metadata, section: @section1, options: 3),
+      checkbox: create_list(:question, 7, :checkbox, section: @section2, options: 3),
+      radiobutton: create_list(:question, 7, :radiobuttons, section: @section3, options: 3),
+      dropdown: create_list(:question, 7, :dropdown, section: @section1, options: 3),
+      multiselectbox: create_list(:question, 7, :multiselectbox, section: @section2, options: 3)
+    }
 
     @plan = create(:plan, :creator, template: template)
     @user = @plan.owner
 
     # Answer the questions in List2
-    @textarea_answers = @textarea_questions.each.map do |question|
+    @textarea_answers = @non_conditional_questions[:textarea].each.map do |question|
       create(:answer, plan: @plan, question: question, user: @user)
     end
 
-    @textfield_answers = @textfield_questions.each.map do |question|
+    @textfield_answers = @non_conditional_questions[:textfield].each.map do |question|
       create(:answer, plan: @plan, question: question, user: @user)
     end
 
-    @date_answers = @date_questions.each.map do |question|
+    @date_answers = @non_conditional_questions[:date].each.map do |question|
       create(:answer, plan: @plan, question: question, user: @user)
     end
 
-    @rda_metadata_answers = @rda_metadata_questions.each.map do |question|
+    @rda_metadata_answers = @non_conditional_questions[:rda_metadata].each.map do |question|
       create(:answer, plan: @plan, question: question, user: @user)
     end
 
-    @checkbox_answers = @checkbox_questions.each.map do |question|
+    @checkbox_answers = @non_conditional_questions[:checkbox].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
 
-    @radiobuttons_answers = @radiobuttons_questions.each.map do |question|
+    @radiobuttons_answers = @non_conditional_questions[:radiobutton].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
 
-    @dropdown_answers = @dropdown_questions.each.map do |question|
+    @dropdown_answers = @non_conditional_questions[:dropdown].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
 
-    @multiselectbox_answers = @multiselectbox_questions.each.map do |question|
+    @multiselectbox_answers = @non_conditional_questions[:multiselectbox].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
 
-    @all_questions_ids = (@conditional_questions + @textarea_questions + @textfield_questions +
-                          @date_questions + @rda_metadata_questions +
-                          @checkbox_questions + @radiobuttons_questions +
-                          @dropdown_questions + @multiselectbox_questions).map(&:id)
+    @all_questions_ids = (@conditional_questions.values + @non_conditional_questions.values.flatten).map(&:id)
 
     @all_answers_ids = (@textarea_answers + @textfield_answers +
                         @date_answers + @rda_metadata_answers +
@@ -89,21 +87,21 @@ RSpec.describe AnswersController, type: :controller do
       # NOTE: Checkboxes allow for multiple options to be selected.
       context 'with conditional checkbox question' do
         it 'handles single option (with condition) in option_list ' do
-          condition = create(:condition, question: @checkbox_conditional_question,
-                                         option_list: [@checkbox_conditional_question.question_options[2].id],
+          condition = create(:condition, question: @conditional_questions[:checkbox],
+                                         option_list: [@conditional_questions[:checkbox].question_options[2].id],
                                          action_type: 'remove',
-                                         remove_data: [@textarea_questions[5].id, @textfield_questions[5].id,
-                                                       @date_questions[5].id, @rda_metadata_questions[5].id,
-                                                       @checkbox_questions[5].id, @radiobuttons_questions[5].id,
-                                                       @dropdown_questions[5].id, @multiselectbox_questions[5].id])
+                                         remove_data: [@non_conditional_questions[:textarea][5].id, @non_conditional_questions[:textfield][5].id,
+                                                       @non_conditional_questions[:date][5].id, @non_conditional_questions[:rda_metadata][5].id,
+                                                       @non_conditional_questions[:checkbox][5].id, @non_conditional_questions[:radiobutton][5].id,
+                                                       @non_conditional_questions[:dropdown][5].id, @non_conditional_questions[:multiselectbox][5].id])
 
           #  We chose an option that is in the option_list of the condition defined above. Note that
           # the text sent by UI is an empty string.
           args = {
             text: '',
-            question_option_ids: [@checkbox_conditional_question.question_options[2].id],
+            question_option_ids: [@conditional_questions[:checkbox].question_options[2].id],
             user_id: @user.id,
-            question_id: @checkbox_conditional_question.id,
+            question_id: @conditional_questions[:checkbox].id,
             plan_id: @plan.id,
             lock_version: 0
           }
@@ -131,28 +129,28 @@ RSpec.describe AnswersController, type: :controller do
           )
         end
         it 'handles single option (without condition) in option_list' do
-          create(:condition, question: @checkbox_conditional_question,
-                             option_list: [@checkbox_conditional_question.question_options[1].id],
+          create(:condition, question: @conditional_questions[:checkbox],
+                             option_list: [@conditional_questions[:checkbox].question_options[1].id],
                              action_type: 'remove',
-                             remove_data: [@textarea_questions[3].id, @textfield_questions[3].id,
-                                           @date_questions[3].id, @rda_metadata_questions[3].id,
-                                           @checkbox_questions[3].id, @dropdown_questions[3].id,
-                                           @multiselectbox_questions[3].id])
+                             remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
+                                           @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
+                                           @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
+                                           @non_conditional_questions[:multiselectbox][3].id])
 
-          create(:condition, question: @checkbox_conditional_question,
-                             option_list: [@checkbox_conditional_question.question_options[4].id],
+          create(:condition, question: @conditional_questions[:checkbox],
+                             option_list: [@conditional_questions[:checkbox].question_options[4].id],
                              action_type: 'remove',
-                             remove_data: [@textarea_questions[0].id, @textfield_questions[0].id,
-                                           @date_questions[0].id, @rda_metadata_questions[0].id,
-                                           @checkbox_questions[0].id, @dropdown_questions[0].id,
-                                           @multiselectbox_questions[0].id])
+                             remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
+                                           @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
+                                           @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
+                                           @non_conditional_questions[:multiselectbox][0].id])
 
           # We choose an option that is not in the option_list of the conditions defined above.
           args = {
             text: '',
-            question_option_ids: [@checkbox_conditional_question.question_options[0].id],
+            question_option_ids: [@conditional_questions[:checkbox].question_options[0].id],
             user_id: @user.id,
-            question_id: @checkbox_conditional_question.id,
+            question_id: @conditional_questions[:checkbox].id,
             plan_id: @plan.id,
             lock_version: 0
           }
@@ -165,30 +163,30 @@ RSpec.describe AnswersController, type: :controller do
         end
 
         it 'handles multiple options (some with conditions) in option_list' do
-          condition1 = create(:condition, question: @checkbox_conditional_question,
-                                          option_list: [@checkbox_conditional_question.question_options[2].id],
+          condition1 = create(:condition, question: @conditional_questions[:checkbox],
+                                          option_list: [@conditional_questions[:checkbox].question_options[2].id],
                                           action_type: 'remove',
-                                          remove_data: [@textarea_questions[0].id, @textfield_questions[0].id,
-                                                        @date_questions[0].id, @rda_metadata_questions[0].id,
-                                                        @checkbox_questions[0].id, @dropdown_questions[0].id,
-                                                        @multiselectbox_questions[0].id])
+                                          remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
+                                                        @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
+                                                        @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
+                                                        @non_conditional_questions[:multiselectbox][0].id])
 
-          condition2 = create(:condition, question: @checkbox_conditional_question,
-                                          option_list: [@checkbox_conditional_question.question_options[4].id],
+          condition2 = create(:condition, question: @conditional_questions[:checkbox],
+                                          option_list: [@conditional_questions[:checkbox].question_options[4].id],
                                           action_type: 'remove',
-                                          remove_data: [@textarea_questions[3].id, @textfield_questions[3].id,
-                                                        @date_questions[3].id, @rda_metadata_questions[3].id,
-                                                        @checkbox_questions[3].id, @dropdown_questions[3].id,
-                                                        @multiselectbox_questions[3].id])
+                                          remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
+                                                        @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
+                                                        @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
+                                                        @non_conditional_questions[:multiselectbox][3].id])
 
           # We choose options that is in the option_list of the conditions defined above as well as an option
           # with no condition defined.
           args = {
-            question_option_ids: [@checkbox_conditional_question.question_options[1].id,
-                                  @checkbox_conditional_question.question_options[2].id,
-                                  @checkbox_conditional_question.question_options[4].id],
+            question_option_ids: [@conditional_questions[:checkbox].question_options[1].id,
+                                  @conditional_questions[:checkbox].question_options[2].id,
+                                  @conditional_questions[:checkbox].question_options[4].id],
             user_id: @user.id,
-            question_id: @checkbox_conditional_question.id,
+            question_id: @conditional_questions[:checkbox].id,
             plan_id: @plan.id,
             lock_version: 0
           }
@@ -206,20 +204,20 @@ RSpec.describe AnswersController, type: :controller do
       #  Note: radiobuttons only allow single selection.
       context 'with conditional radiobuttons question' do
         it 'handles single option (with condition) in option_list ' do
-          condition = create(:condition, question: @radiobutton_conditional_question,
-                                         option_list: [@radiobutton_conditional_question.question_options[2].id],
+          condition = create(:condition, question: @conditional_questions[:radiobutton],
+                                         option_list: [@conditional_questions[:radiobutton].question_options[2].id],
                                          action_type: 'remove',
-                                         remove_data: [@textarea_questions[5].id, @textfield_questions[5].id,
-                                                       @date_questions[5].id, @rda_metadata_questions[5].id,
-                                                       @checkbox_questions[5].id, @radiobuttons_questions[5].id,
-                                                       @dropdown_questions[5].id, @multiselectbox_questions[5].id])
+                                         remove_data: [@non_conditional_questions[:textarea][5].id, @non_conditional_questions[:textfield][5].id,
+                                                       @non_conditional_questions[:date][5].id, @non_conditional_questions[:rda_metadata][5].id,
+                                                       @non_conditional_questions[:checkbox][5].id, @non_conditional_questions[:radiobutton][5].id,
+                                                       @non_conditional_questions[:dropdown][5].id, @non_conditional_questions[:multiselectbox][5].id])
 
           # We choose an option that is in the option_list of the condition defined above.
           args = {
             text: '',
-            question_option_ids: [@radiobutton_conditional_question.question_options[2].id],
+            question_option_ids: [@conditional_questions[:radiobutton].question_options[2].id],
             user_id: @user.id,
-            question_id: @radiobutton_conditional_question.id,
+            question_id: @conditional_questions[:radiobutton].id,
             plan_id: @plan.id,
             lock_version: 0
           }
@@ -233,28 +231,28 @@ RSpec.describe AnswersController, type: :controller do
           expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
         end
         it 'handles single option (without condition) in option_list' do
-          create(:condition, question: @radiobutton_conditional_question,
-                             option_list: [@radiobutton_conditional_question.question_options[1].id],
+          create(:condition, question: @conditional_questions[:radiobutton],
+                             option_list: [@conditional_questions[:radiobutton].question_options[1].id],
                              action_type: 'remove',
-                             remove_data: [@textarea_questions[3].id, @textfield_questions[3].id,
-                                           @date_questions[3].id, @rda_metadata_questions[3].id,
-                                           @checkbox_questions[3].id, @dropdown_questions[3].id,
-                                           @multiselectbox_questions[3].id])
+                             remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
+                                           @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
+                                           @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
+                                           @non_conditional_questions[:multiselectbox][3].id])
 
-          create(:condition, question: @radiobutton_conditional_question,
-                             option_list: [@radiobutton_conditional_question.question_options[4].id],
+          create(:condition, question: @conditional_questions[:radiobutton],
+                             option_list: [@conditional_questions[:radiobutton].question_options[4].id],
                              action_type: 'remove',
-                             remove_data: [@textarea_questions[0].id, @textfield_questions[0].id,
-                                           @date_questions[0].id, @rda_metadata_questions[0].id,
-                                           @checkbox_questions[0].id, @dropdown_questions[0].id,
-                                           @multiselectbox_questions[0].id])
+                             remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
+                                           @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
+                                           @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
+                                           @non_conditional_questions[:multiselectbox][0].id])
 
           # We choose an option that is not in the option_list of the conditions defined above.
           args = {
             text: '',
-            question_option_ids: [@radiobutton_conditional_question.question_options[0].id],
+            question_option_ids: [@conditional_questions[:radiobutton].question_options[0].id],
             user_id: @user.id,
-            question_id: @radiobutton_conditional_question.id,
+            question_id: @conditional_questions[:radiobutton].id,
             plan_id: @plan.id,
             lock_version: 0
           }
@@ -270,20 +268,20 @@ RSpec.describe AnswersController, type: :controller do
       # NOTE: dropdowns only allow single selection.
       context 'with conditional dropdown question' do
         it 'handles single option (with condition) in option_list ' do
-          condition = create(:condition, question: @dropdown_conditional_question,
-                                         option_list: [@dropdown_conditional_question.question_options[2].id],
+          condition = create(:condition, question: @conditional_questions[:dropdown],
+                                         option_list: [@conditional_questions[:dropdown].question_options[2].id],
                                          action_type: 'remove',
-                                         remove_data: [@textarea_questions[5].id, @textfield_questions[5].id,
-                                                       @date_questions[5].id, @rda_metadata_questions[5].id,
-                                                       @checkbox_questions[5].id, @radiobuttons_questions[5].id,
-                                                       @dropdown_questions[5].id, @multiselectbox_questions[5].id])
+                                         remove_data: [@non_conditional_questions[:textarea][5].id, @non_conditional_questions[:textfield][5].id,
+                                                       @non_conditional_questions[:date][5].id, @non_conditional_questions[:rda_metadata][5].id,
+                                                       @non_conditional_questions[:checkbox][5].id, @non_conditional_questions[:radiobutton][5].id,
+                                                       @non_conditional_questions[:dropdown][5].id, @non_conditional_questions[:multiselectbox][5].id])
 
           #  We chose an option that is in the option_list of the condition defined above.
           args = {
-            text: @dropdown_conditional_question.question_options[2].text,
-            question_option_ids: [@dropdown_conditional_question.question_options[2].id],
+            text: @conditional_questions[:dropdown].question_options[2].text,
+            question_option_ids: [@conditional_questions[:dropdown].question_options[2].id],
             user_id: @user.id,
-            question_id: @dropdown_conditional_question.id,
+            question_id: @conditional_questions[:dropdown].id,
             plan_id: @plan.id,
             lock_version: 0
           }
@@ -297,28 +295,28 @@ RSpec.describe AnswersController, type: :controller do
           expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
         end
         it 'handles single option (without condition) in option_list' do
-          create(:condition, question: @dropdown_conditional_question,
-                             option_list: [@dropdown_conditional_question.question_options[1].id],
+          create(:condition, question: @conditional_questions[:dropdown],
+                             option_list: [@conditional_questions[:dropdown].question_options[1].id],
                              action_type: 'remove',
-                             remove_data: [@textarea_questions[3].id, @textfield_questions[3].id,
-                                           @date_questions[3].id, @rda_metadata_questions[3].id,
-                                           @checkbox_questions[3].id, @dropdown_questions[3].id,
-                                           @multiselectbox_questions[3].id])
+                             remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
+                                           @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
+                                           @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
+                                           @non_conditional_questions[:multiselectbox][3].id])
 
-          create(:condition, question: @dropdown_conditional_question,
-                             option_list: [@dropdown_conditional_question.question_options[4].id],
+          create(:condition, question: @conditional_questions[:dropdown],
+                             option_list: [@conditional_questions[:dropdown].question_options[4].id],
                              action_type: 'remove',
-                             remove_data: [@textarea_questions[0].id, @textfield_questions[0].id,
-                                           @date_questions[0].id, @rda_metadata_questions[0].id,
-                                           @checkbox_questions[0].id, @dropdown_questions[0].id,
-                                           @multiselectbox_questions[0].id])
+                             remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
+                                           @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
+                                           @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
+                                           @non_conditional_questions[:multiselectbox][0].id])
 
           # We choose an option that is not in the option_list of the conditions defined above.
           args = {
             text: '',
-            question_option_ids: [@dropdown_conditional_question.question_options[0].id],
+            question_option_ids: [@conditional_questions[:dropdown].question_options[0].id],
             user_id: @user.id,
-            question_id: @dropdown_conditional_question.id,
+            question_id: @conditional_questions[:dropdown].id,
             plan_id: @plan.id,
             lock_version: 0
           }
@@ -343,16 +341,16 @@ RSpec.describe AnswersController, type: :controller do
       it 'handles a checkbox option (with add_webhook condition)' do
         add_webhook_condition = create(
           :condition, :webhook,
-          question: @checkbox_conditional_question,
-          option_list: [@checkbox_conditional_question.question_options[2].id]
+          question: @conditional_questions[:checkbox],
+          option_list: [@conditional_questions[:checkbox].question_options[2].id]
         )
         #  We chose an option that is in the option_list of the condition defined above. Note that
         # the text sent by UI is an empty string.
         args = {
           text: '',
-          question_option_ids: [@checkbox_conditional_question.question_options[2].id],
+          question_option_ids: [@conditional_questions[:checkbox].question_options[2].id],
           user_id: @user.id,
-          question_id: @checkbox_conditional_question.id,
+          question_id: @conditional_questions[:checkbox].id,
           plan_id: @plan.id,
           lock_version: 0
         }
@@ -381,33 +379,33 @@ RSpec.describe AnswersController, type: :controller do
 
           # Message should have @user.name, chosen option text and question text.
           expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@checkbox_conditional_question.question_options[2].text)
-          expect(mail.body.encoded).to include(@checkbox_conditional_question.text)
+          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].question_options[2].text)
+          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].text)
         end
       end
       it 'handles multiple checkbox options (one of which is add_webhook condition)' do
         add_webhook_condition = create(:condition,
                                        :webhook,
-                                       question: @checkbox_conditional_question,
-                                       option_list: [@checkbox_conditional_question.question_options[2].id])
+                                       question: @conditional_questions[:checkbox],
+                                       option_list: [@conditional_questions[:checkbox].question_options[2].id])
 
-        condition2 = create(:condition, question: @checkbox_conditional_question,
-                                        option_list: [@checkbox_conditional_question.question_options[4].id],
+        condition2 = create(:condition, question: @conditional_questions[:checkbox],
+                                        option_list: [@conditional_questions[:checkbox].question_options[4].id],
                                         action_type: 'remove',
-                                        remove_data: [@textarea_questions[3].id, @textfield_questions[3].id,
-                                                      @date_questions[3].id, @rda_metadata_questions[3].id,
-                                                      @checkbox_questions[3].id, @dropdown_questions[3].id,
-                                                      @multiselectbox_questions[3].id])
+                                        remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
+                                                      @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
+                                                      @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
+                                                      @non_conditional_questions[:multiselectbox][3].id])
 
         #  We chose an option that is in the option_list of the condition defined above. Note that
         # the text sent by UI is an empty string.
         args = {
           text: '',
-          question_option_ids: [@checkbox_conditional_question.question_options[2].id,
-                                @checkbox_conditional_question.question_options[4].id,
-                                @checkbox_conditional_question.question_options[1].id],
+          question_option_ids: [@conditional_questions[:checkbox].question_options[2].id,
+                                @conditional_questions[:checkbox].question_options[4].id,
+                                @conditional_questions[:checkbox].question_options[1].id],
           user_id: @user.id,
-          question_id: @checkbox_conditional_question.id,
+          question_id: @conditional_questions[:checkbox].id,
           plan_id: @plan.id,
           lock_version: 0
         }
@@ -437,24 +435,24 @@ RSpec.describe AnswersController, type: :controller do
 
           # Message should have @user.name, chosen option text and question text.
           expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@checkbox_conditional_question.question_options[2].text)
-          expect(mail.body.encoded).to include(@checkbox_conditional_question.text)
+          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].question_options[2].text)
+          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].text)
         end
       end
 
       it 'handles selection of a dropdown option (with add_webhook condition)' do
         add_webhook_condition = create(:condition,
                                        :webhook,
-                                       question: @dropdown_conditional_question,
-                                       option_list: [@dropdown_conditional_question.question_options[2].id])
+                                       question: @conditional_questions[:dropdown],
+                                       option_list: [@conditional_questions[:dropdown].question_options[2].id])
 
         #  We chose an option that is in the option_list of the condition defined above. Note that
         # the text sent by UI is an empty string.
         args = {
           text: '',
-          question_option_ids: [@dropdown_conditional_question.question_options[2].id],
+          question_option_ids: [@conditional_questions[:dropdown].question_options[2].id],
           user_id: @user.id,
-          question_id: @dropdown_conditional_question.id,
+          question_id: @conditional_questions[:dropdown].id,
           plan_id: @plan.id,
           lock_version: 0
         }
@@ -483,24 +481,24 @@ RSpec.describe AnswersController, type: :controller do
 
           # Message should have @user.name, chosen option text and question text.
           expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@dropdown_conditional_question.question_options[2].text)
-          expect(mail.body.encoded).to include(@dropdown_conditional_question.text)
+          expect(mail.body.encoded).to include(@conditional_questions[:dropdown].question_options[2].text)
+          expect(mail.body.encoded).to include(@conditional_questions[:dropdown].text)
         end
       end
 
       it 'handles selection of a radiobutton option (with add_webhook condition)' do
         add_webhook_condition = create(:condition,
                                        :webhook,
-                                       question: @radiobutton_conditional_question,
-                                       option_list: [@radiobutton_conditional_question.question_options[2].id])
+                                       question: @conditional_questions[:radiobutton],
+                                       option_list: [@conditional_questions[:radiobutton].question_options[2].id])
 
         #  We chose an option that is in the option_list of the condition defined above. Note that
         # the text sent by UI is an empty string.
         args = {
           text: '',
-          question_option_ids: [@radiobutton_conditional_question.question_options[2].id],
+          question_option_ids: [@conditional_questions[:radiobutton].question_options[2].id],
           user_id: @user.id,
-          question_id: @radiobutton_conditional_question.id,
+          question_id: @conditional_questions[:radiobutton].id,
           plan_id: @plan.id,
           lock_version: 0
         }
@@ -529,8 +527,8 @@ RSpec.describe AnswersController, type: :controller do
 
           # Message should have @user.name, chosen option text and question text.
           expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@radiobutton_conditional_question.question_options[2].text)
-          expect(mail.body.encoded).to include(@radiobutton_conditional_question.text)
+          expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].question_options[2].text)
+          expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].text)
         end
       end
     end

--- a/spec/controllers/answers_controller_with_conditional_questions_spec.rb
+++ b/spec/controllers/answers_controller_with_conditional_questions_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe AnswersController, type: :controller do
   include RolesHelper
+  include ConditionalQuestionsHelper
 
   before(:each) do
     template = create(:template, phases: 1, sections: 3)
@@ -11,10 +12,10 @@ RSpec.describe AnswersController, type: :controller do
     @section1, @section2, @section3 = template.sections
 
     # Different types of questions (than can have conditional options)
-    @conditional_questions = create_conditional_questions
+    @conditional_questions = create_conditional_questions(5)
 
     # Questions that do not have conditional options for adding or removing
-    @non_conditional_questions = create_non_conditional_questions
+    @non_conditional_questions = create_non_conditional_questions(7, 3)
 
     @plan = create(:plan, :creator, template: template)
     @user = @plan.owner
@@ -375,66 +376,5 @@ RSpec.describe AnswersController, type: :controller do
         check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :radiobutton)
       end
     end
-  end
-
-  private
-
-  def create_conditional_questions
-    {
-      checkbox: create(:question, :checkbox, section: @section1, options: 5),
-      radiobutton: create(:question, :radiobuttons, section: @section2, options: 5),
-      dropdown: create(:question, :dropdown, section: @section3, options: 5)
-    }
-  end
-
-  def create_non_conditional_questions
-    {
-      textarea: create_list(:question, 7, :textarea, section: @section1),
-      textfield: create_list(:question, 7, :textfield, section: @section2),
-      date: create_list(:question, 7, :date, section: @section3),
-      rda_metadata: create_list(:question, 7, :rda_metadata, section: @section1, options: 3),
-      checkbox: create_list(:question, 7, :checkbox, section: @section2, options: 3),
-      radiobutton: create_list(:question, 7, :radiobuttons, section: @section3, options: 3),
-      dropdown: create_list(:question, 7, :dropdown, section: @section1, options: 3),
-      multiselectbox: create_list(:question, 7, :multiselectbox, section: @section2, options: 3)
-    }
-  end
-
-  def non_conditional_questions_ids_by_index(index)
-    @non_conditional_questions.map { |_, questions| questions[index].id }
-  end
-
-  def create_answers
-    question_types_with_question_options = %i[checkbox radiobutton dropdown multiselectbox]
-    answers = {}
-    @non_conditional_questions.each do |question_type, questions|
-      answers[question_type] = questions.map do |question|
-        if question_types_with_question_options.include?(question_type)
-          create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-        else
-          create(:answer, plan: @plan, question: question, user: @user)
-        end
-      end
-    end
-    answers
-  end
-
-  def check_delivered_mail_for_webhook_data_and_question_data(webhook_data, question_type)
-    ActionMailer::Base.deliveries.first do |mail|
-      expect(mail.to).to eq([webhook_data['email']])
-      expect(mail.subject).to eq(webhook_data['subject'])
-      expect(mail.body.encoded).to include(webhook_data['message'])
-      # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-
-      # Message should have @user.name, chosen option text and question text.
-      expect(mail.body.encoded).to include(@user.name)
-      expect(mail.body.encoded).to include(@conditional_questions[question_type].question_options[2].text)
-      expect(mail.body.encoded).to include(@conditional_questions[question_type].text)
-    end
-  end
-
-  def check_question_ids_to_show_and_hide(json, question_ids_to_hide = [])
-    expect(json[:qn_data][:to_show]).to match_array(@all_questions_ids - question_ids_to_hide)
-    expect(json[:qn_data][:to_hide]).to match_array(question_ids_to_hide)
   end
 end

--- a/spec/controllers/answers_controller_with_conditional_questions_spec.rb
+++ b/spec/controllers/answers_controller_with_conditional_questions_spec.rb
@@ -33,44 +33,20 @@ RSpec.describe AnswersController, type: :controller do
     @user = @plan.owner
 
     # Answer the questions in List2
-    @textarea_answers = @non_conditional_questions[:textarea].each.map do |question|
-      create(:answer, plan: @plan, question: question, user: @user)
-    end
-
-    @textfield_answers = @non_conditional_questions[:textfield].each.map do |question|
-      create(:answer, plan: @plan, question: question, user: @user)
-    end
-
-    @date_answers = @non_conditional_questions[:date].each.map do |question|
-      create(:answer, plan: @plan, question: question, user: @user)
-    end
-
-    @rda_metadata_answers = @non_conditional_questions[:rda_metadata].each.map do |question|
-      create(:answer, plan: @plan, question: question, user: @user)
-    end
-
-    @checkbox_answers = @non_conditional_questions[:checkbox].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-
-    @radiobuttons_answers = @non_conditional_questions[:radiobutton].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-
-    @dropdown_answers = @non_conditional_questions[:dropdown].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-
-    @multiselectbox_answers = @non_conditional_questions[:multiselectbox].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
+    @answers = {}
+    @non_conditional_questions.each do |question_type, questions|
+      @answers[question_type] = questions.map do |question|
+        if %i[textarea textfield date rda_metadata].include?(question_type)
+          create(:answer, plan: @plan, question: question, user: @user)
+        else
+          create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
+        end
+      end
     end
 
     @all_questions_ids = (@conditional_questions.values + @non_conditional_questions.values.flatten).map(&:id)
 
-    @all_answers_ids = (@textarea_answers + @textfield_answers +
-                        @date_answers + @rda_metadata_answers +
-                        @checkbox_answers + @radiobuttons_answers +
-                        @dropdown_answers + @multiselectbox_answers).map(&:id)
+    @all_answers_ids = @answers.values.flatten.map(&:id)
 
     sign_in(@user)
   end
@@ -118,10 +94,10 @@ RSpec.describe AnswersController, type: :controller do
 
           #  Check Answers in database (persisted). Expect removed answers to be destroyed.
           # Answers destroyed eare easier checked using array of ids rather than individually as in example
-          # expect(Answer.exists?(@textarea_answers[5].id)).to be_falsey.
-          removed_answers = [@textarea_answers[5].id, @textfield_answers[5].id,
-                             @date_answers[5].id, @rda_metadata_answers[5].id, @checkbox_answers[5].id,
-                             @radiobuttons_answers[5].id, @dropdown_answers[5].id, @multiselectbox_answers[5].id]
+          # expect(Answer.exists?(@answers[:textarea][5].id)).to be_falsey.
+          removed_answers = [@answers[:textarea][5].id, @answers[:textfield][5].id,
+                             @answers[:date][5].id, @answers[:rda_metadata][5].id, @answers[:checkbox][5].id,
+                             @answers[:radiobutton][5].id, @answers[:dropdown][5].id, @answers[:multiselectbox][5].id]
           expect(Answer.where(id: removed_answers).pluck(:id)).to be_empty
           # Answers left
           expect(Answer.where(id: @all_answers_ids).pluck(:id)).to match_array(

--- a/spec/controllers/answers_controller_with_conditional_questions_spec.rb
+++ b/spec/controllers/answers_controller_with_conditional_questions_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe AnswersController, type: :controller do
   before(:each) do
     template = create(:template, phases: 1, sections: 3)
     # 3 sections for ensuring that conditions involve questions in different sections.
-    @section1 = template.sections[0]
-    @section2 = template.sections[1]
-    @section3 = template.sections[2]
+    @section1, @section2, @section3 = template.sections
 
     # Different types of questions (than can have conditional options)
     @checkbox_conditional_question = create(:question, :checkbox, section: @section1, options: 5)

--- a/spec/controllers/answers_controller_with_conditional_questions_spec.rb
+++ b/spec/controllers/answers_controller_with_conditional_questions_spec.rb
@@ -61,10 +61,7 @@ RSpec.describe AnswersController, type: :controller do
           json = JSON.parse(response.body).with_indifferent_access
 
           # Check hide/show questions lists sent to frontend.
-          expected_to_show_question_ids = @all_questions_ids - condition.remove_data
-          expected_to_hide_question_ids = condition.remove_data
-          expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-          expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+          check_question_ids_to_show_and_hide(json, condition.remove_data)
 
           #  Check Answers in database (persisted). Expect removed answers to be destroyed.
           # Answers destroyed eare easier checked using array of ids rather than individually as in example
@@ -100,8 +97,7 @@ RSpec.describe AnswersController, type: :controller do
           post :create_or_update, params: { answer: args }
 
           json = JSON.parse(response.body).with_indifferent_access
-          expect(json[:qn_data][:to_show]).to match_array(@all_questions_ids)
-          expect(json[:qn_data][:to_hide]).to match_array([])
+          check_question_ids_to_show_and_hide(json)
         end
 
         it 'handles multiple options (some with conditions) in option_list' do
@@ -130,11 +126,8 @@ RSpec.describe AnswersController, type: :controller do
           post :create_or_update, params: { answer: args }
 
           json = JSON.parse(response.body).with_indifferent_access
-
-          expected_to_show_question_ids = @all_questions_ids - condition1.remove_data - condition2.remove_data
-          expected_to_hide_question_ids = condition1.remove_data + condition2.remove_data
-          expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-          expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+          remove_data = condition1.remove_data + condition2.remove_data
+          check_question_ids_to_show_and_hide(json, remove_data)
         end
       end
       #  Note: radiobuttons only allow single selection.
@@ -158,10 +151,7 @@ RSpec.describe AnswersController, type: :controller do
           post :create_or_update, params: { answer: args }
 
           json = JSON.parse(response.body).with_indifferent_access
-          expected_to_show_question_ids = @all_questions_ids - condition.remove_data
-          expected_to_hide_question_ids = condition.remove_data
-          expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-          expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+          check_question_ids_to_show_and_hide(json, condition.remove_data)
         end
         it 'handles single option (without condition) in option_list' do
           create(:condition, question: @conditional_questions[:radiobutton],
@@ -187,8 +177,7 @@ RSpec.describe AnswersController, type: :controller do
           post :create_or_update, params: { answer: args }
 
           json = JSON.parse(response.body).with_indifferent_access
-          expect(json[:qn_data][:to_show]).to match_array(@all_questions_ids)
-          expect(json[:qn_data][:to_hide]).to match_array([])
+          check_question_ids_to_show_and_hide(json)
         end
       end
 
@@ -213,10 +202,7 @@ RSpec.describe AnswersController, type: :controller do
           post :create_or_update, params: { answer: args }
 
           json = JSON.parse(response.body).with_indifferent_access
-          expected_to_show_question_ids = @all_questions_ids - condition.remove_data
-          expected_to_hide_question_ids = condition.remove_data
-          expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-          expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+          check_question_ids_to_show_and_hide(json, condition.remove_data)
         end
         it 'handles single option (without condition) in option_list' do
           create(:condition, question: @conditional_questions[:dropdown],
@@ -242,8 +228,7 @@ RSpec.describe AnswersController, type: :controller do
           post :create_or_update, params: { answer: args }
 
           json = JSON.parse(response.body).with_indifferent_access
-          expect(json[:qn_data][:to_show]).to match_array(@all_questions_ids)
-          expect(json[:qn_data][:to_hide]).to match_array([])
+          check_question_ids_to_show_and_hide(json)
         end
       end
     end
@@ -276,19 +261,14 @@ RSpec.describe AnswersController, type: :controller do
         post :create_or_update, params: { answer: args }
 
         json = JSON.parse(response.body).with_indifferent_access
-
         # Check hide/show questions lists sent to frontend.
-        expected_to_show_question_ids = @all_questions_ids - add_webhook_condition.remove_data
-        expected_to_hide_question_ids = add_webhook_condition.remove_data
-        expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-        expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+        check_question_ids_to_show_and_hide(json, add_webhook_condition.remove_data)
 
         # An email should have been sent to the configured recipient in the webhook.
         # The webhook_data is a Json string of form:
         # '{"name":"Joe Bloggs","email":"joe.bloggs@example.com","subject":"Large data volume","message":"A message."}'
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
-
         check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :checkbox)
       end
       it 'handles multiple checkbox options (one of which is add_webhook condition)' do
@@ -320,18 +300,14 @@ RSpec.describe AnswersController, type: :controller do
         json = JSON.parse(response.body).with_indifferent_access
 
         # Check hide/show questions lists sent to frontend.
-        removed_data = add_webhook_condition.remove_data + condition2.remove_data
-        expected_to_show_question_ids = @all_questions_ids - removed_data
-        expected_to_hide_question_ids = add_webhook_condition.remove_data + condition2.remove_data
-        expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-        expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+        remove_data = add_webhook_condition.remove_data + condition2.remove_data
+        check_question_ids_to_show_and_hide(json, remove_data)
 
         # An email should have been sent to the configured recipient in the webhook.
         # The webhook_data is a Json string of form:
         # '{"name":"Joe Bloggs","email":"joe.bloggs@example.com","subject":"Large data volume","message":"A message."}'
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
-
         check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :checkbox)
       end
 
@@ -357,17 +333,13 @@ RSpec.describe AnswersController, type: :controller do
         json = JSON.parse(response.body).with_indifferent_access
 
         # Check hide/show questions lists sent to frontend.
-        expected_to_show_question_ids = @all_questions_ids - add_webhook_condition.remove_data
-        expected_to_hide_question_ids = add_webhook_condition.remove_data
-        expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-        expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+        check_question_ids_to_show_and_hide(json, add_webhook_condition.remove_data)
 
         # An email should have been sent to the configured recipient in the webhook.
         # The webhook_data is a Json string of form:
         # '{"name":"Joe Bloggs","email":"joe.bloggs@example.com","subject":"Large data volume","message":"A message."}'
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
-
         check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :dropdown)
       end
 
@@ -393,17 +365,13 @@ RSpec.describe AnswersController, type: :controller do
         json = JSON.parse(response.body).with_indifferent_access
 
         # Check hide/show questions lists sent to frontend.
-        expected_to_show_question_ids = @all_questions_ids - add_webhook_condition.remove_data
-        expected_to_hide_question_ids = add_webhook_condition.remove_data
-        expect(json[:qn_data][:to_show]).to match_array(expected_to_show_question_ids)
-        expect(json[:qn_data][:to_hide]).to match_array(expected_to_hide_question_ids)
+        check_question_ids_to_show_and_hide(json, add_webhook_condition.remove_data)
 
         # An email should have been sent to the configured recipient in the webhook.
         # The webhook_data is a Json string of form:
         # '{"name":"Joe Bloggs","email":"joe.bloggs@example.com","subject":"Large data volume","message":"A message."}'
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
-
         check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :radiobutton)
       end
     end
@@ -463,5 +431,10 @@ RSpec.describe AnswersController, type: :controller do
       expect(mail.body.encoded).to include(@conditional_questions[question_type].question_options[2].text)
       expect(mail.body.encoded).to include(@conditional_questions[question_type].text)
     end
+  end
+
+  def check_question_ids_to_show_and_hide(json, question_ids_to_hide = [])
+    expect(json[:qn_data][:to_show]).to match_array(@all_questions_ids - question_ids_to_hide)
+    expect(json[:qn_data][:to_hide]).to match_array(question_ids_to_hide)
   end
 end

--- a/spec/controllers/answers_controller_with_conditional_questions_spec.rb
+++ b/spec/controllers/answers_controller_with_conditional_questions_spec.rb
@@ -289,17 +289,7 @@ RSpec.describe AnswersController, type: :controller do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
 
-        ActionMailer::Base.deliveries.first do |mail|
-          expect(mail.to).to eq([webhook_data['email']])
-          expect(mail.subject).to eq(webhook_data['subject'])
-          expect(mail.body.encoded).to include(webhook_data['message'])
-          # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-
-          # Message should have @user.name, chosen option text and question text.
-          expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].question_options[2].text)
-          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].text)
-        end
+        check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :checkbox)
       end
       it 'handles multiple checkbox options (one of which is add_webhook condition)' do
         add_webhook_condition = create(:condition,
@@ -342,17 +332,7 @@ RSpec.describe AnswersController, type: :controller do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
 
-        ActionMailer::Base.deliveries.first do |mail|
-          expect(mail.to).to eq([webhook_data['email']])
-          expect(mail.subject).to eq(webhook_data['subject'])
-          expect(mail.body.encoded).to include(webhook_data['message'])
-          # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-
-          # Message should have @user.name, chosen option text and question text.
-          expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].question_options[2].text)
-          expect(mail.body.encoded).to include(@conditional_questions[:checkbox].text)
-        end
+        check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :checkbox)
       end
 
       it 'handles selection of a dropdown option (with add_webhook condition)' do
@@ -388,17 +368,7 @@ RSpec.describe AnswersController, type: :controller do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
 
-        ActionMailer::Base.deliveries.first do |mail|
-          expect(mail.to).to eq([webhook_data['email']])
-          expect(mail.subject).to eq(webhook_data['subject'])
-          expect(mail.body.encoded).to include(webhook_data['message'])
-          # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-
-          # Message should have @user.name, chosen option text and question text.
-          expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@conditional_questions[:dropdown].question_options[2].text)
-          expect(mail.body.encoded).to include(@conditional_questions[:dropdown].text)
-        end
+        check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :dropdown)
       end
 
       it 'handles selection of a radiobutton option (with add_webhook condition)' do
@@ -434,17 +404,7 @@ RSpec.describe AnswersController, type: :controller do
         expect(ActionMailer::Base.deliveries.count).to eq(1)
         webhook_data = JSON.parse(add_webhook_condition.webhook_data)
 
-        ActionMailer::Base.deliveries.first do |mail|
-          expect(mail.to).to eq([webhook_data['email']])
-          expect(mail.subject).to eq(webhook_data['subject'])
-          expect(mail.body.encoded).to include(webhook_data['message'])
-          # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-
-          # Message should have @user.name, chosen option text and question text.
-          expect(mail.body.encoded).to include(@user.name)
-          expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].question_options[2].text)
-          expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].text)
-        end
+        check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :radiobutton)
       end
     end
   end
@@ -489,5 +449,19 @@ RSpec.describe AnswersController, type: :controller do
       end
     end
     answers
+  end
+
+  def check_delivered_mail_for_webhook_data_and_question_data(webhook_data, question_type)
+    ActionMailer::Base.deliveries.first do |mail|
+      expect(mail.to).to eq([webhook_data['email']])
+      expect(mail.subject).to eq(webhook_data['subject'])
+      expect(mail.body.encoded).to include(webhook_data['message'])
+      # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
+
+      # Message should have @user.name, chosen option text and question text.
+      expect(mail.body.encoded).to include(@user.name)
+      expect(mail.body.encoded).to include(@conditional_questions[question_type].question_options[2].text)
+      expect(mail.body.encoded).to include(@conditional_questions[question_type].text)
+    end
   end
 end

--- a/spec/controllers/answers_controller_with_conditional_questions_spec.rb
+++ b/spec/controllers/answers_controller_with_conditional_questions_spec.rb
@@ -43,10 +43,7 @@ RSpec.describe AnswersController, type: :controller do
           condition = create(:condition, question: @conditional_questions[:checkbox],
                                          option_list: [@conditional_questions[:checkbox].question_options[2].id],
                                          action_type: 'remove',
-                                         remove_data: [@non_conditional_questions[:textarea][5].id, @non_conditional_questions[:textfield][5].id,
-                                                       @non_conditional_questions[:date][5].id, @non_conditional_questions[:rda_metadata][5].id,
-                                                       @non_conditional_questions[:checkbox][5].id, @non_conditional_questions[:radiobutton][5].id,
-                                                       @non_conditional_questions[:dropdown][5].id, @non_conditional_questions[:multiselectbox][5].id])
+                                         remove_data: non_conditional_questions_ids_by_index(5))
 
           #  We chose an option that is in the option_list of the condition defined above. Note that
           # the text sent by UI is an empty string.
@@ -72,9 +69,7 @@ RSpec.describe AnswersController, type: :controller do
           #  Check Answers in database (persisted). Expect removed answers to be destroyed.
           # Answers destroyed eare easier checked using array of ids rather than individually as in example
           # expect(Answer.exists?(@answers[:textarea][5].id)).to be_falsey.
-          removed_answers = [@answers[:textarea][5].id, @answers[:textfield][5].id,
-                             @answers[:date][5].id, @answers[:rda_metadata][5].id, @answers[:checkbox][5].id,
-                             @answers[:radiobutton][5].id, @answers[:dropdown][5].id, @answers[:multiselectbox][5].id]
+          removed_answers = @answers.map { |_, answers| answers[5].id }
           expect(Answer.where(id: removed_answers).pluck(:id)).to be_empty
           # Answers left
           expect(Answer.where(id: @all_answers_ids).pluck(:id)).to match_array(
@@ -85,18 +80,12 @@ RSpec.describe AnswersController, type: :controller do
           create(:condition, question: @conditional_questions[:checkbox],
                              option_list: [@conditional_questions[:checkbox].question_options[1].id],
                              action_type: 'remove',
-                             remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
-                                           @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
-                                           @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
-                                           @non_conditional_questions[:multiselectbox][3].id])
+                             remove_data: non_conditional_questions_ids_by_index(3))
 
           create(:condition, question: @conditional_questions[:checkbox],
                              option_list: [@conditional_questions[:checkbox].question_options[4].id],
                              action_type: 'remove',
-                             remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
-                                           @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
-                                           @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
-                                           @non_conditional_questions[:multiselectbox][0].id])
+                             remove_data: non_conditional_questions_ids_by_index(0))
 
           # We choose an option that is not in the option_list of the conditions defined above.
           args = {
@@ -119,18 +108,12 @@ RSpec.describe AnswersController, type: :controller do
           condition1 = create(:condition, question: @conditional_questions[:checkbox],
                                           option_list: [@conditional_questions[:checkbox].question_options[2].id],
                                           action_type: 'remove',
-                                          remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
-                                                        @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
-                                                        @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
-                                                        @non_conditional_questions[:multiselectbox][0].id])
+                                          remove_data: non_conditional_questions_ids_by_index(0))
 
           condition2 = create(:condition, question: @conditional_questions[:checkbox],
                                           option_list: [@conditional_questions[:checkbox].question_options[4].id],
                                           action_type: 'remove',
-                                          remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
-                                                        @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
-                                                        @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
-                                                        @non_conditional_questions[:multiselectbox][3].id])
+                                          remove_data: non_conditional_questions_ids_by_index(3))
 
           # We choose options that is in the option_list of the conditions defined above as well as an option
           # with no condition defined.
@@ -160,10 +143,7 @@ RSpec.describe AnswersController, type: :controller do
           condition = create(:condition, question: @conditional_questions[:radiobutton],
                                          option_list: [@conditional_questions[:radiobutton].question_options[2].id],
                                          action_type: 'remove',
-                                         remove_data: [@non_conditional_questions[:textarea][5].id, @non_conditional_questions[:textfield][5].id,
-                                                       @non_conditional_questions[:date][5].id, @non_conditional_questions[:rda_metadata][5].id,
-                                                       @non_conditional_questions[:checkbox][5].id, @non_conditional_questions[:radiobutton][5].id,
-                                                       @non_conditional_questions[:dropdown][5].id, @non_conditional_questions[:multiselectbox][5].id])
+                                         remove_data: non_conditional_questions_ids_by_index(5))
 
           # We choose an option that is in the option_list of the condition defined above.
           args = {
@@ -187,18 +167,12 @@ RSpec.describe AnswersController, type: :controller do
           create(:condition, question: @conditional_questions[:radiobutton],
                              option_list: [@conditional_questions[:radiobutton].question_options[1].id],
                              action_type: 'remove',
-                             remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
-                                           @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
-                                           @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
-                                           @non_conditional_questions[:multiselectbox][3].id])
+                             remove_data: non_conditional_questions_ids_by_index(3))
 
           create(:condition, question: @conditional_questions[:radiobutton],
                              option_list: [@conditional_questions[:radiobutton].question_options[4].id],
                              action_type: 'remove',
-                             remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
-                                           @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
-                                           @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
-                                           @non_conditional_questions[:multiselectbox][0].id])
+                             remove_data: non_conditional_questions_ids_by_index(0))
 
           # We choose an option that is not in the option_list of the conditions defined above.
           args = {
@@ -224,10 +198,7 @@ RSpec.describe AnswersController, type: :controller do
           condition = create(:condition, question: @conditional_questions[:dropdown],
                                          option_list: [@conditional_questions[:dropdown].question_options[2].id],
                                          action_type: 'remove',
-                                         remove_data: [@non_conditional_questions[:textarea][5].id, @non_conditional_questions[:textfield][5].id,
-                                                       @non_conditional_questions[:date][5].id, @non_conditional_questions[:rda_metadata][5].id,
-                                                       @non_conditional_questions[:checkbox][5].id, @non_conditional_questions[:radiobutton][5].id,
-                                                       @non_conditional_questions[:dropdown][5].id, @non_conditional_questions[:multiselectbox][5].id])
+                                         remove_data: non_conditional_questions_ids_by_index(5))
 
           #  We chose an option that is in the option_list of the condition defined above.
           args = {
@@ -251,18 +222,12 @@ RSpec.describe AnswersController, type: :controller do
           create(:condition, question: @conditional_questions[:dropdown],
                              option_list: [@conditional_questions[:dropdown].question_options[1].id],
                              action_type: 'remove',
-                             remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
-                                           @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
-                                           @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
-                                           @non_conditional_questions[:multiselectbox][3].id])
+                             remove_data: non_conditional_questions_ids_by_index(3))
 
           create(:condition, question: @conditional_questions[:dropdown],
                              option_list: [@conditional_questions[:dropdown].question_options[4].id],
                              action_type: 'remove',
-                             remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
-                                           @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
-                                           @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
-                                           @non_conditional_questions[:multiselectbox][0].id])
+                             remove_data: non_conditional_questions_ids_by_index(0))
 
           # We choose an option that is not in the option_list of the conditions defined above.
           args = {
@@ -345,10 +310,7 @@ RSpec.describe AnswersController, type: :controller do
         condition2 = create(:condition, question: @conditional_questions[:checkbox],
                                         option_list: [@conditional_questions[:checkbox].question_options[4].id],
                                         action_type: 'remove',
-                                        remove_data: [@non_conditional_questions[:textarea][3].id, @non_conditional_questions[:textfield][3].id,
-                                                      @non_conditional_questions[:date][3].id, @non_conditional_questions[:rda_metadata][3].id,
-                                                      @non_conditional_questions[:checkbox][3].id, @non_conditional_questions[:dropdown][3].id,
-                                                      @non_conditional_questions[:multiselectbox][3].id])
+                                        remove_data: non_conditional_questions_ids_by_index(3))
 
         #  We chose an option that is in the option_list of the condition defined above. Note that
         # the text sent by UI is an empty string.
@@ -508,6 +470,10 @@ RSpec.describe AnswersController, type: :controller do
       dropdown: create_list(:question, 7, :dropdown, section: @section1, options: 3),
       multiselectbox: create_list(:question, 7, :multiselectbox, section: @section2, options: 3)
     }
+  end
+
+  def non_conditional_questions_ids_by_index(index)
+    @non_conditional_questions.map { |_, questions| questions[index].id }
   end
 
   def create_answers

--- a/spec/features/questions/conditions_questions_spec.rb
+++ b/spec/features/questions/conditions_questions_spec.rb
@@ -363,8 +363,10 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
     end
 
     scenario 'User answers chooses radiobutton option with a condition (with action_type: add_webhook)', :js do
-      condition = create(:condition, :webhook, question: @conditional_questions[:radiobutton],
-                                               option_list: [@conditional_questions[:radiobutton].question_options[0].id])
+      condition = create(:condition,
+                         :webhook,
+                         question: @conditional_questions[:radiobutton],
+                         option_list: [@conditional_questions[:radiobutton].question_options[0].id])
 
       visit overview_plan_path(@plan)
 

--- a/spec/features/questions/conditions_questions_spec.rb
+++ b/spec/features/questions/conditions_questions_spec.rb
@@ -14,68 +14,66 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
     @section3 = create(:section, phase: @phase)
 
     # Different types of questions (than can have conditional options)
-    @checkbox_conditional_question = create(:question, :checkbox, section: @section1, options: 5)
-    @radiobutton_conditional_question = create(:question, :radiobuttons, section: @section2, options: 5)
-    @dropdown_conditional_question = create(:question, :dropdown, section: @section3, options: 5)
-
-    @conditional_questions = [@checkbox_conditional_question, @radiobutton_conditional_question,
-                              @dropdown_conditional_question]
+    @conditional_questions = {
+      checkbox: create(:question, :checkbox, section: @section1, options: 5),
+      radiobutton: create(:question, :radiobuttons, section: @section2, options: 5),
+      dropdown: create(:question, :dropdown, section: @section3, options: 5)
+    }
 
     # Questions that do not have conditional options for adding or removing
-    @textarea_questions = create_list(:question, 3, :textarea, section: @section1)
-    @textfield_questions = create_list(:question, 3, :textfield, section: @section2)
-    @date_questions = create_list(:question, 3, :date, section: @section3)
-    @rda_metadata_questions = create_list(:question, 3, :rda_metadata, section: @section1, options: 5)
-    @checkbox_questions = create_list(:question, 3, :checkbox, section: @section2, options: 5)
-    @radiobuttons_questions = create_list(:question, 3, :radiobuttons, section: @section3, options: 5)
-    @dropdown_questions = create_list(:question, 3, :dropdown, section: @section1, options: 5)
-    @multiselectbox_questions = create_list(:question, 3, :multiselectbox, section: @section2, options: 5)
+    @non_conditional_questions = {
+      textarea: create_list(:question, 3, :textarea, section: @section1),
+      textfield: create_list(:question, 3, :textfield, section: @section2),
+      date: create_list(:question, 3, :date, section: @section3),
+      rda_metadata: create_list(:question, 3, :rda_metadata, section: @section1, options: 5),
+      checkbox: create_list(:question, 3, :checkbox, section: @section2, options: 5),
+      radiobutton: create_list(:question, 3, :radiobuttons, section: @section3, options: 5),
+      dropdown: create_list(:question, 3, :dropdown, section: @section1, options: 5),
+      multiselectbox: create_list(:question, 3, :multiselectbox, section: @section2, options: 5)
+    }
 
     create(:role, :creator, :editor, :commenter, user: @user, plan: @plan)
 
-    @all_questions_ids = (@conditional_questions + @textarea_questions + @textfield_questions +
-                          @date_questions + @rda_metadata_questions +
-                          @checkbox_questions + @radiobuttons_questions +
-                          @dropdown_questions + @multiselectbox_questions).map(&:id)
+    @all_questions_ids = (@conditional_questions.values + @non_conditional_questions.values.flatten).map(&:id)
 
     # Answer the non-conditional questions
-    @textarea_answers = @textarea_questions.each.map do |question|
+    @textarea_answers = @non_conditional_questions[:textarea].each.map do |question|
       create(:answer, plan: @plan, question: question, user: @user)
     end
 
     @all_non_conditional_question_answers_ids = @textarea_answers.map(&:id)
 
-    @textfield_answers = @textfield_questions.each.map do |question|
+    @textfield_answers = @non_conditional_questions[:textfield].each.map do |question|
       create(:answer, plan: @plan, question: question, user: @user)
     end
     @all_non_conditional_question_answers_ids += @textfield_answers.map(&:id)
 
-    @date_answers = @date_questions.each.map do |question|
+    @date_answers = @non_conditional_questions[:date].each.map do |question|
       create(:answer, plan: @plan, question: question, user: @user)
     end
     @all_non_conditional_question_answers_ids += @date_answers.map(&:id)
 
-    @rda_metadata_answers = @rda_metadata_questions.each.map do |question|
+    @rda_metadata_answers = @non_conditional_questions[:rda_metadata].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
     @all_non_conditional_question_answers_ids += @rda_metadata_answers.map(&:id)
 
-    @checkbox_answers = @checkbox_questions.each.map do |question|
+    @checkbox_answers = @non_conditional_questions[:checkbox].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
     @all_non_conditional_question_answers_ids += @checkbox_answers.map(&:id)
 
-    @radiobuttons_answers = @radiobuttons_questions.each.map do |question|
+    @radiobuttons_answers = @non_conditional_questions[:radiobutton].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
     @all_non_conditional_question_answers_ids += @radiobuttons_answers.map(&:id)
 
-    @dropdown_answers = @dropdown_questions.each.map do |question|
+    @dropdown_answers = @non_conditional_questions[:dropdown].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
     @all_non_conditional_question_answers_ids += @dropdown_answers.map(&:id)
 
-    @multiselectbox_answers = @multiselectbox_questions.each.map do |question|
+    @multiselectbox_answers = @non_conditional_questions[:multiselectbox].each.map do |question|
       create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
     end
     @all_non_conditional_question_answers_ids += @multiselectbox_answers.map(&:id)
@@ -94,17 +92,17 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
   describe 'conditions with action_type remove' do
     feature 'User answers a checkboxes question with a condition' do
       scenario 'User answers chooses checkbox option with a condition', :js do
-        condition = create(:condition, question: @checkbox_conditional_question,
-                                       option_list: [@checkbox_conditional_question.question_options[2].id],
+        condition = create(:condition, question: @conditional_questions[:checkbox],
+                                       option_list: [@conditional_questions[:checkbox].question_options[2].id],
                                        action_type: 'remove',
-                                       remove_data: [@textarea_questions[0].id,
-                                                     @textfield_questions[1].id,
-                                                     @date_questions[2].id,
-                                                     @rda_metadata_questions[0].id,
-                                                     @checkbox_questions[1].id,
-                                                     @radiobuttons_questions[2].id,
-                                                     @dropdown_questions[0].id,
-                                                     @multiselectbox_questions[1].id])
+                                       remove_data: [@non_conditional_questions[:textarea][0].id,
+                                                     @non_conditional_questions[:textfield][1].id,
+                                                     @non_conditional_questions[:date][2].id,
+                                                     @non_conditional_questions[:rda_metadata][0].id,
+                                                     @non_conditional_questions[:checkbox][1].id,
+                                                     @non_conditional_questions[:radiobutton][2].id,
+                                                     @non_conditional_questions[:dropdown][0].id,
+                                                     @non_conditional_questions[:multiselectbox][1].id])
 
         visit overview_plan_path(@plan)
 
@@ -118,8 +116,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         expect(page).to have_text('24/27 answered')
 
         # Answer the checkbox_conditional_question.
-        within("#answer-form-#{@checkbox_conditional_question.id}") do
-          check @checkbox_conditional_question.question_options[2].text
+        within("#answer-form-#{@conditional_questions[:checkbox].id}") do
+          check @conditional_questions[:checkbox].question_options[2].text
           click_button 'Save'
         end
 
@@ -140,33 +138,33 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         end
 
         # Now uncheck checkbox_conditional_question answer.
-        within("#answer-form-#{@checkbox_conditional_question.id}") do
-          uncheck @checkbox_conditional_question.question_options[2].text
+        within("#answer-form-#{@conditional_questions[:checkbox].id}") do
+          uncheck @conditional_questions[:checkbox].question_options[2].text
           click_button 'Save'
         end
 
         # Expect 27 questions to appear again, but the 8 answers that were removed should not be there.
-        # Also 1 answer should be removed as we unchecked  @checkbox_conditional_question.question_options[2].text
+        # Also 1 answer should be removed as we unchecked  @conditional_questions[:checkbox].question_options[2].text
         # 17 (from previous check) - 1 = 16
         expect(page).to have_text('16/27 answered')
       end
 
       scenario 'User answers chooses checkbox option without a condition', :js do
-        create(:condition, question: @checkbox_conditional_question,
-                           option_list: [@checkbox_conditional_question.question_options[1].id],
+        create(:condition, question: @conditional_questions[:checkbox],
+                           option_list: [@conditional_questions[:checkbox].question_options[1].id],
                            action_type: 'remove',
-                           remove_data: [@textarea_questions[2].id, @textfield_questions[2].id,
-                                         @date_questions[2].id, @rda_metadata_questions[2].id,
-                                         @checkbox_questions[2].id, @dropdown_questions[2].id,
-                                         @multiselectbox_questions[2].id])
+                           remove_data: [@non_conditional_questions[:textarea][2].id, @non_conditional_questions[:textfield][2].id,
+                                         @non_conditional_questions[:date][2].id, @non_conditional_questions[:rda_metadata][2].id,
+                                         @non_conditional_questions[:checkbox][2].id, @non_conditional_questions[:dropdown][2].id,
+                                         @non_conditional_questions[:multiselectbox][2].id])
 
-        create(:condition, question: @checkbox_conditional_question,
-                           option_list: [@checkbox_conditional_question.question_options[4].id],
+        create(:condition, question: @conditional_questions[:checkbox],
+                           option_list: [@conditional_questions[:checkbox].question_options[4].id],
                            action_type: 'remove',
-                           remove_data: [@textarea_questions[0].id, @textfield_questions[0].id,
-                                         @date_questions[0].id, @rda_metadata_questions[0].id,
-                                         @checkbox_questions[0].id, @dropdown_questions[0].id,
-                                         @multiselectbox_questions[0].id])
+                           remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
+                                         @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
+                                         @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
+                                         @non_conditional_questions[:multiselectbox][0].id])
 
         # We choose an option that is not in the option_list of the conditions defined above.
         visit overview_plan_path(@plan)
@@ -181,8 +179,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         expect(page).to have_text('24/27 answered')
 
         # Answer the checkbox_conditional_question
-        within("#answer-form-#{@checkbox_conditional_question.id}") do
-          check @checkbox_conditional_question.question_options[0].text
+        within("#answer-form-#{@conditional_questions[:checkbox].id}") do
+          check @conditional_questions[:checkbox].question_options[0].text
           click_button 'Save'
         end
 
@@ -195,17 +193,17 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
 
     feature 'User answers a radiobutton question with a condition' do
       scenario 'User answers selects radiobutton option with a condition', :js do
-        condition = create(:condition, question: @radiobutton_conditional_question,
-                                       option_list: [@radiobutton_conditional_question.question_options[2].id],
+        condition = create(:condition, question: @conditional_questions[:radiobutton],
+                                       option_list: [@conditional_questions[:radiobutton].question_options[2].id],
                                        action_type: 'remove',
-                                       remove_data: [@textarea_questions[0].id,
-                                                     @textfield_questions[1].id,
-                                                     @date_questions[2].id,
-                                                     @rda_metadata_questions[0].id,
-                                                     @checkbox_questions[1].id,
-                                                     @radiobuttons_questions[2].id,
-                                                     @dropdown_questions[0].id,
-                                                     @multiselectbox_questions[1].id])
+                                       remove_data: [@non_conditional_questions[:textarea][0].id,
+                                                     @non_conditional_questions[:textfield][1].id,
+                                                     @non_conditional_questions[:date][2].id,
+                                                     @non_conditional_questions[:rda_metadata][0].id,
+                                                     @non_conditional_questions[:checkbox][1].id,
+                                                     @non_conditional_questions[:radiobutton][2].id,
+                                                     @non_conditional_questions[:dropdown][0].id,
+                                                     @non_conditional_questions[:multiselectbox][1].id])
 
         visit overview_plan_path(@plan)
 
@@ -219,8 +217,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         expect(page).to have_text('24/27 answered')
 
         # Answer the radiobutton_conditional_question.
-        within("#answer-form-#{@radiobutton_conditional_question.id}") do
-          choose @radiobutton_conditional_question.question_options[2].text
+        within("#answer-form-#{@conditional_questions[:radiobutton].id}") do
+          choose @conditional_questions[:radiobutton].question_options[2].text
           click_button 'Save'
         end
 
@@ -243,34 +241,34 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
 
         # Now for radiobutton_conditional_question answer, there in no unchoose option,
         # so we switch options to a different option without any conditions.
-        within("#answer-form-#{@radiobutton_conditional_question.id}") do
-          choose @radiobutton_conditional_question.question_options[0].text
+        within("#answer-form-#{@conditional_questions[:radiobutton].id}") do
+          choose @conditional_questions[:radiobutton].question_options[0].text
           click_button 'Save'
         end
 
         # Check questions answered in progress bar.
         # Expect 27 questions to appear again, but the 8 answers that were removed should not be there.
-        # Also 1 answer should be removed as we unchecked  @radiobutton_conditional_question.question_options[2].text
+        # Also 1 answer should be removed as we unchecked  @conditional_questions[:radiobutton].question_options[2].text
         # 17 (from previous check) - 1 = 16
         expect(page).to have_text('17/27 answered')
       end
 
       scenario 'User answers selects radiobutton option without a condition', :js do
-        create(:condition, question: @radiobutton_conditional_question,
-                           option_list: [@radiobutton_conditional_question.question_options[1].id],
+        create(:condition, question: @conditional_questions[:radiobutton],
+                           option_list: [@conditional_questions[:radiobutton].question_options[1].id],
                            action_type: 'remove',
-                           remove_data: [@textarea_questions[2].id, @textfield_questions[2].id,
-                                         @date_questions[2].id, @rda_metadata_questions[2].id,
-                                         @checkbox_questions[2].id, @dropdown_questions[2].id,
-                                         @multiselectbox_questions[2].id])
+                           remove_data: [@non_conditional_questions[:textarea][2].id, @non_conditional_questions[:textfield][2].id,
+                                         @non_conditional_questions[:date][2].id, @non_conditional_questions[:rda_metadata][2].id,
+                                         @non_conditional_questions[:checkbox][2].id, @non_conditional_questions[:dropdown][2].id,
+                                         @non_conditional_questions[:multiselectbox][2].id])
 
-        create(:condition, question: @radiobutton_conditional_question,
-                           option_list: [@radiobutton_conditional_question.question_options[4].id],
+        create(:condition, question: @conditional_questions[:radiobutton],
+                           option_list: [@conditional_questions[:radiobutton].question_options[4].id],
                            action_type: 'remove',
-                           remove_data: [@textarea_questions[0].id, @textfield_questions[0].id,
-                                         @date_questions[0].id, @rda_metadata_questions[0].id,
-                                         @checkbox_questions[0].id, @dropdown_questions[0].id,
-                                         @multiselectbox_questions[0].id])
+                           remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
+                                         @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
+                                         @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
+                                         @non_conditional_questions[:multiselectbox][0].id])
 
         # We choose an option that is not in the option_list of the conditions defined above.
         visit overview_plan_path(@plan)
@@ -285,8 +283,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         expect(page).to have_text('24/27 answered')
 
         # Answer the radiobutton_conditional_question.
-        within("#answer-form-#{@radiobutton_conditional_question.id}") do
-          choose @radiobutton_conditional_question.question_options[0].text
+        within("#answer-form-#{@conditional_questions[:radiobutton].id}") do
+          choose @conditional_questions[:radiobutton].question_options[0].text
           click_button 'Save'
         end
 
@@ -299,17 +297,17 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
 
     feature 'User answers a dropdown question with a condition' do
       scenario 'User answers chooses dropdown option with a condition', :js do
-        condition = create(:condition, question: @dropdown_conditional_question,
-                                       option_list: [@dropdown_conditional_question.question_options[2].id],
+        condition = create(:condition, question: @conditional_questions[:dropdown],
+                                       option_list: [@conditional_questions[:dropdown].question_options[2].id],
                                        action_type: 'remove',
-                                       remove_data: [@textarea_questions[0].id,
-                                                     @textfield_questions[1].id,
-                                                     @date_questions[2].id,
-                                                     @rda_metadata_questions[0].id,
-                                                     @checkbox_questions[1].id,
-                                                     @radiobuttons_questions[2].id,
-                                                     @dropdown_questions[0].id,
-                                                     @multiselectbox_questions[1].id])
+                                       remove_data: [@non_conditional_questions[:textarea][0].id,
+                                                     @non_conditional_questions[:textfield][1].id,
+                                                     @non_conditional_questions[:date][2].id,
+                                                     @non_conditional_questions[:rda_metadata][0].id,
+                                                     @non_conditional_questions[:checkbox][1].id,
+                                                     @non_conditional_questions[:radiobutton][2].id,
+                                                     @non_conditional_questions[:dropdown][0].id,
+                                                     @non_conditional_questions[:multiselectbox][1].id])
 
         visit overview_plan_path(@plan)
 
@@ -323,8 +321,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         expect(page).to have_text('24/27 answered')
 
         # Answer the dropdown_conditional_question
-        within("#answer-form-#{@dropdown_conditional_question.id}") do
-          select(@dropdown_conditional_question.question_options[2].text, from: 'answer_question_option_ids')
+        within("#answer-form-#{@conditional_questions[:dropdown].id}") do
+          select(@conditional_questions[:dropdown].question_options[2].text, from: 'answer_question_option_ids')
           click_button 'Save'
         end
 
@@ -346,8 +344,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         end
 
         # Now select another option for dropdown_conditional_question.
-        within("#answer-form-#{@dropdown_conditional_question.id}") do
-          select(@dropdown_conditional_question.question_options[1].text, from: 'answer_question_option_ids')
+        within("#answer-form-#{@conditional_questions[:dropdown].id}") do
+          select(@conditional_questions[:dropdown].question_options[1].text, from: 'answer_question_option_ids')
           click_button 'Save'
         end
 
@@ -358,21 +356,21 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
       end
 
       scenario 'User answers select dropdown option without a condition', :js do
-        create(:condition, question: @dropdown_conditional_question,
-                           option_list: [@dropdown_conditional_question.question_options[1].id],
+        create(:condition, question: @conditional_questions[:dropdown],
+                           option_list: [@conditional_questions[:dropdown].question_options[1].id],
                            action_type: 'remove',
-                           remove_data: [@textarea_questions[2].id, @textfield_questions[2].id,
-                                         @date_questions[2].id, @rda_metadata_questions[2].id,
-                                         @checkbox_questions[2].id, @dropdown_questions[2].id,
-                                         @multiselectbox_questions[2].id])
+                           remove_data: [@non_conditional_questions[:textarea][2].id, @non_conditional_questions[:textfield][2].id,
+                                         @non_conditional_questions[:date][2].id, @non_conditional_questions[:rda_metadata][2].id,
+                                         @non_conditional_questions[:checkbox][2].id, @non_conditional_questions[:dropdown][2].id,
+                                         @non_conditional_questions[:multiselectbox][2].id])
 
-        create(:condition, question: @dropdown_conditional_question,
-                           option_list: [@dropdown_conditional_question.question_options[4].id],
+        create(:condition, question: @conditional_questions[:dropdown],
+                           option_list: [@conditional_questions[:dropdown].question_options[4].id],
                            action_type: 'remove',
-                           remove_data: [@textarea_questions[0].id, @textfield_questions[0].id,
-                                         @date_questions[0].id, @rda_metadata_questions[0].id,
-                                         @checkbox_questions[0].id, @dropdown_questions[0].id,
-                                         @multiselectbox_questions[0].id])
+                           remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
+                                         @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
+                                         @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
+                                         @non_conditional_questions[:multiselectbox][0].id])
         visit overview_plan_path(@plan)
 
         click_link 'Write Plan'
@@ -385,8 +383,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         expect(page).to have_text('24/27 answered')
 
         # Answer the dropdown_conditional_question.
-        within("#answer-form-#{@dropdown_conditional_question.id}") do
-          select(@dropdown_conditional_question.question_options[0].text, from: 'answer_question_option_ids')
+        within("#answer-form-#{@conditional_questions[:dropdown].id}") do
+          select(@conditional_questions[:dropdown].question_options[0].text, from: 'answer_question_option_ids')
           click_button 'Save'
         end
 
@@ -399,8 +397,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
   end
   describe 'conditions with action_type add_webhook' do
     scenario 'User answers chooses checkbox option with a condition (with action_type: add_webhook)', :js do
-      condition = create(:condition, :webhook, question: @checkbox_conditional_question,
-                                               option_list: [@checkbox_conditional_question.question_options[2].id])
+      condition = create(:condition, :webhook, question: @conditional_questions[:checkbox],
+                                               option_list: [@conditional_questions[:checkbox].question_options[2].id])
 
       visit overview_plan_path(@plan)
 
@@ -414,8 +412,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
       expect(page).to have_text('24/27 answered')
 
       # Answer the checkbox_conditional_question.
-      within("#answer-form-#{@checkbox_conditional_question.id}") do
-        check @checkbox_conditional_question.question_options[2].text
+      within("#answer-form-#{@conditional_questions[:checkbox].id}") do
+        check @conditional_questions[:checkbox].question_options[2].text
       end
 
       expect(page).to have_text('Answered just now')
@@ -437,14 +435,14 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
         # Message should have @user.name, chosen option text and question text.
         expect(mail.body.encoded).to include(@user.name)
-        expect(mail.body.encoded).to include(@checkbox_conditional_question.question_options[2].text)
-        expect(mail.body.encoded).to include(@checkbox_conditional_question.text)
+        expect(mail.body.encoded).to include(@conditional_questions[:checkbox].question_options[2].text)
+        expect(mail.body.encoded).to include(@conditional_questions[:checkbox].text)
       end
     end
 
     scenario 'User answers chooses radiobutton option with a condition (with action_type: add_webhook)', :js do
-      condition = create(:condition, :webhook, question: @radiobutton_conditional_question,
-                                               option_list: [@radiobutton_conditional_question.question_options[0].id])
+      condition = create(:condition, :webhook, question: @conditional_questions[:radiobutton],
+                                               option_list: [@conditional_questions[:radiobutton].question_options[0].id])
 
       visit overview_plan_path(@plan)
 
@@ -459,8 +457,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
 
       # Now for radiobutton_conditional_question answer, there in no unchoose option,
       # so we switch options to a different option without any conditions.
-      within("#answer-form-#{@radiobutton_conditional_question.id}") do
-        choose @radiobutton_conditional_question.question_options[0].text
+      within("#answer-form-#{@conditional_questions[:radiobutton].id}") do
+        choose @conditional_questions[:radiobutton].question_options[0].text
       end
 
       expect(page).to have_text('Answered just now')
@@ -482,14 +480,14 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
         # Message should have @user.name, chosen option text and question text.
         expect(mail.body.encoded).to include(@user.name)
-        expect(mail.body.encoded).to include(@radiobutton_conditional_question.question_options[0].text)
-        expect(mail.body.encoded).to include(@radiobutton_conditional_question.text)
+        expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].question_options[0].text)
+        expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].text)
       end
     end
 
     scenario 'User answers chooses dropdown option with a condition (with action_type: add_webhook)', :js do
-      condition = create(:condition, :webhook, question: @dropdown_conditional_question,
-                                               option_list: [@dropdown_conditional_question.question_options[2].id])
+      condition = create(:condition, :webhook, question: @conditional_questions[:dropdown],
+                                               option_list: [@conditional_questions[:dropdown].question_options[2].id])
 
       visit overview_plan_path(@plan)
 
@@ -503,8 +501,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
       expect(page).to have_text('24/27 answered')
 
       # Answer the dropdown_conditional_question
-      within("#answer-form-#{@dropdown_conditional_question.id}") do
-        select(@dropdown_conditional_question.question_options[2].text, from: 'answer_question_option_ids')
+      within("#answer-form-#{@conditional_questions[:dropdown].id}") do
+        select(@conditional_questions[:dropdown].question_options[2].text, from: 'answer_question_option_ids')
       end
 
       expect(page).to have_text('Answered just now')
@@ -526,8 +524,8 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
         # Message should have @user.name, chosen option text and question text.
         expect(mail.body.encoded).to include(@user.name)
-        expect(mail.body.encoded).to include(@dropdown_conditional_question.question_options[2].text)
-        expect(mail.body.encoded).to include(@dropdown_conditional_question.text)
+        expect(mail.body.encoded).to include(@conditional_questions[:dropdown].question_options[2].text)
+        expect(mail.body.encoded).to include(@conditional_questions[:dropdown].text)
       end
     end
   end

--- a/spec/features/questions/conditions_questions_spec.rb
+++ b/spec/features/questions/conditions_questions_spec.rb
@@ -358,16 +358,7 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       webhook_data = JSON.parse(condition.webhook_data)
 
-      ActionMailer::Base.deliveries.last do |mail|
-        expect(mail.to).to eq([webhook_data['email']])
-        expect(mail.subject).to eq(webhook_data['subject'])
-        expect(mail.body.encoded).to include(webhook_data['message'])
-        # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-        # Message should have @user.name, chosen option text and question text.
-        expect(mail.body.encoded).to include(@user.name)
-        expect(mail.body.encoded).to include(@conditional_questions[:checkbox].question_options[2].text)
-        expect(mail.body.encoded).to include(@conditional_questions[:checkbox].text)
-      end
+      check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :checkbox)
     end
 
     scenario 'User answers chooses radiobutton option with a condition (with action_type: add_webhook)', :js do
@@ -403,16 +394,7 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       webhook_data = JSON.parse(condition.webhook_data)
 
-      ActionMailer::Base.deliveries.last do |mail|
-        expect(mail.to).to eq([webhook_data['email']])
-        expect(mail.subject).to eq(webhook_data['subject'])
-        expect(mail.body.encoded).to include(webhook_data['message'])
-        # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-        # Message should have @user.name, chosen option text and question text.
-        expect(mail.body.encoded).to include(@user.name)
-        expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].question_options[0].text)
-        expect(mail.body.encoded).to include(@conditional_questions[:radiobutton].text)
-      end
+      check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :radiobutton)
     end
 
     scenario 'User answers chooses dropdown option with a condition (with action_type: add_webhook)', :js do
@@ -447,16 +429,7 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
       expect(ActionMailer::Base.deliveries.count).to eq(1)
       webhook_data = JSON.parse(condition.webhook_data)
 
-      ActionMailer::Base.deliveries.last do |mail|
-        expect(mail.to).to eq([webhook_data['email']])
-        expect(mail.subject).to eq(webhook_data['subject'])
-        expect(mail.body.encoded).to include(webhook_data['message'])
-        # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
-        # Message should have @user.name, chosen option text and question text.
-        expect(mail.body.encoded).to include(@user.name)
-        expect(mail.body.encoded).to include(@conditional_questions[:dropdown].question_options[2].text)
-        expect(mail.body.encoded).to include(@conditional_questions[:dropdown].text)
-      end
+      check_delivered_mail_for_webhook_data_and_question_data(webhook_data, :dropdown)
     end
   end
 
@@ -498,5 +471,19 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
 
   def non_conditional_questions_ids_by_index(index)
     @non_conditional_questions.map { |_, questions| questions[index].id }
+  end
+
+  def check_delivered_mail_for_webhook_data_and_question_data(webhook_data, question_type)
+    ActionMailer::Base.deliveries.first do |mail|
+      expect(mail.to).to eq([webhook_data['email']])
+      expect(mail.subject).to eq(webhook_data['subject'])
+      expect(mail.body.encoded).to include(webhook_data['message'])
+      # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
+
+      # Message should have @user.name, chosen option text and question text.
+      expect(mail.body.encoded).to include(@user.name)
+      expect(mail.body.encoded).to include(@conditional_questions[question_type].question_options[2].text)
+      expect(mail.body.encoded).to include(@conditional_questions[question_type].text)
+    end
   end
 end

--- a/spec/features/questions/conditions_questions_spec.rb
+++ b/spec/features/questions/conditions_questions_spec.rb
@@ -14,39 +14,17 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
     @section3 = create(:section, phase: @phase)
 
     # Different types of questions (than can have conditional options)
-    @conditional_questions = {
-      checkbox: create(:question, :checkbox, section: @section1, options: 5),
-      radiobutton: create(:question, :radiobuttons, section: @section2, options: 5),
-      dropdown: create(:question, :dropdown, section: @section3, options: 5)
-    }
+    @conditional_questions = create_conditional_questions
 
     # Questions that do not have conditional options for adding or removing
-    @non_conditional_questions = {
-      textarea: create_list(:question, 3, :textarea, section: @section1),
-      textfield: create_list(:question, 3, :textfield, section: @section2),
-      date: create_list(:question, 3, :date, section: @section3),
-      rda_metadata: create_list(:question, 3, :rda_metadata, section: @section1, options: 5),
-      checkbox: create_list(:question, 3, :checkbox, section: @section2, options: 5),
-      radiobutton: create_list(:question, 3, :radiobuttons, section: @section3, options: 5),
-      dropdown: create_list(:question, 3, :dropdown, section: @section1, options: 5),
-      multiselectbox: create_list(:question, 3, :multiselectbox, section: @section2, options: 5)
-    }
+    @non_conditional_questions = create_non_conditional_questions
 
     create(:role, :creator, :editor, :commenter, user: @user, plan: @plan)
 
     @all_questions_ids = (@conditional_questions.values + @non_conditional_questions.values.flatten).map(&:id)
 
     # Answer the non-conditional questions
-    @non_conditional_questions.each do |question_type, questions|
-      questions.map do |question|
-        if %i[textarea textfield date rda_metadata].include?(question_type)
-          create(:answer, plan: @plan, question: question, user: @user)
-        else
-          create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]],
-                          user: @user)
-        end
-      end
-    end
+    create_answers
 
     sign_in(@user)
 
@@ -496,6 +474,42 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         expect(mail.body.encoded).to include(@user.name)
         expect(mail.body.encoded).to include(@conditional_questions[:dropdown].question_options[2].text)
         expect(mail.body.encoded).to include(@conditional_questions[:dropdown].text)
+      end
+    end
+  end
+
+  private
+
+  def create_conditional_questions
+    {
+      checkbox: create(:question, :checkbox, section: @section1, options: 5),
+      radiobutton: create(:question, :radiobuttons, section: @section2, options: 5),
+      dropdown: create(:question, :dropdown, section: @section3, options: 5)
+    }
+  end
+
+  def create_non_conditional_questions
+    {
+      textarea: create_list(:question, 3, :textarea, section: @section1),
+      textfield: create_list(:question, 3, :textfield, section: @section2),
+      date: create_list(:question, 3, :date, section: @section3),
+      rda_metadata: create_list(:question, 3, :rda_metadata, section: @section1, options: 5),
+      checkbox: create_list(:question, 3, :checkbox, section: @section2, options: 5),
+      radiobutton: create_list(:question, 3, :radiobuttons, section: @section3, options: 5),
+      dropdown: create_list(:question, 3, :dropdown, section: @section1, options: 5),
+      multiselectbox: create_list(:question, 3, :multiselectbox, section: @section2, options: 5)
+    }
+  end
+
+  def create_answers
+    @non_conditional_questions.each do |question_type, questions|
+      questions.map do |question|
+        if %i[textarea textfield date rda_metadata].include?(question_type)
+          create(:answer, plan: @plan, question: question, user: @user)
+        else
+          create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]],
+                          user: @user)
+        end
       end
     end
   end

--- a/spec/features/questions/conditions_questions_spec.rb
+++ b/spec/features/questions/conditions_questions_spec.rb
@@ -37,46 +37,16 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
     @all_questions_ids = (@conditional_questions.values + @non_conditional_questions.values.flatten).map(&:id)
 
     # Answer the non-conditional questions
-    @textarea_answers = @non_conditional_questions[:textarea].each.map do |question|
-      create(:answer, plan: @plan, question: question, user: @user)
+    @non_conditional_questions.each do |question_type, questions|
+      questions.map do |question|
+        if %i[textarea textfield date rda_metadata].include?(question_type)
+          create(:answer, plan: @plan, question: question, user: @user)
+        else
+          create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]],
+                          user: @user)
+        end
+      end
     end
-
-    @all_non_conditional_question_answers_ids = @textarea_answers.map(&:id)
-
-    @textfield_answers = @non_conditional_questions[:textfield].each.map do |question|
-      create(:answer, plan: @plan, question: question, user: @user)
-    end
-    @all_non_conditional_question_answers_ids += @textfield_answers.map(&:id)
-
-    @date_answers = @non_conditional_questions[:date].each.map do |question|
-      create(:answer, plan: @plan, question: question, user: @user)
-    end
-    @all_non_conditional_question_answers_ids += @date_answers.map(&:id)
-
-    @rda_metadata_answers = @non_conditional_questions[:rda_metadata].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-    @all_non_conditional_question_answers_ids += @rda_metadata_answers.map(&:id)
-
-    @checkbox_answers = @non_conditional_questions[:checkbox].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-    @all_non_conditional_question_answers_ids += @checkbox_answers.map(&:id)
-
-    @radiobuttons_answers = @non_conditional_questions[:radiobutton].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-    @all_non_conditional_question_answers_ids += @radiobuttons_answers.map(&:id)
-
-    @dropdown_answers = @non_conditional_questions[:dropdown].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-    @all_non_conditional_question_answers_ids += @dropdown_answers.map(&:id)
-
-    @multiselectbox_answers = @non_conditional_questions[:multiselectbox].each.map do |question|
-      create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
-    end
-    @all_non_conditional_question_answers_ids += @multiselectbox_answers.map(&:id)
 
     sign_in(@user)
 

--- a/spec/features/questions/conditions_questions_spec.rb
+++ b/spec/features/questions/conditions_questions_spec.rb
@@ -101,18 +101,12 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         create(:condition, question: @conditional_questions[:checkbox],
                            option_list: [@conditional_questions[:checkbox].question_options[1].id],
                            action_type: 'remove',
-                           remove_data: [@non_conditional_questions[:textarea][2].id, @non_conditional_questions[:textfield][2].id,
-                                         @non_conditional_questions[:date][2].id, @non_conditional_questions[:rda_metadata][2].id,
-                                         @non_conditional_questions[:checkbox][2].id, @non_conditional_questions[:dropdown][2].id,
-                                         @non_conditional_questions[:multiselectbox][2].id])
+                           remove_data: non_conditional_questions_ids_by_index(2))
 
         create(:condition, question: @conditional_questions[:checkbox],
                            option_list: [@conditional_questions[:checkbox].question_options[4].id],
                            action_type: 'remove',
-                           remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
-                                         @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
-                                         @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
-                                         @non_conditional_questions[:multiselectbox][0].id])
+                           remove_data: non_conditional_questions_ids_by_index(0))
 
         # We choose an option that is not in the option_list of the conditions defined above.
         visit overview_plan_path(@plan)
@@ -205,18 +199,12 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         create(:condition, question: @conditional_questions[:radiobutton],
                            option_list: [@conditional_questions[:radiobutton].question_options[1].id],
                            action_type: 'remove',
-                           remove_data: [@non_conditional_questions[:textarea][2].id, @non_conditional_questions[:textfield][2].id,
-                                         @non_conditional_questions[:date][2].id, @non_conditional_questions[:rda_metadata][2].id,
-                                         @non_conditional_questions[:checkbox][2].id, @non_conditional_questions[:dropdown][2].id,
-                                         @non_conditional_questions[:multiselectbox][2].id])
+                           remove_data: non_conditional_questions_ids_by_index(2))
 
         create(:condition, question: @conditional_questions[:radiobutton],
                            option_list: [@conditional_questions[:radiobutton].question_options[4].id],
                            action_type: 'remove',
-                           remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
-                                         @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
-                                         @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
-                                         @non_conditional_questions[:multiselectbox][0].id])
+                           remove_data: non_conditional_questions_ids_by_index(0))
 
         # We choose an option that is not in the option_list of the conditions defined above.
         visit overview_plan_path(@plan)
@@ -307,18 +295,12 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         create(:condition, question: @conditional_questions[:dropdown],
                            option_list: [@conditional_questions[:dropdown].question_options[1].id],
                            action_type: 'remove',
-                           remove_data: [@non_conditional_questions[:textarea][2].id, @non_conditional_questions[:textfield][2].id,
-                                         @non_conditional_questions[:date][2].id, @non_conditional_questions[:rda_metadata][2].id,
-                                         @non_conditional_questions[:checkbox][2].id, @non_conditional_questions[:dropdown][2].id,
-                                         @non_conditional_questions[:multiselectbox][2].id])
+                           remove_data: non_conditional_questions_ids_by_index(2))
 
         create(:condition, question: @conditional_questions[:dropdown],
                            option_list: [@conditional_questions[:dropdown].question_options[4].id],
                            action_type: 'remove',
-                           remove_data: [@non_conditional_questions[:textarea][0].id, @non_conditional_questions[:textfield][0].id,
-                                         @non_conditional_questions[:date][0].id, @non_conditional_questions[:rda_metadata][0].id,
-                                         @non_conditional_questions[:checkbox][0].id, @non_conditional_questions[:dropdown][0].id,
-                                         @non_conditional_questions[:multiselectbox][0].id])
+                           remove_data: non_conditional_questions_ids_by_index(0))
         visit overview_plan_path(@plan)
 
         click_link 'Write Plan'
@@ -512,5 +494,9 @@ RSpec.feature 'Question::Conditions questions', type: :feature do
         end
       end
     end
+  end
+
+  def non_conditional_questions_ids_by_index(index)
+    @non_conditional_questions.map { |_, questions| questions[index].id }
   end
 end

--- a/spec/support/helpers/conditional_questions_helper.rb
+++ b/spec/support/helpers/conditional_questions_helper.rb
@@ -28,7 +28,11 @@ module ConditionalQuestionsHelper
     @non_conditional_questions.each do |question_type, questions|
       answers[question_type] = questions.map do |question|
         if question_types_with_question_options.include?(question_type)
-          create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
+          create(:answer,
+                 plan: @plan,
+                 question: question,
+                 question_options: [question.question_options[2]],
+                 user: @user)
         else
           create(:answer, plan: @plan, question: question, user: @user)
         end
@@ -46,6 +50,7 @@ module ConditionalQuestionsHelper
     expect(json[:qn_data][:to_hide]).to match_array(question_ids_to_hide)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def check_delivered_mail_for_webhook_data_and_question_data(webhook_data, question_type)
     ActionMailer::Base.deliveries.first do |mail|
       expect(mail.to).to eq([webhook_data['email']])
@@ -59,4 +64,5 @@ module ConditionalQuestionsHelper
       expect(mail.body.encoded).to include(@conditional_questions[question_type].text)
     end
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/spec/support/helpers/conditional_questions_helper.rb
+++ b/spec/support/helpers/conditional_questions_helper.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module ConditionalQuestionsHelper
+  def create_conditional_questions(num_options)
+    {
+      checkbox: create(:question, :checkbox, section: @section1, options: num_options),
+      radiobutton: create(:question, :radiobuttons, section: @section2, options: num_options),
+      dropdown: create(:question, :dropdown, section: @section3, options: num_options)
+    }
+  end
+
+  def create_non_conditional_questions(num_questions, num_options)
+    {
+      textarea: create_list(:question, num_questions, :textarea, section: @section1),
+      textfield: create_list(:question, num_questions, :textfield, section: @section2),
+      date: create_list(:question, num_questions, :date, section: @section3),
+      rda_metadata: create_list(:question, num_questions, :rda_metadata, section: @section1, options: num_options),
+      checkbox: create_list(:question, num_questions, :checkbox, section: @section2, options: num_options),
+      radiobutton: create_list(:question, num_questions, :radiobuttons, section: @section3, options: num_options),
+      dropdown: create_list(:question, num_questions, :dropdown, section: @section1, options: num_options),
+      multiselectbox: create_list(:question, num_questions, :multiselectbox, section: @section2, options: num_options)
+    }
+  end
+
+  def create_answers
+    question_types_with_question_options = %i[checkbox radiobutton dropdown multiselectbox]
+    answers = {}
+    @non_conditional_questions.each do |question_type, questions|
+      answers[question_type] = questions.map do |question|
+        if question_types_with_question_options.include?(question_type)
+          create(:answer, plan: @plan, question: question, question_options: [question.question_options[2]], user: @user)
+        else
+          create(:answer, plan: @plan, question: question, user: @user)
+        end
+      end
+    end
+    answers
+  end
+
+  def non_conditional_questions_ids_by_index(index)
+    @non_conditional_questions.map { |_, questions| questions[index].id }
+  end
+
+  def check_question_ids_to_show_and_hide(json, question_ids_to_hide = [])
+    expect(json[:qn_data][:to_show]).to match_array(@all_questions_ids - question_ids_to_hide)
+    expect(json[:qn_data][:to_hide]).to match_array(question_ids_to_hide)
+  end
+
+  def check_delivered_mail_for_webhook_data_and_question_data(webhook_data, question_type)
+    ActionMailer::Base.deliveries.first do |mail|
+      expect(mail.to).to eq([webhook_data['email']])
+      expect(mail.subject).to eq(webhook_data['subject'])
+      expect(mail.body.encoded).to include(webhook_data['message'])
+      # To see structure of email sent see app/views/user_mailer/question_answered.html.erb.
+
+      # Message should have @user.name, chosen option text and question text.
+      expect(mail.body.encoded).to include(@user.name)
+      expect(mail.body.encoded).to include(@conditional_questions[question_type].question_options[2].text)
+      expect(mail.body.encoded).to include(@conditional_questions[question_type].text)
+    end
+  end
+end


### PR DESCRIPTION
Changes proposed in this PR:
- https://github.com/DMPRoadmap/roadmap/pull/3516 adds a lot of test coverage within `spec/features/questions/conditions_questions_spec.rb` and `spec/controllers/answers_controller_with_conditional_questions_spec.rb`. This PR attempts to refactor those files by applying DRY principles.
- `spec/support/helpers/conditional_questions_helper.rb` has been created to facilitate the shared logic between the two aforementioned files.
- The only actual change is the addition of `@non_conditional_questions[:radiobutton][index].id` to some `remove_data: ` values. (I am not sure why these `:radiobutton` options were absent in the first place and could add them back if needed.)
