### PR TITLE
Properly Validate CSV Separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove Auto-Generated TinyMCE Skins and Add `public/tinymce/skins/` to `.gitignore` [#3466](https://github.com/DMPRoadmap/roadmap/pull/3466)
 - Re-implement email confirmation [#3507](https://github.com/DMPRoadmap/roadmap/pull/3507)
 - Update `spec/support/faker.rb` to use `I18n.default_locale` [#3507](https://github.com/DMPRoadmap/roadmap/pull/3507)
+- Properly validate CSV Separator [#3557](https://github.com/DMPRoadmap/roadmap/pull/3557)
 
 ## v5.0.0
 

--- a/app/controllers/usage_controller.rb
+++ b/app/controllers/usage_controller.rb
@@ -151,9 +151,14 @@ class UsageController < ApplicationController
     params[:filtered].present? && params[:filtered] == 'true'
   end
 
-  # set the csv separator or default to comma
+  # This sets the csv separator
+  # Ensures separator is either a comma or a safe separator
   def sep_param
-    params['sep'] || ','
+    safe_csv_separators = Rails.configuration.x.application.csv_separators
+    sep = params['sep'].to_s
+    return sep if safe_csv_separators.include?(sep)
+
+    ','
   end
 
   def min_max_dates(args:)


### PR DESCRIPTION
Fixes CSV separators not being validated.

Changes proposed in this PR:
- Refactor the sep_param method in `usage_controller` to validate that the provided CSV field separator is a safe, predefined character.
