### PR TITLE
DRAFT PR: Added feature "Org admins can show/hide the ethical_issues field on p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Feature for Org admins can show/hide the ethical_issues field on plans [#3555](https://github.com/DMPRoadmap/roadmap/pull/3555) if config enabled.
+
 ## v5.0.2
 - Bump Ruby to v3.1.4 and use `.ruby-version` in CI
   - [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)

--- a/app/controllers/org_admin/templates_controller.rb
+++ b/app/controllers/org_admin/templates_controller.rb
@@ -380,7 +380,7 @@ module OrgAdmin
       #         }
       # While this is working as-is we should consider folding these into
       # the template: :links context.
-      params.require(:template).permit(:title, :description, :visibility, :links)
+      params.require(:template).permit(:title, :description, :visibility, :links, :hide_ethical_issues_question)
     end
 
     def parse_visibility(args, org)

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -19,6 +19,7 @@
 #  updated_at       :datetime
 #  family_id        :integer
 #  org_id           :integer
+#  hide_ethical_issues_question :boolean
 #
 # Indexes
 #
@@ -62,6 +63,7 @@ class Template < ApplicationRecord
   attribute :customization_of, :integer, default: nil
   attribute :family_id, :integer, default: -> { Template.new_family_id }
   attribute :visibility, default: Template.visibilities[:organisationally_visible]
+  attribute :hide_ethical_issues_question, :boolean, default: false
 
   # ================
   # = Associations =

--- a/app/views/org_admin/templates/_form.html.erb
+++ b/app/views/org_admin/templates/_form.html.erb
@@ -1,4 +1,5 @@
 <% description_tooltip = _('Enter a description that helps you to differentiate between templates e.g. if you have ones for different audiences') %>
+<% hide_ethics_tooltip = _('If checked, the question about ethical issues will be hidden when creating a plan using this template. This setting only applies if the global setting to enable ethical issues is also enabled.') %>
 
 <div class="form-control mb-3 col-xs-8">
   <%= f.label(:title, _('Title'), class: "form-label") %>
@@ -10,6 +11,22 @@
   <%= f.label(:description, _('Description'), class: "form-label") %>
   <%= f.text_area(:description, class: "template", spellcheck: true) %>
 </div>
+
+<% if Rails.configuration.x.madmp.enable_ethical_issues &&  Rails.configuration.x.madmp.enable_hide_ethical_issues_per_template %>
+  <!-- Show the ethical issues question if the global flag is enabled and either the per-template flag is disabled
+       or if the per-template flag is enabled and the current template does not have the hide_ethical_issues_question set to true -->
+  <div class="form-control mb-3">
+    <div class="col-lg-8">
+      <div class="form-check">
+        <%= f.label(:hide_ethical_issues_question, class: 'form-label', title: hide_ethics_tooltip) do %>
+          <%= f.check_box(:hide_ethical_issues_question, {},
+                          true, false) %>
+          <%= _('Hide question about ethical issues') %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>
 
 <% if current_user.org.funder? && !current_user.org.funder_only? %>
   <!-- If the Org is a funder and another org type then allow then to set the visibility -->

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -102,7 +102,11 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
   </div>
 <% end %>
 
-<% if Rails.configuration.x.madmp.enable_ethical_issues %>
+<!-- This condition allows the existing functionality of displaying the Ethical Issues fragment with new feature proposed in 
+ https://github.com/DMPRoadmap/roadmap/issues/3555 -->
+<% if Rails.configuration.x.madmp.enable_ethical_issues && 
+      (!Rails.configuration.x.madmp.enable_hide_ethical_issues_per_template  || 
+       (Rails.configuration.x.madmp.enable_hide_ethical_issues_per_template  && plan.template.present?  && !plan.template.hide_ethical_issues_question)) %>
   <conditional>
     <div class="form-control mb-3">
       <div class="col-lg-8">

--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -224,6 +224,14 @@ module DMPRoadmap
     config.x.madmp.enable_ethical_issues = true
     config.x.madmp.enable_research_domain = true
 
+    # If enable_ethical_issues is true, this flag hide_ethical_issues_question_per_template comes into play.
+    # It will determine if the ethical_issues question is hidden/shown based on the template selected for the plan.
+    # If the template has the hide_ethical_issues attribute set to true, then the question will be hidden.
+    # If the template has the hide_ethical_issues is set to false, then the question will be shown.
+    # If enable_ethical_issues is false, this flag has no effect.
+    # config.x.madmp.enable_hide_ethical_issues_per_template  = true
+    config.x.madmp.enable_hide_ethical_issues_per_template = false
+
     # This flag will enable/disable the entire Research Outputs tab. The others below will
     # just enable/disable specific functionality on the Research Outputs tab
     config.x.madmp.enable_research_outputs = true

--- a/db/migrate/20251016134521_add_hide_ethical_issues_question_to_templates.rb
+++ b/db/migrate/20251016134521_add_hide_ethical_issues_question_to_templates.rb
@@ -1,0 +1,5 @@
+class AddHideEthicalIssuesQuestionToTemplates < ActiveRecord::Migration[7.1]
+  def change
+    add_column :templates, :hide_ethical_issues_question, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_15_102816) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_16_134521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -548,6 +548,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_15_102816) do
     t.integer "family_id"
     t.boolean "archived"
     t.text "links"
+    t.boolean "hide_ethical_issues_question"
     t.index ["family_id", "version"], name: "index_templates_on_family_id_and_version", unique: true
     t.index ["family_id"], name: "index_templates_on_family_id"
     t.index ["org_id", "family_id"], name: "template_organisation_dmptemplate_index"


### PR DESCRIPTION
…lans" #3555 
Changes:

(1) Added a property Rails.configuration.x.madmp.enable_ethical_issues_per_template to configuration which works as follows: If Rails.configuration.x.madmp.enable_ethical_issues is true, this flag hide_ethical_issues_question_per_template comes into play. It will determine if the ethical_issues question is hidden/shown based on the template selected for the plan. If the template has the hide_ethical_issues attribute set to true, then the question will be hidden. If the template has the hide_ethical_issues is set to false, then the question will be shown.

(2) Added to Template model
    attribute :hide_ethical_issues_question, :boolean, default: false
with migration.

(3) Added a safe param :hide_ethical_issues_question to the org admin Template controller.

(4) Updated the app/views/org_admin/templates/_form.html.erb to display a checkbox for "Hide question about ethical issues". This checkbox will only appear if Rails.configuration.x.madmp.enable_ethical_issues and Rails.configuration.x.madmp.enable_ethical_issues_per_template are both set to true in config.

(5) Updated the conitional for display of the ethical issues question in the Project details page as follows:
<% if Rails.configuration.x.madmp.enable_ethical_issues &&
      (!Rails.configuration.x.madmp.enable_hide_ethical_issues_per_template  ||
       (Rails.configuration.x.madmp.enable_hide_ethical_issues_per_template  && plan.template.present? && plan.template.hide_ethical_issues_question.present? && !plan.template.hide_ethical_issues_question)) %>
