### PR TITLE
Fix danger.yml workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -17,7 +17,6 @@ jobs:
     # Install Ruby - using the version found in the Gemfile.lock
     - name: 'Install Ruby'
       uses: ruby/setup-ruby@v1
-      with:
 
     - name: 'Bundle Install'
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## v5.0.2
-- Bump Ruby to v3.1.4 and use `.ruby-version` in CI [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)
+- Bump Ruby to v3.1.4 and use `.ruby-version` in CI
+  - [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)
+  - [#3573](https://github.com/DMPRoadmap/roadmap/pull/3573)
 - Enable session timeout after 90 minutes of inactivity [#3568](https://github.com/DMPRoadmap/roadmap/pull/3568)
 - Validate CSV Separator [#3569](https://github.com/DMPRoadmap/roadmap/pull/3569)
 - Fix rendering of `confirm_merge` partial [#3567](https://github.com/DMPRoadmap/roadmap/pull/3567)


### PR DESCRIPTION
# Changes proposed in this PR:
Resolves the following error:
[Invalid workflow file: .github/workflows/danger.yml#L1 (Line: 20, Col: 12): Unexpected value ''](https://github.com/DMPRoadmap/roadmap/actions/runs/18349609764)

Commit 8b95198184178a48b9e9796b79169a2c09b23b9b should've removed this alongside the `ruby-version: ` code.