### PR TITLE
Fix handling of `attrs[:managed]` + Refactor `OrgsController#admin_update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix Handling of `attrs[:managed]` + Refactor `OrgsController#admin_update` [#3529](https://github.com/DMPRoadmap/roadmap/pull/3529)
+
 ## v5.0.2
 - Bump Ruby to v3.1.4 and use `.ruby-version` in CI
   - [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -44,7 +44,7 @@ class OrgsController < ApplicationController
     # Only allow super admins to change the org types and shib info
     if current_user.can_super_admin?
       identifiers = []
-      attrs[:managed] = attrs[:managed] == '1'
+      attrs = handle_managed_flag(attrs)
 
       # Handle Shibboleth identifier if that is enabled
       if Rails.configuration.x.shibboleth.use_filtered_discovery_service
@@ -234,6 +234,13 @@ class OrgsController < ApplicationController
 
   def search_params
     params.require(:org).permit(:name, :type)
+  end
+
+  def handle_managed_flag(attrs)
+    # NOTE: `:managed` is controlled by a check_box in the form
+    #   `app/views/orgs/_profile_form.html.erb`.
+    attrs[:managed] = (attrs[:managed] == '1') if attrs.key?(:managed)
+    attrs
   end
 
   def shib_login_url

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -33,41 +33,17 @@ class OrgsController < ApplicationController
     @org = Org.find(params[:id])
     authorize @org
 
-    # If a new logo was supplied then use it, otherwise retain the existing one
-    attrs[:logo] = attrs[:logo].present? ? attrs[:logo] : @org.logo
-    # Remove the logo if the user checked the box
-    attrs[:logo] = nil if attrs[:remove_logo] == '1'
+    attrs = handle_logo(attrs)
 
     tab = (attrs[:feedback_enabled].present? ? 'feedback' : 'profile')
     @org.links = ActiveSupport::JSON.decode(params[:org_links]) if params[:org_links].present?
 
     # Only allow super admins to change the org types and shib info
     if current_user.can_super_admin?
-      identifiers = []
       attrs = handle_managed_flag(attrs)
+      attrs = handle_shibboleth_identifier(attrs)
 
-      # Handle Shibboleth identifier if that is enabled
-      if Rails.configuration.x.shibboleth.use_filtered_discovery_service
-        shib = IdentifierScheme.by_name('shibboleth').first
-
-        if shib.present? && attrs[:identifiers_attributes].present?
-          key = attrs[:identifiers_attributes].keys.first
-          entity_id = attrs[:identifiers_attributes][:"#{key}"][:value]
-          # rubocop:disable Metrics/BlockNesting
-          if entity_id.present?
-            identifier = Identifier.find_or_initialize_by(
-              identifiable: @org, identifier_scheme: shib, value: entity_id
-            )
-            @org = process_identifier_change(org: @org, identifier: identifier)
-          else
-            # The user blanked out the entityID so delete the record
-            @org.identifier_for_scheme(scheme: shib)&.destroy
-          end
-          # rubocop:enable Metrics/BlockNesting
-        end
-        attrs.delete(:identifiers_attributes)
-      end
-
+      identifiers = []
       # See if the user selected a new Org via the Org Lookup and
       # convert it into an Org
       lookup = org_from_params(params_in: attrs)
@@ -236,10 +212,41 @@ class OrgsController < ApplicationController
     params.require(:org).permit(:name, :type)
   end
 
+  def handle_logo(attrs)
+    # If a new logo was supplied then use it, otherwise retain the existing one
+    attrs[:logo] = attrs[:logo].present? ? attrs[:logo] : @org.logo
+    # Remove the logo if the user checked the box
+    attrs[:logo] = nil if attrs[:remove_logo] == '1'
+    attrs
+  end
+
   def handle_managed_flag(attrs)
     # NOTE: `:managed` is controlled by a check_box in the form
     #   `app/views/orgs/_profile_form.html.erb`.
     attrs[:managed] = (attrs[:managed] == '1') if attrs.key?(:managed)
+    attrs
+  end
+
+  # Updates the @org's Shibboleth identifier(s) if the required conditions are met
+  def handle_shibboleth_identifier(attrs)
+    return attrs unless Rails.configuration.x.shibboleth.use_filtered_discovery_service
+
+    shib = IdentifierScheme.by_name('shibboleth').first
+
+    if shib.present? && attrs[:identifiers_attributes].present?
+      key = attrs[:identifiers_attributes].keys.first
+      entity_id = attrs[:identifiers_attributes][:"#{key}"][:value]
+      if entity_id.present?
+        identifier = Identifier.find_or_initialize_by(
+          identifiable: @org, identifier_scheme: shib, value: entity_id
+        )
+        @org = process_identifier_change(org: @org, identifier: identifier)
+      else
+        # The user blanked out the entityID so delete the record
+        @org.identifier_for_scheme(scheme: shib)&.destroy
+      end
+    end
+    attrs.delete(:identifiers_attributes)
     attrs
   end
 

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -228,6 +228,7 @@ class OrgsController < ApplicationController
   end
 
   # Updates the @org's Shibboleth identifier(s) if the required conditions are met
+  # rubocop:disable Metrics/AbcSize
   def handle_shibboleth_identifier(attrs)
     return attrs unless Rails.configuration.x.shibboleth.use_filtered_discovery_service
 
@@ -249,6 +250,7 @@ class OrgsController < ApplicationController
     attrs.delete(:identifiers_attributes)
     attrs
   end
+  # rubocop:enable Metrics/AbcSize
 
   def shib_login_url
     shib_login = Rails.configuration.x.shibboleth.login_url


### PR DESCRIPTION
Fixes #3528

Changes proposed in this PR:
- This change resolves issue #3528 by preventing the updating of `@org.managed` when `attrs[:managed]` is missing. Prior to this change, the `if attrs.key?(:managed)` was not present. But it was necessary, because that key is not present when a super user clicks "Save" on the "Request Feedback" page.
- As a result, if `attrs[:managed]` was not present,  then `attrs[:managed] = (attrs[:managed] == '1')` would evaluate false, and `if @org.update(attrs)` (line 81) would subsequently update `@org.managed` to false in the db.