### PR TITLE
Add complete plan flag to V2 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add complete plan flag to V2 API [#3595](https://github.com/DMPRoadmap/roadmap/pull/3595)
+
 ## v5.0.2
 - Bump Ruby to v3.1.4 and use `.ruby-version` in CI
   - [#3566](https://github.com/DMPRoadmap/roadmap/pull/3566)

--- a/app/controllers/api/v2/plans_controller.rb
+++ b/app/controllers/api/v2/plans_controller.rb
@@ -4,12 +4,13 @@ module Api
   module V2
     class PlansController < BaseApiController # rubocop:todo Style/Documentation
       respond_to :json
+      before_action :set_complete_param, only: %i[show index]
 
       # GET /api/v2/plans/:id
       def show
         raise Pundit::NotAuthorizedError unless @scopes.include?('read')
 
-        @plan = Plan.find_by(id: params[:id])
+        @plan = Plan.includes(roles: :user).find_by(id: params[:id])
 
         raise Pundit::NotAuthorizedError unless @plan.present?
 
@@ -27,6 +28,13 @@ module Api
         @plans = PlansPolicy::Scope.new(@resource_owner).resolve
         @items = paginate_response(results: @plans)
         render '/api/v2/plans/index', status: :ok
+      end
+
+      private
+
+      # GET /api/v2/plans?complete=true and  /api/v2/plans/:id?complete=true
+      def set_complete_param
+        @complete = params[:complete].to_s.downcase == 'true'
       end
     end
   end

--- a/app/controllers/api/v2/plans_controller.rb
+++ b/app/controllers/api/v2/plans_controller.rb
@@ -26,6 +26,7 @@ module Api
         raise Pundit::NotAuthorizedError unless @scopes.include?('read')
 
         @plans = PlansPolicy::Scope.new(@resource_owner).resolve
+        @plans = @plans.includes(answers: { question: :section }) if @complete
         @items = paginate_response(results: @plans)
         render '/api/v2/plans/index', status: :ok
       end

--- a/app/presenters/api/v2/plan_presenter.rb
+++ b/app/presenters/api/v2/plan_presenter.rb
@@ -68,6 +68,7 @@ module Api
           next unless q.present?
 
           {
+            id: q.id,
             title: "Question #{q.number || q.id}",
             section: q.section&.title,
             question: q.text.to_s,

--- a/app/presenters/api/v2/plan_presenter.rb
+++ b/app/presenters/api/v2/plan_presenter.rb
@@ -60,7 +60,7 @@ module Api
 
       # Fetch all questions and answers from a plan, regardless of theme
       def fetch_all_q_and_a
-        answers = @plan.answers.includes(question: [:section])
+        answers = @plan.answers
         return [] unless answers.present?
 
         answers.filter_map do |answer|

--- a/app/presenters/api/v2/plan_presenter.rb
+++ b/app/presenters/api/v2/plan_presenter.rb
@@ -4,9 +4,9 @@ module Api
   module V2
     # Helper class for the API V2 project / DMP
     class PlanPresenter
-      attr_reader :data_contact, :contributors, :costs
+      attr_reader :data_contact, :contributors, :costs, :complete_plan_data
 
-      def initialize(plan:)
+      def initialize(plan:, complete: false)
         @contributors = []
         return unless plan.present?
 
@@ -22,6 +22,8 @@ module Api
         end
 
         @costs = plan_costs(plan: @plan)
+
+        @complete_plan_data = fetch_all_q_and_a if complete
       end
 
       # Extract the ARK or DOI for the DMP OR use its URL if none exists
@@ -53,6 +55,24 @@ module Api
           # TODO: Investigate whether question level guidance should be the description
           { title: answer.question.text, description: nil,
             currency_code: 'usd', value: answer.text }
+        end
+      end
+
+      # Fetch all questions and answers from a plan, regardless of theme
+      def fetch_all_q_and_a
+        answers = @plan.answers.includes(question: [:section])
+        return [] unless answers.present?
+
+        answers.filter_map do |answer|
+          q = answer.question
+          next unless q.present?
+
+          {
+            title: "Question #{q.number || q.id}",
+            section: q.section&.title,
+            question: q.text.to_s,
+            answer: answer.text.to_s
+          }
         end
       end
     end

--- a/app/views/api/v2/plans/_show.json.jbuilder
+++ b/app/views/api/v2/plans/_show.json.jbuilder
@@ -4,7 +4,7 @@
 
 json.schema 'https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/tree/master/examples/JSON/JSON-schema/1.0'
 
-presenter = Api::V2::PlanPresenter.new(plan: plan)
+presenter = Api::V2::PlanPresenter.new(plan: plan, complete: @complete)
 
 # Note the symbol of the dmproadmap json object
 # nested in extensions which is the container for the json template object, etc.
@@ -66,6 +66,20 @@ unless @minimal
       json.template do
         json.id template.id
         json.title template.title
+      end
+    end
+
+    if @complete
+      json.complete_plan do
+        q_and_a = presenter.complete_plan_data
+        next if q_and_a.blank?
+
+        json.array! q_and_a do |item|
+          json.title item[:title]
+          json.section item[:section]
+          json.question item[:question]
+          json.answer item[:answer]
+        end
       end
     end
   end

--- a/app/views/api/v2/plans/_show.json.jbuilder
+++ b/app/views/api/v2/plans/_show.json.jbuilder
@@ -75,6 +75,7 @@ unless @minimal
         next if q_and_a.blank?
 
         json.array! q_and_a do |item|
+          json.question_id item[:id]
           json.title item[:title]
           json.section item[:section]
           json.question item[:question]


### PR DESCRIPTION
Changes proposed in this PR:
- Add the `complete` flag to the V2 API to enable accessing all questions and answers belonging to a plan in the API response.
- Per the V2 API Documentation: "The idea is to have a flag which defaults to false and thereby is compliant with the RDA metadata standard, but can be passed in with a value of true to include the questions and answers of the plan."
- The flag is optional and works with the `api/v2/plans` and `api/v2/plans/[plan_id]` endpoints. For example: `api/v2/plans/12345?complete=true`.
- The schema the flag returns is as follows:
- ```
        "complete_plan": [
            {
              "title": "Question 1",
              "question": "<p>What considerations will you take into account with respect to ethical, legal, or commercial issues?</p>\r\n<p><br>Describe any applicable ethical, legal, or commercial considerations related to your project and data. This includes research involving Indigenous communities and knowledges, human subjects, legal and commercial considerations/agreements, partnerships or data with a high level of risk associated with it.</p>",
              "answer": "<p>test</p>"
            },
            {
              "title": "Question 2",
              "question": "<p>What data will you collect or otherwise bring into your project under this plan?</p>\r\n<p><br>Describe the data that will be collected, generated, and/or acquired.</p>",
              "answer": "<p>test</p>"
            },
          ]
- Questions with no answers are not included in the response.