### PR TITLE
Bugfix: Disable Shibboleth / fix sign-out error

### DIFF
--- a/config/initializers/_dmproadmap.rb
+++ b/config/initializers/_dmproadmap.rb
@@ -133,7 +133,7 @@ module DMPRoadmap
     # Enable shibboleth as an alternative authentication method
     # Requires server configuration and omniauth shibboleth provider configuration
     # See config/initializers/devise.rb
-    config.x.shibboleth.enabled = true
+    config.x.shibboleth.enabled = false
 
     # Relative path to Shibboleth SSO Logouts
     config.x.shibboleth.login_url = '/Shibboleth.sso/Login'


### PR DESCRIPTION
# Changes proposed in this PR:

Although `config.x.shibboleth.enabled` was previously set to true, Shibboleth sign-in was not working within the app. Additionally, signing out of the app was throwing the following error.
```
Routing Error
No route matches [GET] "/Shibboleth.sso/Logout"
```

This error can be traced to `ApplicationController#after_sign_out_path_for`.
