### PR TITLE
Issue #3555 - Added feature for Org admins can show/hide the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Feature for Org admins can show/hide the ethical_issues field on plans [#3555](https://github.com/DMPRoadmap/roadmap/pull/3555).
+
 ## v5.0.2
 - Bump Ruby to v3.1.4 and use `.ruby-version` in CI
   - [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)

--- a/app/controllers/orgs_controller.rb
+++ b/app/controllers/orgs_controller.rb
@@ -222,6 +222,7 @@ class OrgsController < ApplicationController
           .permit(:name, :abbreviation, :logo, :contact_email, :contact_name,
                   :remove_logo, :managed, :feedback_enabled, :org_links,
                   :funder, :institution, :organisation,
+                  :add_ro_ethical_concerns,
                   :feedback_msg, :org_id, :org_name, :org_crosswalk,
                   :helpdesk_email,
                   identifiers_attributes: %i[identifier_scheme_id value],

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -25,6 +25,7 @@
 #  region_id              :integer
 #  managed                :boolean          default(false), not null
 #  helpdesk_email         :string
+#  add_ro_ethical_concerns  :boolean        default(true), not null
 #
 # Foreign Keys
 #

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -180,7 +180,37 @@
       </div>
     <% end %>
   </div>
+  <hr>
+  <%# Organisation Permissions block where super admin can add:
+    "Project details" tab in a plan
+  %>
 
+  <% org_perms_header_block = capture do %>
+    <h3>
+      <%= _('Organisation Permissions') %>
+    </h3>
+  <% end %>
+
+  <% add_ro_ethical_concerns_block = capture do %>
+    <div class="checkbox">
+      <%= f.label :add_ro_ethical_concerns do %>
+        <%= f.check_box :add_ro_ethical_concerns, { class: 'org_types', value: org.add_ro_ethical_concerns?  }, "true", "false" %>
+        <%= _('Add "Research outputs may have ethical concerns" field to "Project details" tab in plans') %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div class="row">
+    <% if current_user.can_super_admin? %>
+      <fieldset class="col-sm-8">
+        <%= org_perms_header_block %>
+        <%= add_ro_ethical_concerns_block %>
+      </fieldset>
+    <% elsif current_user.can_org_admin? %>
+      <%= org_perms_header_block %>
+      <%= add_ro_ethical_concerns_block %>
+    <% end %>
+  </div>
   <hr>
 
   <% if !org.new_record? %>

--- a/app/views/orgs/_profile_form.html.erb
+++ b/app/views/orgs/_profile_form.html.erb
@@ -200,18 +200,15 @@
     </div>
   <% end %>
 
-  <div class="row">
-    <% if current_user.can_super_admin? %>
+  <% if current_user.can_org_admin? %>
+     <div class="row">
       <fieldset class="col-sm-8">
         <%= org_perms_header_block %>
         <%= add_ro_ethical_concerns_block %>
       </fieldset>
-    <% elsif current_user.can_org_admin? %>
-      <%= org_perms_header_block %>
-      <%= add_ro_ethical_concerns_block %>
-    <% end %>
-  </div>
-  <hr>
+    </div>
+    <hr>
+  <% end %>
 
   <% if !org.new_record? %>
     <%= render partial: "orgs/external_identifiers",

--- a/app/views/plans/_project_details.html.erb
+++ b/app/views/plans/_project_details.html.erb
@@ -102,7 +102,7 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
   </div>
 <% end %>
 
-<% if Rails.configuration.x.madmp.enable_ethical_issues %>
+<% ethical_issues_block = capture do %>
   <conditional>
     <div class="form-control mb-3">
       <div class="col-lg-8">
@@ -141,6 +141,16 @@ ethics_report_tooltip = _("Link to a protocol from a meeting with an ethics comm
       </div>
     </div>
   </conditional>
+<% end %>
+
+<% if Rails.configuration.x.madmp.enable_ethical_issues %>
+    <% if plan.ethical_issues == true %>
+      <%= ethical_issues_block %>
+    <% else %>
+      <% if current_user.org.add_ro_ethical_concerns? %>
+        <%= ethical_issues_block %>
+      <% end %>
+    <% end %>
 <% end %>
 
 <conditional>

--- a/db/migrate/20250829093759_add_add_ro_ethical_concerns_to_orgs.rb
+++ b/db/migrate/20250829093759_add_add_ro_ethical_concerns_to_orgs.rb
@@ -1,0 +1,6 @@
+class AddAddRoEthicalConcernsToOrgs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :orgs, :add_ro_ethical_concerns, :boolean, default: true, null: false
+    Org.update_all(add_ro_ethical_concerns: true)
+  end
+end

--- a/db/migrate/20251027100520_add_add_ro_ethical_concerns_to_orgs.rb
+++ b/db/migrate/20251027100520_add_add_ro_ethical_concerns_to_orgs.rb
@@ -1,4 +1,4 @@
-class AddAddRoEthicalConcernsToOrgs < ActiveRecord::Migration[6.1]
+class AddAddRoEthicalConcernsToOrgs < ActiveRecord::Migration[7.1]
   def change
     add_column :orgs, :add_ro_ethical_concerns, :boolean, default: true, null: false
     Org.update_all(add_ro_ethical_concerns: true)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_15_102816) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_16_134521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -276,6 +276,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_15_102816) do
     t.string "api_create_plan_email_subject"
     t.text "api_create_plan_email_body"
     t.string "helpdesk_email"
+    t.boolean "add_ro_ethical_concerns", default: true, null: false
     t.index ["language_id"], name: "fk_rails_5640112cab"
     t.index ["region_id"], name: "fk_rails_5a6adf6bab"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_10_16_134521) do
+ActiveRecord::Schema[7.1].define(version: 2025_10_27_100520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Ethical_Issues fragment in plans project details page.
Co-authored-by: don-stuckey <dstuckey@ed.ac.uk>

This feature was contributed to DMPonline by @don-stuckey.

**Changes:**
- These changes only kick in if enable_ethical_issues is enable in the application config.
- Added to Org model attribute in a migration add_ro_ethical_concerns  :boolean  default(true), not null
- Added a checkbox '_Add "Research outputs may have ethical concerns" field to "Project details" tab in plans_' to app/views/orgs/_profile_form.html.erb.
- Added code to the Plan Project Details view to show or hide the Ethical Issues fragment.
- Added :add_ro_ethical_concerns to the strong params org_params for the Org controller.

Here is the spec and tests compiled by @don-stuckey who contributed this feature to DMPonline:

**Specification**
For each organisation’s profile in DMPonline, the “Organisation Permission” section now includes the checkbox “Add "Research outputs may have ethical concerns" field to "Project details" tab in plans”, and the default value of this checkbox is true.

**Test 1: Ensuring that the option to enable / disable the "Research outputs may have ethical concerns" checkbox for an organisation is available for super-admins** 

Test steps: 

    tester signs in as a super-admin and opens their organisation, e.g. “Organisation 1” (Org1) in edit mode 

Expected results: 

    tester sees the option to enable / disable the "Research outputs may have ethical concerns" checkbox for the organisation 

**Test 2: Ensuring that the option to enable / disable the "Research outputs may have ethical concerns" checkbox for an organisation is available for org-admins for their organisation** 

Test steps: 

    tester signs in as a org-admin and opens their organisation, e.g. “Organisation 1” (Org1) in edit mode 

Expected results: 

    tester sees the option to enable / disable the "Research outputs may have ethical concerns" checkbox for their organisation 

**Test 3: Disabling "Research outputs may have ethical concerns" checkbox for an organisation** 

Test steps: 

    tester signs in as a org-admin and opens their organisation, e.g. “Organisation 1” (Org1) in edit mode 

    tester de-selects the checkbox “Organisation Permissions > “Add "Research outputs may have ethical concerns" field to "Project details" tab in plans” and selects “Save” 

    tester signs in as a standard user associated with Org1 

    tester creates a plan and saves a plan 

Expected results: 

    tester does not see the "Research outputs may have ethical concerns" field in the “Project details” page on creating a plan or on editing that plan they just created 

**Test 4: Ensuring that existing plans that have the "Research outputs may have ethical concerns" checkbox checked still have that field as visible if the organisation disables the "Research outputs may have ethical concerns" checkbox** 

Test steps: 

    tester signs in as a org-admin and opens an organisation, e.g. “Organisation 1” (Org1) in edit mode, and ensures that  

    the “Organisation Permissions > “Add "Research outputs may have ethical concerns" field to "Project details" tab in plans” field is checked 

    tester signs in as a standard user associated with Org1 

    tester creates a plan, checks the  "Research outputs may have ethical concerns" field, and saves the plan 

    tester signs in as a org-admin and opens up Org1 in edit mode 

    tester then deselects the “Organisation Permissions > “Add "Research outputs may have ethical concerns" field to "Project details" tab in plans” checkbox and saves the change 

    tester signs in as a standard user  

Expected results: 

    tester should still see the "Research outputs may have ethical concerns" checkbox in the plan they created even though that field has been disabled for all new (not existing) plans going forward 

**Test 5: Ensuring that existing plans that have the do not have the "Research outputs may have ethical concerns" checkbox checked subsequently do not show that field when the organisation disables the "Research outputs may have ethical concerns" checkbox** 

Test steps: 

    tester signs in as a org-admin and opens an organisation, e.g. “Organisation 1” (Org1) in edit mode, and ensures that  

    the “Organisation Permissions > “Add "Research outputs may have ethical concerns" field to "Project details" tab in plans” checkbox is checked 

    tester signs in as a standard user associated with Org1 

    tester creates a plan, and does not check the "Research outputs may have ethical concerns" checkbox, and saves the plan 

    tester signs in as a org-admin and opens up Org1 in edit mode 

    tester then de-selects the “Organisation Permissions > “Add "Research outputs may have ethical concerns" field to "Project details" tab in plans” checkbox and saves the change 

    tester signs in as a standard user and opens the plan they just created 

Expected results: 

    tester should not see the "Research outputs may have ethical concerns" checkbox in the plan they created 

<img width="873" height="780" alt="Selection_139" src="https://github.com/user-attachments/assets/151c1cce-2584-4541-8809-31190f8fb8b6" />

<img width="883" height="834" alt="Selection_140" src="https://github.com/user-attachments/assets/1c28ea70-96b3-41ff-ab9b-c28b3a5b577a" />

<img width="896" height="645" alt="Selection_141" src="https://github.com/user-attachments/assets/6670b3a3-a2b1-4e04-abcb-838a62eaa983" />
