### PR TITLE
Fix creator & commenter traits in plans factory

### DIFF
--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -62,13 +62,13 @@ FactoryBot.define do
       guidance_groups { 0 }
     end
     trait :creator do
-      after(:create) do |obj|
-        obj.roles << create(:role, :creator, user: create(:user, org: create(:org)))
+      after(:create) do |plan|
+        plan.roles << create(:role, :creator, user: create(:user, org: create(:org)), plan: plan)
       end
     end
     trait :commenter do
-      after(:create) do |obj|
-        obj.roles << create(:role, :commenter, user: create(:user, org: create(:org)))
+      after(:create) do |plan|
+        plan.roles << create(:role, :commenter, user: create(:user, org: create(:org)), plan: plan)
       end
     end
     trait :organisationally_visible do


### PR DESCRIPTION
- Prior to this change, rather than assigning the desired role to the newly created plan, executing `create(:plan, :creator...` or `create(:plan, :commenter...` would create a second new plan.
- This code change makes sure that when the `creator` or `commenter` trait is specified, it is applied to the first created plan and a second one is not created.

Fixes # .

Changes proposed in this PR:
-
