### PR TITLE
    Issue #3561 - Fix for bug "Discrepancy in Org Admin view of the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bump rexml from 3.4.1 to 3.4.2 [#3562](https://github.com/DMPRoadmap/roadmap/pull/3562)
 - Bump tmp from 0.2.3 to 0.2.4 [#3548](https://github.com/DMPRoadmap/roadmap/pull/3548)
 - Update Gems and Address New Rubocop Offences [#3572](https://github.com/DMPRoadmap/roadmap/pull/3572)
+- Fix for a discrepancy in Org Admin view of the Organisation Plans and the related CSV Download. [#3561] (https://github.com/DMPRoadmap/roadmap/issues/3561)
 
 ## v5.0.1
 - Updated seeds.rb file for identifier_schemes to include context value and removed logo_url and idenitifier_prefix for Shibboleth (as it was causing issues with SSO). [#3525](https://github.com/DMPRoadmap/roadmap/pull/3525)

--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -46,13 +46,8 @@ module Paginable
       @super_admin = current_user.can_super_admin?
       @clicked_through = params[:click_through].present?
 
-      plans = if @super_admin
-                Plan.all.joins(:template, roles: [user: :org])
-                    .where(Role.creator_condition)
-              else
-                current_user.org.org_admin_plans
-                            .joins(:template, roles: [user: :org])
-              end
+      plans = @super_admin ? Plan.where(Role.creator_condition) : current_user.org.org_admin_plans
+      plans = plans.joins(:template, roles: [user: :org])
 
       paginable_renderise(
         partial: 'org_admin',

--- a/app/controllers/paginable/plans_controller.rb
+++ b/app/controllers/paginable/plans_controller.rb
@@ -45,8 +45,14 @@ module Paginable
       # check if current user if super_admin
       @super_admin = current_user.can_super_admin?
       @clicked_through = params[:click_through].present?
-      plans = @super_admin ? Plan.all : current_user.org.org_admin_plans
-      plans = plans.joins(:template, roles: [user: :org]).where(Role.creator_condition)
+
+      plans = if @super_admin
+                Plan.all.joins(:template, roles: [user: :org])
+                    .where(Role.creator_condition)
+              else
+                current_user.org.org_admin_plans
+                            .joins(:template, roles: [user: :org])
+              end
 
       paginable_renderise(
         partial: 'org_admin',

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -293,11 +293,13 @@ class Org < ApplicationRecord
     if Rails.configuration.x.plans.org_admins_read_all
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
           .where(roles: { active: true })
+          .where(Role.creator_condition)
     else
       Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
           .where.not(visibility: Plan.visibilities[:privately_visible])
           .where.not(visibility: Plan.visibilities[:is_test])
           .where(roles: { active: true })
+          .where(Role.creator_condition)
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -288,19 +288,17 @@ class Org < ApplicationRecord
   # This replaces the old plans method. We now use the native plans method and this.
   # rubocop:disable Metrics/AbcSize
   def org_admin_plans
-    combined_plan_ids = (native_plan_ids + affiliated_plan_ids).flatten.uniq
+    scope = Plan.includes(:template, :phases, :roles, :users)
+                .where(id: (native_plan_ids + affiliated_plan_ids).uniq)
+                .where(roles: { active: true })
+                .where(Role.creator_condition)
 
-    if Rails.configuration.x.plans.org_admins_read_all
-      Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
-          .where(roles: { active: true })
-          .where(Role.creator_condition)
-    else
-      Plan.includes(:template, :phases, :roles, :users).where(id: combined_plan_ids)
-          .where.not(visibility: Plan.visibilities[:privately_visible])
-          .where.not(visibility: Plan.visibilities[:is_test])
-          .where(roles: { active: true })
-          .where(Role.creator_condition)
+    unless Rails.configuration.x.plans.org_admins_read_all
+      scope = scope.where.not(visibility: Plan.visibilities[:privately_visible])
+                   .where.not(visibility: Plan.visibilities[:is_test])
     end
+
+    scope
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -66,9 +66,24 @@ FactoryBot.define do
         obj.roles << create(:role, :creator, user: create(:user, org: create(:org)))
       end
     end
+    trait :administrator do
+      after(:create) do |obj|
+        obj.roles << create(:role, :administrator, user: create(:user, org: create(:org)))
+      end
+    end
+    trait :editor do
+      after(:create) do |obj|
+        obj.roles << create(:role, :editor, user: create(:user, org: create(:org)))
+      end
+    end
     trait :commenter do
       after(:create) do |obj|
         obj.roles << create(:role, :commenter, user: create(:user, org: create(:org)))
+      end
+    end
+    trait :reviewer do
+      after(:create) do |obj|
+        obj.roles << create(:role, :reviewer, user: create(:user, org: create(:org)))
       end
     end
     trait :organisationally_visible do

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -61,52 +61,20 @@ FactoryBot.define do
       answers { 0 }
       guidance_groups { 0 }
     end
-    trait :creator do
-      after(:create) do |obj|
-        obj.roles << create(:role, :creator, user: create(:user, org: create(:org)))
-      end
-    end
-    trait :administrator do
-      after(:create) do |obj|
-        obj.roles << create(:role, :administrator, user: create(:user, org: create(:org)))
-      end
-    end
-    trait :editor do
-      after(:create) do |obj|
-        obj.roles << create(:role, :editor, user: create(:user, org: create(:org)))
-      end
-    end
-    trait :commenter do
-      after(:create) do |obj|
-        obj.roles << create(:role, :commenter, user: create(:user, org: create(:org)))
-      end
-    end
-    trait :reviewer do
-      after(:create) do |obj|
-        obj.roles << create(:role, :reviewer, user: create(:user, org: create(:org)))
-      end
-    end
-    trait :organisationally_visible do
-      after(:create) do |plan|
-        plan.update(visibility: Plan.visibilities[:organisationally_visible])
+
+    %i[creator administrator editor commenter reviewer].each do |role|
+      trait role do
+        after(:create) do |obj|
+          obj.roles << create(:role, role, user: create(:user, org: create(:org)))
+        end
       end
     end
 
-    trait :publicly_visible do
-      after(:create) do |plan|
-        plan.update(visibility: Plan.visibilities[:publicly_visible])
-      end
-    end
-
-    trait :is_test do
-      after(:create) do |plan|
-        plan.update(visibility: Plan.visibilities[:is_test])
-      end
-    end
-
-    trait :privately_visible do
-      after(:create) do |plan|
-        plan.update(visibility: Plan.visibilities[:privately_visible])
+    %i[organisationally_visible publicly_visible is_test privately_visible].each do |visibility|
+      trait visibility do
+        after(:create) do |obj|
+          obj.update(visibility: Plan.visibilities[visibility])
+        end
       end
     end
 

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -343,126 +343,103 @@ RSpec.describe Org, type: :model do
   end
 
   describe '#org_admin_plans' do
-    Rails.configuration.x.plans.org_admins_read_all = true
-    # Two Orgs
-    let!(:org1) { create(:org) }
-    let!(:org2) { create(:org) }
-
-    # Plans for org1
-    let!(:org1plan1) { create(:plan, :creator, :organisationally_visible, org: org1) }
-    let!(:org1plan2) { create(:plan, :creator, :privately_visible, org: org1) }
-    let!(:org1plan3) { create(:plan, :creator, :publicly_visible, org: org1) }
-    let!(:org1plan4) { create(:plan, :creator, :organisationally_visible, org: org1) }
-
-    # Plans for org2
-    let!(:org2plan1) { create(:plan, :creator, :organisationally_visible, org: org2) }
-
-    subject { org1.org_admin_plans }
-
-    context 'when user belongs to Org and plan owner with role :creator' do
-      before do
-        Rails.configuration.x.plans.org_admins_read_all = true
-      end
-      it { is_expected.to include(org1plan1, org1plan2, org1plan3, org1plan4) }
-      it { is_expected.not_to include(org2plan1) }
+    # Helper for returning all plans from the `plans` hash
+    def all_plans
+      plans.values.flat_map(&:values)
     end
 
-    context 'when user belongs to Org and a plan removed by creator assuming there are no coowners' do
-      before do
-        Rails.configuration.x.plans.org_admins_read_all = true
-        org1plan4.roles.map { |r| r.update(active: false) if r.user_id == org1plan4.owner.id }
-      end
-
-      it { is_expected.to include(org1plan1, org1plan2, org1plan3) }
-      it { is_expected.not_to include(org1plan4) }
+    # Helper for deactivating roles (creator or administrator) from plans
+    def deactivate_roles_for_plans(plans, role_condition)
+      Role.where(plan_id: plans.map(&:id)).where(role_condition).update_all(active: false)
     end
 
-    context 'when user belongs to Org and a plan removed by creator, but coowner still active.' do
-      before do
-        Rails.configuration.x.plans.org_admins_read_all = true
-        coowner = create(:user, org: org1)
-        #  Add coowner to the plan by giving user the role administrator
-        org1plan4.add_user!(coowner.id, :administrator)
-        owner_id = org1plan4.owner.id
-        org1plan4.roles.map { |r| r.update(active: false) if r.user_id == owner_id }
-      end
-
-      it { is_expected.to include(org1plan1, org1plan2, org1plan3) }
-      it { is_expected.not_to include(org1plan4) }
-    end
-
-    context 'when user belongs to Org, plan user with role :administrator, but plan creator from a different Org' do
-      before do
-        Rails.configuration.x.plans.org_admins_read_all = true
-        # Creator belongs to different org
-        @plan = create(:plan, :creator, :organisationally_visible, org: create(:org))
-        @plan.add_user!(create(:user, org: org1).id, :administrator)
-      end
-
-      it {
-        is_expected.to include(org1plan1, org1plan2, org1plan3, org1plan4, @plan)
+    def create_plans_for(org)
+      {
+        public: create(:plan, :creator, :publicly_visible, org: org),
+        org: create(:plan, :creator, :organisationally_visible, org: org),
+        private: create(:plan, :creator, :privately_visible, org: org),
+        test: create(:plan, :creator, :is_test, org: org)
       }
     end
 
-    context 'user belongs to Org and plan user with role :editor, but not :creator and :admin' do
-      before do
-        Rails.configuration.x.plans.org_admins_read_all = true
-        # Creator and admin belongs to different orgs
-        @plan = create(:plan, :creator, :organisationally_visible, org: create(:org))
-        @plan.add_user!(create(:org).id, :administrator)
-        # Editor belongs to org1
-        @plan.add_user!(create(:user, org: org1).id, :editor)
-      end
+    let!(:org) { create(:org) }
+    let!(:org_user) { create(:user, org: org) }
+    let!(:other_org) { create(:org) }
 
-      it { is_expected.not_to include(@plan) }
+    # org_admin_plans consists of "native" and "affiliated" plans
+    # - native plans have plan.org == org
+    # - affiliated plans have an active administrator role for a user where user.org == org
+    let!(:plans) do
+      {
+        native: create_plans_for(org),
+        affiliated: create_plans_for(other_org)
+      }.tap do |hash|
+        # Add the required administrator role for the `affiliated` plans
+        hash[:affiliated].each_value do |plan|
+          plan.add_user!(org_user.id, :administrator)
+        end
+      end
     end
 
-    context 'user belongs to Org and plan user with role :commenter, but not :creator and :admin' do
+    let!(:other_org_plan) { create(:plan, :creator, :publicly_visible, org: other_org) }
+
+    subject { org.org_admin_plans }
+
+    shared_examples 'org_admin_plans expectations' do |org_admins_read_all: true|
       before do
-        Rails.configuration.x.plans.org_admins_read_all = true
-        # Creator and admin belongs to different orgs
-        @plan = create(:plan, :creator, :organisationally_visible, org: create(:org))
-        @plan.add_user!(create(:org).id, :administrator)
-        # Commenter belongs to org1
-        @plan.add_user!(create(:user, org: org1).id, :commentor)
+        Rails.configuration.x.plans.org_admins_read_all = org_admins_read_all
       end
 
-      it { is_expected.not_to include(@plan) }
+      it 'includes/excludes the expected plans' do
+        expect(subject).to include(*Array(included))
+        expect(subject).not_to include(*Array(excluded))
+      end
     end
 
-    context 'user belongs to Org and plan user with role :reviewer, but not :creator and :admin' do
-      before do
-        Rails.configuration.x.plans.org_admins_read_all = true
-        # Creator and admin belongs to different orgs
-        @plan = create(:plan, :creator, :organisationally_visible, org: create(:org))
-        @plan.add_user!(create(:org).id, :administrator)
-        # Reviewer belongs to org1
-        @plan.add_user!(create(:user, org: org1).id, :reviewer)
+    context 'default context with org_admins_read_all = true' do
+      include_examples 'org_admin_plans expectations' do
+        let(:included) { all_plans }
+        let(:excluded) { other_org_plan }
       end
-
-      it { is_expected.not_to include(@plan) }
     end
 
-    context 'read_all is false, visibility private and user org_admin' do
-      before do
-        Rails.configuration.x.plans.org_admins_read_all = false
-        @user = create(:user, :org_admin, org: org1)
-        @plan = create(:plan, :creator, :privately_visible, org: org1)
-        @plan.add_user!(@user.id, :reviewer)
+    context 'default context with org_admins_read_all = false' do
+      let(:private_and_test_plans) do
+        plans.fetch_values(:native, :affiliated).flat_map do |h|
+          h.values_at(:private, :test)
+        end
       end
 
-      it { is_expected.not_to include(@plan) }
+      include_examples 'org_admin_plans expectations', org_admins_read_all: false do
+        let(:included) { (all_plans - private_and_test_plans).flatten }
+        let(:excluded) { private_and_test_plans + [other_org_plan] }
+      end
     end
 
-    context 'read_all is false, visibility public and user org_admin' do
+    context 'creator role is deactivated for some native and affiliated plans' do
+      # Deactivate the creator role for both a native and an affiliated plan
+      let(:plans_to_deactivate) { [plans[:native][:public], plans[:affiliated][:public]] }
       before do
-        Rails.configuration.x.plans.org_admins_read_all = false
-        @user = create(:user, :org_admin, org: org1)
-        @plan = create(:plan, :creator, :publicly_visible, org: org1)
-        @plan.add_user!(@user.id, :reviewer)
+        deactivate_roles_for_plans(plans_to_deactivate, Role.creator_condition)
       end
 
-      it { is_expected.to include(@plan) }
+      include_examples 'org_admin_plans expectations' do
+        let(:included) { (all_plans - plans_to_deactivate).flatten }
+        let(:excluded) { plans_to_deactivate + [other_org_plan] }
+      end
+    end
+
+    context 'administrator role is deactivated for some affiliated plans' do
+      # Deactivate the administrator role for some affiliated plans
+      let(:plans_to_deactivate) { [plans[:affiliated][:public], plans[:affiliated][:org]] }
+      before do
+        deactivate_roles_for_plans(plans_to_deactivate, Role.administrator_condition)
+      end
+
+      include_examples 'org_admin_plans expectations' do
+        let(:included) { (all_plans - plans_to_deactivate).flatten }
+        let(:excluded) { plans_to_deactivate + [other_org_plan] }
+      end
     end
   end
 

--- a/spec/models/org_spec.rb
+++ b/spec/models/org_spec.rb
@@ -377,11 +377,12 @@ RSpec.describe Org, type: :model do
       it { is_expected.not_to include(org1plan4) }
     end
 
-    context 'when user belongs to Org and a plan removed by creator, but cowner still active.' do
+    context 'when user belongs to Org and a plan removed by creator, but coowner still active.' do
       before do
         Rails.configuration.x.plans.org_admins_read_all = true
         coowner = create(:user, org: org1)
-        org1plan4.add_user!(coowner.id, :coowner)
+        #  Add coowner to the plan by giving user the role administrator
+        org1plan4.add_user!(coowner.id, :administrator)
         owner_id = org1plan4.owner.id
         org1plan4.roles.map { |r| r.update(active: false) if r.user_id == owner_id }
       end


### PR DESCRIPTION
    Organisation Plans and the related CSV Download".

    **Changes:**
    - where(Role.creator_condition) condition added to Plans retrieved in the Org model's org_admin_plans method. This ensures that Plans returned are only active plans. Note: if an owner or co-owner de-activates a plan the Role of the user is set to active: false, so any plan with creator with role (having active: false) would mean the Plan is removed.
    - To avoid duplication we removed .where(Role.creator_condition) in org_admin method in app/controllers/paginable/plans_controller.rb from line plans = plans.joins(:template, roles: [user::org]).where(Role.creator_condition).
    - Updated RSpec tests for Org method org_admin_plans() in spec/models/org_spec.rb.
    - Update CHANGELOG.


Under the current code an Org plan that is removed by owner or coowner will be visible by the Org admins for the Org in the CSV. The Org Admin, correctly, does not show plan. With this change in code the removed plan is no longer present in the CSV.
**To test:**
Look at a given removed plan before and after code change.