### PR TITLE
Redesigned plan-creation page to enforce template access rules and simplify UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Redesigned plan-creation page to enforce template access rules and simplify UI [#3534](https://github.com/DMPRoadmap/roadmap/issues/3534)
+
 ## v5.0.2
 - Bump Ruby to v3.1.4 and use `.ruby-version` in CI
   - [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)

--- a/app/assets/stylesheets/blocks/_forms.scss
+++ b/app/assets/stylesheets/blocks/_forms.scss
@@ -1,21 +1,55 @@
 @use '../variables/colours' as *;
 
-.form-control {
-    border: 0px;
-}
 
-.form-control input, .form-control textarea, .form-control select{
-    border: 2px solid $color-border-light;
+
+.form-control input,
+.form-control textarea,
+.form-control select {
+  border: 2px solid $color-border-light;
 }
 
 .form-check {
-    padding-left: 0rem;
+  padding-left: 0rem;
 }
 
-.form-inline{
-    margin-bottom: 5px;
+.form-inline {
+  margin-bottom: 5px;
 }
 
 .form-check-label {
-    padding-left: 5px;
+  padding-left: 5px;
+}
+
+// Added for new plan create page app/views/plans/new.html.erb
+.roadmap-form {
+  margin-bottom: 1rem;
+
+  legend {
+    padding-inline: 2px;
+    float: none;
+    width: auto;
+    padding: 0.5rem;
+    font-size: 1rem;
+    background-color: $color-primary-background;
+    color: $color-primary-text;
+  }
+
+  fieldset {
+    border: 2px solid #555555;
+    padding: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .form-row {
+    margin-bottom: 1rem;
+  }
+
+  .form-row:last-child {
+    margin-bottom: 0;
+  }
+
+  .form-check .form-check-input {
+    float: left;
+    margin-left: 0.5rem;
+  }
 }

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -29,62 +29,15 @@ class PlansController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   # GET /plans/new
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def new
     @plan = Plan.new
     authorize @plan
-    @plan.org_id = current_user.org&.id
-    # looks into the list of families of templates
-    customizations = Template.latest_customized_version_per_org(@plan.org_id)
-    customization_ids = customizations.select(&:published?).collect(&:customization_of)
+    org_id = current_user.org&.id
 
-    # get templates of user's own org
-    user_org_own_templates = Template.organisationally_visible
-                                     .where(org_id: @plan.org_id, customization_of: nil)
-                                     .published
-                                     .uniq.sort_by(&:title)
-
-    # get templates of user's customised org
-    user_org_custom_templates = Template.latest_customized_version_per_org(@plan.org_id)
-                                        .published
-                                        .uniq.sort_by(&:title)
-
-    # get funder templates no customised templates
-    funder_non_customised_templates = Template.published
-                                              .joins(:org)
-                                              .where(orgs: { org_type: Org.org_type_values_for(:funder) })
-                                              # The next line removes templates that belong to a family that
-                                              # has customised templates
-                                              .where.not(family_id: customization_ids)
-                                              .uniq.sort_by(&:title)
-
-    # get global templates
-    global_templates = Template.published
-                               .where(is_default: true)
-                               # The next line removes templates that belong to a family that
-                               # has customised templates
-                               .where.not(family_id: customization_ids)
-                               .uniq.sort_by(&:title)
-
-    # create templates-grouped hash
-    @templates_grouped = {
-      _("Your Organisation's Templates:") => user_org_own_templates.map do |t|
-        [t.title, t.id]
-      end,
-      _("Your Organisation's Customised Templates:") => user_org_custom_templates.map do |t|
-        [t.title, t.id]
-      end,
-      _('Global Templates:') => global_templates.map do |t|
-        [t.title, t.id]
-      end,
-      _('Funder Templates:') => funder_non_customised_templates.map do |t|
-        [t.title, t.id]
-      end
-    }.reject { |_, val| val.empty? }
-
+    # Get templates grouped hash
+    @templates_grouped = templates_available_to_org_user(org_id)
     respond_to :html
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   # POST /plans
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -102,6 +55,15 @@ class PlansController < ApplicationController
         format.html { redirect_to new_plan_path }
       end
     else
+      template_id = plan_params[:template_id].to_i
+      unless validate_template_available_to_org_user?(template_id, current_user.org_id)
+        respond_to do |format|
+          flash[:alert] = _('The selected template is not available to your organisation.')
+          format.html { redirect_to new_plan_path }
+        end
+        return
+      end
+
       @plan.visibility = if plan_params['visibility'].blank?
                            Rails.configuration.x.plans.default_visibility
                          else
@@ -567,6 +529,68 @@ class PlansController < ApplicationController
              answers: answers,
              guidance_presenter: GuidancePresenter.new(plan)
            })
+  end
+
+  # Get templates available to org users
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+  def templates_available_to_org_user(org_id)
+    # looks into the list of families of templates
+    customizations = Template.latest_customized_version_per_org(org_id)
+    customization_ids = customizations.select(&:published?).collect(&:customization_of)
+
+    # get templates of user's own org
+    user_org_own_templates = Template.organisationally_visible
+                                     .where(org_id: org_id, customization_of: nil)
+                                     .published
+                                     .uniq.sort_by(&:title)
+
+    # get templates of user's customised org
+    user_org_custom_templates = Template.latest_customized_version_per_org(org_id)
+                                        .published
+                                        .uniq.sort_by(&:title)
+
+    # get funder templates no customised templates
+    funder_non_customised_templates = Template.published
+                                              .joins(:org)
+                                              .where(orgs: { org_type: Org.org_type_values_for(:funder) })
+                                              # The next line removes templates that belong to a family that
+                                              # has customised templates
+                                              .where.not(family_id: customization_ids)
+                                              .uniq.sort_by(&:title)
+
+    # get global templates
+    global_templates = Template.published
+                               .where(is_default: true)
+                               # The next line removes templates that belong to a family that
+                               # has customised templates
+                               .where.not(family_id: customization_ids)
+                               .uniq.sort_by(&:title)
+
+    # create templates-grouped hash
+    @templates_grouped = {
+      _("Your Organisation's Templates:") => user_org_own_templates.map do |t|
+        [t.title, t.id]
+      end,
+      _("Your Organisation's Customised Templates:") => user_org_custom_templates.map do |t|
+        [t.title, t.id]
+      end,
+      _('Global Templates:') => global_templates.map do |t|
+        [t.title, t.id]
+      end,
+      _('Funder Templates:') => funder_non_customised_templates.map do |t|
+        [t.title, t.id]
+      end
+    }.reject { |_, val| val.empty? }
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+  # Validate that a template_id is available to the org user
+  def validate_template_available_to_org_user?(template_id, org_id)
+    return false if template_id.blank? || org_id.blank?
+
+    available_templates = templates_available_to_org_user(org_id)
+    available_template_ids = available_templates.values.flat_map { |group| group.map(&:last) }
+    available_template_ids.include?(template_id.to_i)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -29,31 +29,43 @@ class PlansController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   # GET /plans/new
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def new
     @plan = Plan.new
     authorize @plan
 
-    # Get all of the available funders and non-funder orgs
-    @funders = Org.funder
-                  .includes(identifiers: :identifier_scheme)
-                  .joins(:templates)
-                  .where(templates: { published: true }).uniq.sort_by(&:name)
-    @orgs = (Org.includes(identifiers: :identifier_scheme).organisation +
-             Org.includes(identifiers: :identifier_scheme).institution +
-             Org.includes(identifiers: :identifier_scheme).default_orgs)
-    @orgs = @orgs.flatten.uniq.sort_by(&:name)
+    # get funder templates
+    funder_templates = Template.published
+                               .joins(:org)
+                               .merge(Org.funder)
+                               .distinct
 
-    @plan.org_id = current_user.org&.id
+    # get global templates
+    global_templates = Template.published
+                               .where(is_default: true)
+                               .distinct
 
-    # TODO: is this still used? We cannot switch this to use the :plan_params
-    #       strong params because any calls that do not include `plan` in the
-    #       query string will fail
-    flash[:notice] = "#{_('This is a')} <strong>#{_('test plan')}</strong>" if params.key?(:test)
-    @is_test = params[:test] ||= false
+    # get templates of user's org
+    user_org_templates = Template.published
+                                 .where(org: current_user.org)
+                                 .distinct
+
+    # create templates-grouped hash
+    @templates_grouped = {
+      _("Your Organisation's Templates:") => user_org_templates.map do |t|
+        [t.title, t.id]
+      end,
+      _('Global Templates:') => global_templates.map do |t|
+        [t.title, t.id]
+      end,
+      _('Funder Templates:') => funder_templates.map do |t|
+        [t.title, t.id]
+      end
+    }.reject { |_, val| val.empty? }
+
     respond_to :html
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   # POST /plans
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -45,7 +45,8 @@ class PlansController < ApplicationController
                                      .uniq.sort_by(&:title)
 
     # get templates of user's customised org
-    user_org_custom_templates = Template.latest_customizable.where(family_id: customization_ids)
+    user_org_custom_templates = Template.latest_customized_version_per_org(@plan.org_id)
+                                        .published
                                         .uniq.sort_by(&:title)
 
     # get funder templates no customised templates

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -29,43 +29,61 @@ class PlansController < ApplicationController
   # rubocop:enable Metrics/AbcSize
 
   # GET /plans/new
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def new
     @plan = Plan.new
     authorize @plan
+    @plan.org_id = current_user.org&.id
+    # looks into the list of families of templates
+    customizations = Template.latest_customized_version_per_org(@plan.org_id)
+    customization_ids = customizations.select(&:published?).collect(&:customization_of)
 
-    # get funder templates
-    funder_templates = Template.published
-                               .joins(:org)
-                               .merge(Org.funder)
-                               .distinct
+    # get templates of user's own org
+    user_org_own_templates = Template.organisationally_visible
+                                     .where(org_id: @plan.org_id, customization_of: nil)
+                                     .published
+                                     .uniq.sort_by(&:title)
+
+    # get templates of user's customised org
+    user_org_custom_templates = Template.latest_customizable.where(family_id: customization_ids)
+                                        .uniq.sort_by(&:title)
+
+    # get funder templates no customised templates
+    funder_non_customised_templates = Template.published
+                                              .joins(:org)
+                                              .where(orgs: { org_type: Org.org_type_values_for(:funder) })
+                                              # The next line removes templates that belong to a family that
+                                              # has customised templates
+                                              .where.not(family_id: customization_ids)
+                                              .uniq.sort_by(&:title)
 
     # get global templates
     global_templates = Template.published
                                .where(is_default: true)
-                               .distinct
-
-    # get templates of user's org
-    user_org_templates = Template.published
-                                 .where(org: current_user.org)
-                                 .distinct
+                               # The next line removes templates that belong to a family that
+                               # has customised templates
+                               .where.not(family_id: customization_ids)
+                               .uniq.sort_by(&:title)
 
     # create templates-grouped hash
     @templates_grouped = {
-      _("Your Organisation's Templates:") => user_org_templates.map do |t|
+      _("Your Organisation's Templates:") => user_org_own_templates.map do |t|
+        [t.title, t.id]
+      end,
+      _("Your Organisation's Customised Templates:") => user_org_custom_templates.map do |t|
         [t.title, t.id]
       end,
       _('Global Templates:') => global_templates.map do |t|
         [t.title, t.id]
       end,
-      _('Funder Templates:') => funder_templates.map do |t|
+      _('Funder Templates:') => funder_non_customised_templates.map do |t|
         [t.title, t.id]
       end
     }.reject { |_, val| val.empty? }
 
     respond_to :html
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   # POST /plans
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/app/views/plans/new.html.erb
+++ b/app/views/plans/new.html.erb
@@ -1,125 +1,90 @@
-<% title _('Create a new plan') %>
-<% required_project_title_tooltip = _('This field is required.') %>
-<% project_title_tooltip = _('If applying for funding, state the project title exactly as in the proposal.') %>
-<% required_research_org_tooltip = _('You must select a research organisation from the list or click the checkbox.') %>
-<% research_org_tooltip = _('Please select a valid research organisation from the list.') %>
-<% required_primary_funding_tooltip = _('You must select a funder from the list or click the checkbox.') %>
-<% primary_funding_tooltip = _('Please select a valid funding organisation from the list.') %>
-
-<div class="row">
-  <div class="col-md-12">
-    <h1><%= _('Create a new plan') %></h1>
-
-    <p class="start-indent">
-      <%= _("Before you get started, we need some information about your research project to set you up with the best DMP template for your needs.") %>
-    </p>
+<form action="<%= plans_path %>" method="post" class="roadmap-form">
+  <div class="row form-row">
+    <div class="col-12">
+      <h1><%= _('Create a new plan') %></h1>
+      <p>
+        <%= _("Before you get started, we need some information about your research project to set you up with the best DMP template for your needs.") %>
+      </p>
+    </div>
   </div>
-</div>
-
-<div class="row">
-  <div class="col-md-12">
-    <%= form_for Plan.new, url: plans_path do |f| %>
-      <!-- Plan name section -->
-      <h2 id="project-title"><span class="red" title="<%= required_project_title_tooltip %>">*<em class="sr-only"><%= required_project_title_tooltip %></em> </span><%= _('What research project are you planning?') %></h2>
-      <div class="row">
-        <div class="form-control mb-3 col-md-8">
-          <%= f.text_field(:title, class: 'form-control', 'aria-labelledby': 'project-title', 'aria-required': 'true', 'aria-label': 'project-title',
-                'data-toggle': 'tooltip',
-                'data-placement': 'bottom',
-                spellcheck: true,
-                title: project_title_tooltip ) %>
-        </div>
-        <div class="form-control mb-3 col-md-6">
-          <div class="checkbox">
-            <%= label_tag(:is_test) do %>
-              <%= check_box_tag(:is_test, "1", false) %>
-              <%= _('mock project for testing, practice, or educational purposes') %>
-            <% end %>
-          </div>
-        </div>
+  <fieldset>
+  <div class="row form-row">
+    <div class="col-12">
+        <!-- Rails form authenticity token -->
+        <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+        <label for="plan_title" id="project-title" class="form-label">
+          <%= _('Enter project title') %>
+        </label>
+        <input type="text"
+              id="plan_title"
+              name="plan[title]"
+              class="form-control"
+              required
+              aria-labelledby="project-title"
+              aria-required="true"
+              aria-label="project-title"
+              data-toggle="tooltip"
+              data-placement="bottom"
+              spellcheck="true">
       </div>
-
-      <!-- Organisation selection -->
-      <h2 id="research-org">
-        <span class="red" title="<%= required_research_org_tooltip %>">*<em class="sr-only"><%= required_research_org_tooltip %></em> </span>
-        <%= _('Select the primary research organisation') %>
-      </h2>
-      <div id="research-org-controls" class="row">
-        <div class="form-control mb-3 col-md-6">
-           <em class="sr-only"><%= research_org_tooltip %></em>
-           <% dflt = @orgs.include?(current_user.org) ? current_user.org : nil %>
-           <%= f.fields_for :org, @plan.org do |org_fields| %>
-             <%= render partial: "shared/org_selectors/local_only",
-                        locals: {
-                          form: org_fields,
-                          id_field: :id,
-                          default_org: dflt,
-                          orgs: @orgs,
-                          required: false
-                        } %>
-          <% end %>
+    </div>
+  <div class="row form-row">
+    <div class="col-12">
+        <div class="form-check">
+          <input type="checkbox"
+                class="form-check-input"
+                id="is_test"
+                value="1">
+          <label class="form-check-label" for="is_test">
+            <%= _('Mock project for testing, practice, or educational purposes') %>
+          </label>
         </div>
-        <div class="col-md-3 text-center"><strong>- <%= _('or') %> -</strong></div>
-        <div class="form-control mb-3 col-md-3">
-          <div class="form-check">
-            <% primary_research_org_message = _('No research organisation associated with this plan or my research organisation is not listed') %>
-            <%= label_tag(:plan_no_org) do %>
-              <%= check_box_tag(:plan_no_org, "0", false, class: "toggle-autocomplete") %>
-              <%= primary_research_org_message %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-
-      <!-- Funder selection -->
-      <h2 id="funder-org"><span class="red" title="<%= required_primary_funding_tooltip %>">* <em class="sr-only"><%= required_primary_funding_tooltip %></em> </span><%= _('Select the primary funding organisation') %></h2>
-      <div id="funder-org-controls" class="row">
-        <div class="form-control mb-3 col-md-6">
-          <em class="sr-only"><%= primary_funding_tooltip %></em>
-          <%= f.fields_for :funder, @plan.funder = Org.new do |funder_fields| %>
-            <%= render partial: "shared/org_selectors/local_only",
-                        locals: {
-                          form: funder_fields,
-                          id_field: :id,
-                          label: _("Funder"),
-                          default_org: nil,
-                          orgs: @funders,
-                          required: false
-                        } %>
-          <% end %>
-        </div>
-        <div class="col-md-3 text-center"><strong>- <%= _('or') %> -</strong></div>
-        <div class="form-control mb-3 col-md-3">
-          <div class="form-check">
-            <% primary_funding_message = _('No funder associated with this plan or my funder is not listed') %>
-            <%= label_tag(:plan_no_funder) do %>
-              <%= check_box_tag(:plan_no_funder, "0", false, class: "toggle-autocomplete") %>
-              <%= primary_funding_message %>
-            <% end %>
-          </div>
-        </div>
-      </div>
-
-      <!-- Template selection -->
-      <div id="available-templates" style="visibility: none;">
-        <%= hidden_field_tag 'template-option-target', template_options_path %>
-        <h2 id="template-selection"><%= _('Which DMP template would you like to use?') %></h2>
-        <div class="form-control mb-3 row">
-          <div class="col-md-6">
-            <%= select_tag(:plan_template_id, "<option value=\"\">#{_('Please select a template')}</option>", name: 'plan[template_id]',
-                           class: 'form-select', 'aria-labelledby': 'template-selection') %>
-          </div>
-          <div class="col-md-6">
-            <span id="multiple-templates">
-              <%= _('We found multiple DMP templates corresponding to your funder.') %>
-            </span>
-          </div>
-        </div>
-      </div>
-
-      <%= f.hidden_field(:visibility, value: @is_test ? 'is_test' : Rails.configuration.x.plans.default_visibility) %>
-      <%= f.button(_('Create plan'), class: "btn btn-primary", type: "submit") %>
-      <%= link_to _('Cancel'), plans_path, class: 'btn btn-secondary' %>
-    <% end %>
+    </div>
   </div>
-</div>
+  </fieldset>
+      <fieldset class="form-group">
+        <legend>
+          <%= _('Select a DMP template') %>
+        </legend>
+  <div class="row form-row">
+    <div class="col-12">
+        <% @templates_grouped.each do |group_label, group_templates| %>
+          <div class="mb-3">
+            <div class="form-label fw-bold">
+              <%= group_label %>
+            </div>
+            <% group_templates.each do |template_title, template_id| %>
+              <div class="form-check">
+                <input
+                class="form-check-input"
+                type="radio"
+                id="template_<%= template_id %>"
+                name="plan[template_id]"
+                value="<%= template_id %>"
+                required
+                aria-labelledby="template_<%= template_id %>"
+                >
+                <label
+                class="form-check-label fw-normal"
+                id="template_<%= template_id %>"
+                for="template_<%= template_id %>"
+                >
+                  <%= template_title %>
+                </label>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+
+    </div>
+  </div>
+  </fieldset>
+  <div class="row form-row">
+    <div class="col-12">
+      <button type="submit" class="btn btn-primary">
+          <%= _('Create') %>
+        </button>
+        <%= link_to _('Cancel'), plans_path, class: 'btn btn-secondary' %>
+    </div>
+  </div>
+</form>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -451,8 +451,18 @@ templates = [
    is_default: false, locale: default_locale,
    version: 0,
    visibility: Template.visibilities[:organisationally_visible],
+   links: {"funder":[],"sample_plan":[]}},
+   
+  {title: "UOS Organizational DMP Template",
+   published: true,
+   description: "Template for internal UOS organizational use",
+   org: Org.find_by(abbreviation: 'UOS'),
+   is_default: false, locale: default_locale,
+   version: 0,
+   visibility: Template.visibilities[:organisationally_visible],
    links: {"funder":[],"sample_plan":[]}}
-]
+  ]
+
 # Template creation calls defaults handler which sets is_default and
 # published to false automatically, so update them after creation
 templates.each { |atts| Template.find_or_create_by(atts) }
@@ -477,13 +487,19 @@ phases = [
   {title: "Detailed Overview",
    number: 2,
    modifiable: false,
-   template: Template.find_by(title: "Department of Testing Award")}
+   template: Template.find_by(title: "Department of Testing Award")},
+
+   {title: "UOS Organizational DMP Phase 1",
+    number: 1,
+    modifiable: true,
+    template: Template.find_by(title: "UOS Organizational DMP Template")}
 ]
 phases.each{ |p| Phase.find_or_create_by(p) }
 
 generic_template_phase_1 = Phase.find_by(title: "Generic Data Management Planning Template")
 funder_template_phase_1  = Phase.find_by(title: "Preliminary Statement of Work")
 funder_template_phase_2  = Phase.find_by(title: "Detailed Overview")
+organizational_template_phase_1 = Phase.find_by(title: "UOS Organizational DMP Phase 1")
 
 # Create sections for the 2 templates and their phases
 # -------------------------------------------------------
@@ -558,7 +574,28 @@ sections = [
     number: 5,
     modifiable: false,
     phase: funder_template_phase_2
+  },
+
+  # Section for UOS organizational DMP Template
+  {
+    title: "Project Information",
+    number: 1,
+    modifiable: true,
+    phase: organizational_template_phase_1
+  },
+  {
+    title: "Project Data Description",
+    number: 2, 
+    modifiable: true,
+    phase: organizational_template_phase_1
+  },
+  {
+    title: "Storage and Security",
+    number: 3,
+    modifiable: true,
+    phase: organizational_template_phase_1
   }
+
 ]
 sections.each{ |s| Section.find_or_create_by(s) }
 
@@ -714,9 +751,67 @@ questions = [
    section: Section.find_by(title: "Preservation and Reuse Policies"),
    question_format: text_area,
    modifiable: false,
-   themes: [Theme.find_by(title: "Preservation"), Theme.find_by(title: "Data Sharing")]}
+   themes: [Theme.find_by(title: "Preservation"), Theme.find_by(title: "Data Sharing")]},
+
+  # Questions for UOS Organizational DMP Template
+   {
+    text: "What is the purpose of the data collection/generation and its relation to the objectives of the project?",
+    number: 1,
+    section: Section.find_by(title: "Project Information"),
+    question_format: QuestionFormat.find_by(title: "Text area"),
+    modifiable: true,
+    themes: [Theme.find_by(title: "Data Description")]
+  },
+  {
+    text: "What types of data will you collect and in what formats?",
+    number: 1, 
+    section: Section.find_by(title: "Project Data Description"),
+    question_format: QuestionFormat.find_by(title: "Text area"),
+    modifiable: true,
+    themes: [Theme.find_by(title: "Data Format")]
+  },
+  {
+    text: "Where and how will the data be stored during the project?",
+    number: 1,
+    section: Section.find_by(title: "Storage and Security"), 
+    question_format: QuestionFormat.find_by(title: "Text area"),
+    modifiable: true,
+    themes: [Theme.find_by(title: "Storage & Security")]
+  }
 ]
 questions.each{ |q| Question.create!(q) unless Question.find_by(section: q[:section], text: q[:text]) }
+
+# Create guidance
+guidance_group = GuidanceGroup.create!(
+  name: "Organizational Template Guidance",
+  org: Org.find_by(abbreviation: Rails.configuration.x.organisation.abbreviation),
+  optional_subset: false,
+  published: true
+)
+
+guidances = [
+  {
+    text: "Clearly describe the purpose of data collection and how it relates to project goals",
+    guidance_group: guidance_group,
+    published: true,
+    themes: [Theme.find_by(title: "Data Description")]
+  },
+  {
+    text: "List file formats and explain why they were chosen",
+    guidance_group: guidance_group, 
+    published: true,
+    themes: [Theme.find_by(title: "Data Format")]
+  },
+  {
+    text: "Detail storage location, backup procedures and access controls",
+    guidance_group: guidance_group,
+    published: true, 
+    themes: [Theme.find_by(title: "Storage & Security")]
+  }
+]
+
+guidances.each { |g| Guidance.create!(g) }
+
 
 radio_button = Question.new(
     text: "Please select the appropriate formats.",

--- a/spec/controllers/plans_controller_templates_spec.rb
+++ b/spec/controllers/plans_controller_templates_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PlansController, type: :controller do
+  describe 'templates availability helpers' do
+    before do
+      @org = create(:org, :organisation, name: 'The User Org')
+      @org_id = @org.id
+
+      @org_template = create(:template, :default, :organisationally_visible, :published, org: @org,
+                                                                                         title: 'Org Template')
+
+      @funder1 = create(:org, :funder, name: 'Funder1 Org')
+      @funder1_template = create(:template, :publicly_visible, :published,
+                                 org: @funder1, title: 'Funder1 Template')
+
+      @org_custom_funder1_template = create(:template, :organisationally_visible, :published,
+                                            org: @org, customization_of: @funder1_template.family_id,
+                                            title: 'Org Customised Funder1 Template')
+
+      @funder2 = create(:org, :funder, name: 'Funder2 Org')
+      @funder2_template = create(:template, :publicly_visible, :published, org: @funder2, title: 'Funder2 Template')
+
+      @global_template = create(:template, :default, :publicly_visible, :published, title: 'Global Template')
+
+      @other_org = create(:org, :organisation, name: 'The Other Org')
+      @other_org_template = create(:template, :organisationally_visible, :published,
+                                   org: @other_org, title: 'Other Org Template')
+    end
+
+    it 'returns a grouped hash containing the available templates' do
+      grouped = controller.send(:templates_available_to_org_user, @org_id)
+      expect(grouped).to be_a(Hash)
+      puts "Grouped templates available to org id #{@org_id}: #{grouped.keys.inspect}"
+
+      # flatten one level to inspect [title, id] entries across groups
+      entries = grouped.values.flatten(1)
+      puts entries.inspect
+      # Available templates
+      expect(entries).to include([@org_template.title, @org_template.id])
+      expect(entries).to include([@org_custom_funder1_template.title, @org_custom_funder1_template.id])
+      expect(entries).to include([@funder2_template.title, @funder2_template.id])
+      expect(entries).to include([@global_template.title, @global_template.id])
+      # Not available templates
+      # As the org has already customised funder1_template, it should not appear in the available list
+      expect(entries).not_to include([@funder1_template.title, @funder1_template.id])
+      # Templates from other orgs should not appear if only organisationally visible
+      expect(entries).not_to include([@other_org_template.title, @other_org_template.id])
+    end
+
+    it 'validates a template id that is available for the org' do
+      expect(controller.send(:validate_template_available_to_org_user?, @org_template.id, @org_id)).to be true
+      expect(controller.send(:validate_template_available_to_org_user?, @org_custom_funder1_template.id,
+                             @org_id)).to be true
+      expect(controller.send(:validate_template_available_to_org_user?, @funder2_template.id, @org_id)).to be true
+      expect(controller.send(:validate_template_available_to_org_user?, @global_template.id, @org_id)).to be true
+    end
+
+    it 'returns false for a template id that is not available for the org' do
+      # As the org has already customised funder1_template, it should not be available
+      expect(controller.send(:validate_template_available_to_org_user?, @funder1_template.id, @org_id)).to be false
+      # Templates from other orgs should not be available if only organisationally visible
+      expect(controller.send(:validate_template_available_to_org_user?, @other_org_template.id, @org_id)).to be false
+    end
+  end
+end

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -6,13 +6,15 @@ RSpec.describe 'Plans', type: :feature do
   include Webmocks
 
   before do
-    @default_template = create(:template, :default, :published)
+    # @default_template = create(:template, :default, :published)
     @org = create(:org)
-    @research_org = create(:org, :organisation, :research_institute,
-                           name: 'Test Research Org', templates: 1)
-    @funding_org  = create(:org, :funder, name: 'Test Funder Org', templates: 1)
-    @template     = create(:template, org: @org)
-    @user         = create(:user, org: @org)
+    @funding_org1  = create(:org, :funder, name: 'Test Funder Org1', templates: 1)
+    @funding_org2  = create(:org, :funder, name: 'Test Funder Org2', templates: 1)
+
+    @global_template = create(:template, :default, :published)
+    @org_template = create(:template, :published, org: @org)
+
+    @user = create(:user, org: @org)
     sign_in(@user)
 
     stub_openaire
@@ -33,16 +35,39 @@ RSpec.describe 'Plans', type: :feature do
   end
 
   it 'User creates a new Plan', :js do
-    # TODO: Revisit this after we start refactoring/building out or tests for
-    #       the new create plan workflow. For some reason the plans/new.js isn't
-    #       firing here but works fine in the UI with manual testing
-    # Action
     click_link 'Create plan'
-    fill_in :plan_title, with: 'My test plan'
-    choose_suggestion('plan_org_org_name', @research_org)
 
-    choose_suggestion('plan_funder_org_name', @funding_org)
-    click_button 'Create plan'
+    # Expect to have 4 templates available
+    within(:xpath, "//fieldset[./legend[contains(., 'Select a DMP template')]]") do
+      expect(page).to have_css('.form-check-input', count: 4)
+      expect(page).to have_content(@global_template.title)
+      expect(page).to have_content(@org_template.title)
+
+      within(:xpath,
+             ".//div[contains(@class,'form-label')][contains(., 'Global Templates:')]/following-sibling::div[1]") do
+        expect(page).to have_css('.form-check-input', count: 1)
+      end
+      # Expect 1 template under form-label 'Your Organisation's Templates:'
+      # rubocop:disable Layout/LineLength
+      within(:xpath,
+             ".//div[contains(@class,'form-label')][contains(., \"Your Organisation's Templates:\")]/following-sibling::div[1]") do
+        expect(page).to have_css('.form-check-input', count: 1)
+      end
+      # rubocop:enable Layout/LineLength
+      # Expect 2 template under form-label 'Funder Templates:'
+      within(:xpath,
+             ".//div[contains(@class,'form-label')][contains(., \"Funder Templates:\")]/following-sibling::div[1]") do
+        expect(page).to have_css('.form-check-input', count: 1)
+      end
+    end
+
+    fill_in 'plan[title]', with: 'My test plan'
+
+    within(:xpath, "//fieldset[./legend[contains(., 'Select a DMP template')]]") do
+      find('.form-check-input', match: :first).click
+    end
+
+    click_button 'Create'
 
     # Expectations
     expect(@user.plans).to be_one
@@ -50,7 +75,5 @@ RSpec.describe 'Plans', type: :feature do
     expect(current_path).to eql(plan_path(@plan))
     expect(page).to have_css("input[type=text][value='#{@plan.title}']")
     expect(@plan.title).to eql('My test plan')
-    expect(@plan.org_id).to eql(@research_org.id)
-    expect(@plan.funder_id).to eql(@funding_org.id)
   end
 end


### PR DESCRIPTION
Redesigned plan-creation page to enforce template access rules and simplify UI [#3534](https://github.com/DMPRoadmap/roadmap/issues/3534)
Co-authored-by: don-stuckey dstuckey@ed.ac.uk

This feature was contributed to DMPonline by @don-stuckey.

Changes:
- Complete re-write of 'Create a new plan' view _app/views/plans/new.html.erb_.
- The Plans controller app/controllers/plans_controller.rb has be greatly simplified to get three types og templates for selection in view: The global templates, the user's org templates and the funder templates available.
- The seeds.rb file has been updated to include templates for the three groups.
- The tests has been updated.

New Create a new plan page
<img width="1690" height="845" alt="Selection_142" src="https://github.com/user-attachments/assets/ff7cf9db-0608-4e4c-8d4d-c05e9568733e" />

Screenshot when running RSpec test in _spec/features/plans_spec.rb_
<img width="1920" height="941" alt="screenshot1" src="https://github.com/user-attachments/assets/f427cf71-5c5e-470c-86cd-709646a71227" />


