### PR TITLE
Timeout session after inactivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v5.0.2
 - Bump Ruby to v3.1.4 and use `.ruby-version` in CI [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)
+- Enable session timeout after 90 minutes of inactivity [#3568](https://github.com/DMPRoadmap/roadmap/pull/3568)
 
 ## v5.0.1
 - Updated seeds.rb file for identifier_schemes to include context value and removed logo_url and idenitifier_prefix for Shibboleth (as it was causing issues with SSO). [#3525](https://github.com/DMPRoadmap/roadmap/pull/3525)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,9 +63,9 @@ class User < ApplicationRecord
   # Devise
   #   Include default devise modules. Others available are:
   #   :token_authenticatable, :confirmable,
-  #   :lockable, :timeoutable and :omniauthable
+  #   :lockable and :omniauthable
   devise :invitable, :database_authenticatable, :registerable, :recoverable,
-         :rememberable, :trackable, :validatable, :omniauthable,
+         :rememberable, :trackable, :validatable, :omniauthable, :timeoutable,
          omniauth_providers: %i[shibboleth orcid]
 
   # default user language to the default language

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -172,7 +172,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 3.hours
+  config.timeout_in = 90.minutes
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false


### PR DESCRIPTION
Fixes sessions not timing out after inactivity.

Changes proposed in this PR:
- Use devise's `timeoutable` gem to timeout sessions after inactivity.
- Inactivity counts as anything that is not a request to the app. So scrolling, typing, and mouse movement with no requests all count as inactivity.
- After the inactivity period has passed, the user will be signed out once they make a request to the app post timeout and will then be redirected to the login page with the flash message "Your session expired, please sign in again to continue".